### PR TITLE
Rename getContent to getContents (octokit deprecation warning)

### DIFF
--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -20,7 +20,7 @@ const path = require('path');
 const EMPTY_SHA = '0'.repeat(40);
 
 async function getBuildArtifactsFile(github, filename) {
-  return await github.repos.getContent({
+  return await github.repos.getContents({
     owner: 'ampproject',
     repo: 'amphtml-build-artifacts',
     path: path.join('bundle-size', filename),

--- a/bundle-size/package-lock.json
+++ b/bundle-size/package-lock.json
@@ -2460,7 +2460,7 @@
     },
     "lru-cache": {
       "version": "4.0.0",
-      "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz",
       "integrity": "sha1-tcvwFVbBaWb+vlTO7A+03JDfbCg=",
       "requires": {
         "pseudomap": "^1.0.1",
@@ -2979,7 +2979,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -3635,7 +3635,7 @@
     },
     "source-map": {
       "version": "0.4.4",
-      "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "requires": {
         "amdefine": ">=0.0.4"


### PR DESCRIPTION
Deprecation warning:
```
DEPRECATED (@octokit/rest): `repos.getContent()` is deprecated, use `repos.getContents()`
```