### PR TITLE
Set the 'trust proxy' flag on the Express server app to find the correct IP address on AppEngine

### DIFF
--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -110,6 +110,7 @@ module.exports = app => {
 
   const v0 = app.route('/v0');
   v0.use((request, response, next) => {
+    request.app.set('trust proxy', true);
     if ('TRAVIS_IP_ADDRESSES' in process.env &&
         !process.env['TRAVIS_IP_ADDRESSES'].includes(request.ip)) {
       app.log(`Refused a request to ${request.originalUrl} from ${request.ip}`);


### PR DESCRIPTION
Without this flag being set, the IP address used to determine whether a request is coming from Travis always assumes that the IP address of the request is that of the proxy server (`::ffff:172.17.0.4`)