### PR TITLE
Modify database connection config to be defined in an explicit JS file

### DIFF
--- a/bundle-size/.env.example
+++ b/bundle-size/.env.example
@@ -2,18 +2,11 @@
 APP_ID=12345
 WEBHOOK_SECRET=0123456789abcdef0123456789abcdef01234567
 WEBHOOK_PROXY_URL=https://smee.io/0123456789abcdef  # For local development only
-PRIVATE_KEY=0123456789abcdefghijklmnopqrstuvwxyz
-TRAVIS_IP_ADDRESSES=1.1.1.1,8.8.8.8
+PRIVATE_KEY=0123456789abcdefghijklmnopqrstuvwxyz  # Base64 encoded private key from GitHub
+TRAVIS_IP_ADDRESSES=1.1.1.1,8.8.8.8  # Remove this line for local development, update based on https://docs.travis-ci.com/user/ip-addresses/ otherwise
 
 # Use `trace` to get verbose logging or `info` to show less
 LOG_LEVEL=trace
-
-# Database environment
-SQL_CLIENT=pg
-CLOUD_SQL_HOST=127.0.0.1
-CLOUD_SQL_USER=postgres
-CLOUD_SQL_PASSWORD=postgres
-CLOUD_SQL_DATABASE=postgres
 
 # Required flag for the GitHub App
 MAX_ALLOWED_INCREASE=0.1

--- a/bundle-size/.gitignore
+++ b/bundle-size/.gitignore
@@ -1,0 +1,1 @@
+db-config.js

--- a/bundle-size/README.md
+++ b/bundle-size/README.md
@@ -51,6 +51,7 @@ Follow these setup instructions to start developing for this App locally:
 2. `npm install`
 3. Run a local instance of PostgreSQL, or use the
    [Cloud SQL Proxy](https://cloud.google.com/sql/docs/postgres/sql-proxy)
+   * While other database engines might work, we have only tested this on pg
 4. Start a new [Smee channel](https://smee.io/). This can be used to proxy
    GitHub webhooks to your local machine
 5. Create a new [GitHub App](https://github.com/settings/apps/new):
@@ -71,7 +72,9 @@ Follow these setup instructions to start developing for this App locally:
      `.pem` file you downloaded from the GitHub App page. On Linux/Mac you can
      convert that file by running `cat private-key-file.pem | base64` in a
      command line
-9. `npm run dev`
+9. Copy the `db-config.example.js` file to `db-config.js` and modify the fields
+   based on the connection information to your database
+10. `npm run dev`
    * This will reload the App on every file change. Quit the server with
      `<Ctrl> + C` or `<Cmd> + C`
 

--- a/bundle-size/db-config.example.js
+++ b/bundle-size/db-config.example.js
@@ -14,9 +14,20 @@
  */
 'use strict';
 
-const knex = require('knex');
-const {dbConfig} = require('./db-config.js');
+exports.dbConfig = {
+  client: 'pg',
+  connection: {
+    // host is used for local development using a standard instance of Postgres
+    // or a CloudSQL instance using the CloudSQL Proxy. Remove if using
+    // `socketPath` instead.
+    host: '127.0.0.1',
 
-exports.dbConnect = () => {
-  return knex(dbConfig);
+    // socketPath is used in AppEngine only. Remove if using `host` instead.
+    socketPath: '/cloudsql/[[instance_connection_name_from_cloudsql_panel]]',
+
+    user: 'postgres',
+    password: 'HelloWorld!',
+    database: 'postgres',
+
+  },
 }


### PR DESCRIPTION
Different environments (local vs. AppEngine) have radically different configs that it didn't make sense to keep inferring them from the `.env` file.

Instead I'd rather have a `db-config.js` file (in the `.gitignore` so it wouldn't be added to the repo) that just has the db connection config in it