### PR TITLE
Retry reports for 60 minutes when the base SHA is missing

### DIFF
--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -73,7 +73,7 @@ module.exports = app => {
     }
   }
 
-  function tryReport(retriesLeft, check, bundleSize) {
+  async function tryReport(retriesLeft, check, bundleSize) {
     const github = await app.auth(check.installation_id);
     const updatedCheckOptions = {
       owner: check.owner,

--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -17,6 +17,9 @@
 const {dbConnect} = require('./db');
 const path = require('path');
 
+const RETRY_MILLIS = 60000;
+const RETRY_TIMES = 10;
+
 /**
  * Get a file from the bundle-size directory in the AMPHTML build artifacts
  * repository.
@@ -67,6 +70,69 @@ module.exports = app => {
       return results[0];
     } else {
       return null;
+    }
+  }
+
+  function tryReport(retriesLeft, check, bundleSize) {
+    const github = await app.auth(check.installation_id);
+    const updatedCheckOptions = {
+      owner: check.owner,
+      repo: check.repo,
+      check_run_id: check.check_run_id,
+      name: 'ampproject/bundle-size',
+      completed_at: new Date().toISOString(),
+    };
+
+    try {
+      const baseBundleSize = parseFloat(
+          await getBuildArtifactsFile(github, check.base_sha));
+      const bundleSizeDelta = bundleSize - baseBundleSize;
+      const bundleSizeDeltaFormatted = formatBundleSizeDelta(bundleSizeDelta);
+
+      await db('checks')
+          .update({delta: bundleSizeDelta})
+          .where({head_sha: check.head_sha});
+
+      if (bundleSizeDelta > process.env['MAX_ALLOWED_INCREASE']) {
+        Object.assign(updatedCheckOptions, {
+          conclusion: 'action_required',
+          output: {
+            title: `${bundleSizeDeltaFormatted} | approval required`,
+            summary: `${bundleSizeDeltaFormatted} | approval required`,
+          },
+        });
+      } else {
+        Object.assign(updatedCheckOptions, {
+          conclusion: 'success',
+          output: {
+            title: `${bundleSizeDeltaFormatted} | no approval necessary`,
+            summary: `${bundleSizeDeltaFormatted} | no approval necessary`,
+          },
+        });
+      }
+      await github.checks.update(updatedCheckOptions);
+      return true;
+    } catch (error) {
+      const partialBaseSha = check.base_sha.substr(0, 7);
+      app.log('ERROR: Failed to retrieve the bundle size of branch point ' +
+              `${partialBaseSha} from GitHub: ${error}`);
+      if (retriesLeft > 0) {
+        app.log(`Will retry ${RETRY_TIMES} more time(s) in ${RETRY_MILLIS} ms`);
+        setTimeout(tryReport, RETRY_MILLIS, retriesLeft - 1, check, bundleSize);
+      } else {
+        app.log('No more retries left. Reporting failure');
+        Object.assign(updatedCheckOptions, {
+          conclusion: 'action_required',
+          output: {
+            title: 'Failed to retrieve the bundle size of branch point ' +
+                partialBaseSha,
+            summary: 'bundle size check skipped for this PR. A member of the ' +
+                'bundle-size squad must approve this PR manually.',
+          },
+        });
+        await github.checks.update(updatedCheckOptions);
+      }
+      return false;
     }
   }
 
@@ -179,59 +245,11 @@ module.exports = app => {
     if (!check) {
       return response.status(404).end(`${headSha} not in database`);
     }
-    const partialBaseSha = check.base_sha.substr(0, 7);
 
-    const updatedCheckOptions = {
-      owner: check.owner,
-      repo: check.repo,
-      check_run_id: check.check_run_id,
-      name: 'ampproject/bundle-size',
-      completed_at: new Date().toISOString(),
-    };
-    const github = await app.auth(check.installation_id);
-
-    try {
-      const baseBundleSize = parseFloat(
-          await getBuildArtifactsFile(github, check.base_sha));
-      const bundleSizeDelta = bundleSize - baseBundleSize;
-      const bundleSizeDeltaFormatted = formatBundleSizeDelta(bundleSizeDelta);
-
-      await db('checks')
-          .update({delta: bundleSizeDelta})
-          .where({head_sha: headSha});
-
-      if (bundleSizeDelta > process.env['MAX_ALLOWED_INCREASE']) {
-        Object.assign(updatedCheckOptions, {
-          conclusion: 'action_required',
-          output: {
-            title: `${bundleSizeDeltaFormatted} | approval required`,
-            summary: `${bundleSizeDeltaFormatted} | approval required`,
-          },
-        });
-      } else {
-        Object.assign(updatedCheckOptions, {
-          conclusion: 'success',
-          output: {
-            title: `${bundleSizeDeltaFormatted} | no approval necessary`,
-            summary: `${bundleSizeDeltaFormatted} | no approval necessary`,
-          },
-        });
-      }
-    } catch (error) {
-      app.log('ERROR: Failed to retrieve the bundle size of branch point ' +
-              `${partialBaseSha} from GitHub: ${error}`);
-      Object.assign(updatedCheckOptions, {
-        conclusion: 'action_required',
-        output: {
-          title: 'Failed to retrieve the bundle size of branch point ' +
-              partialBaseSha,
-          summary: 'bundle size check skipped for this PR. A member of the ' +
-              'bundle-size squad must approve this PR manually.',
-        },
-      });
+    if (tryReport(RETRY_TIMES, check, bundleSize)) {
+      response.end();
+    } else {
+      response.status(202).end();
     }
-
-    await github.checks.update(updatedCheckOptions);
-    response.end();
   });
 };

--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -18,7 +18,7 @@ const {dbConnect} = require('./db');
 const path = require('path');
 
 const RETRY_MILLIS = 60000;
-const RETRY_TIMES = 10;
+const RETRY_TIMES = 60;
 
 /**
  * Get a file from the bundle-size directory in the AMPHTML build artifacts

--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -73,6 +73,14 @@ module.exports = app => {
     }
   }
 
+  /**
+   * Try to report the bundle size of a pull request to the GitHub check.
+   *
+   * @param {number} retriesLeft number of times to retry the report.
+   * @param {!Object} check GitHub Check object.
+   * @param {number} bundleSize the total bundle size in KB.
+   * @return {boolean} true if succeeded; false otherwise.
+   */
   async function tryReport(retriesLeft, check, bundleSize) {
     const github = await app.auth(check.installation_id);
     const updatedCheckOptions = {

--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -113,11 +113,13 @@ module.exports = app => {
       await github.checks.update(updatedCheckOptions);
       return true;
     } catch (error) {
+      const partialHeadSha = check.head_sha.substr(0, 7);
       const partialBaseSha = check.base_sha.substr(0, 7);
-      app.log('ERROR: Failed to retrieve the bundle size of branch point ' +
-              `${partialBaseSha} from GitHub: ${error}`);
+      app.log('ERROR: Failed to retrieve the bundle size of ' +
+              `${partialHeadSha} (PR #${check.pull_request_id}) with branch ` +
+              `point ${partialBaseSha} from GitHub: ${error}`);
       if (retriesLeft > 0) {
-        app.log(`Will retry ${RETRY_TIMES} more time(s) in ${RETRY_MILLIS} ms`);
+        app.log(`Will retry ${retriesLeft} more time(s) in ${RETRY_MILLIS} ms`);
         setTimeout(tryReport, RETRY_MILLIS, retriesLeft - 1, check, bundleSize);
       } else {
         app.log('No more retries left. Reporting failure');

--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -63,8 +63,8 @@ module.exports = app => {
    */
   async function getCheckFromDatabase(headSha) {
     const results = await db('checks')
-        .select('base_sha', 'pull_request_id', 'installation_id', 'owner',
-            'repo', 'check_run_id', 'delta')
+        .select('head_sha', 'base_sha', 'pull_request_id', 'installation_id',
+            'owner', 'repo', 'check_run_id', 'delta')
         .where('head_sha', headSha);
     if (results.length > 0) {
       return results[0];

--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -248,7 +248,7 @@ module.exports = app => {
       return response.status(404).end(`${headSha} not in database`);
     }
 
-    if (tryReport(RETRY_TIMES, check, bundleSize)) {
+    if (await tryReport(RETRY_TIMES, check, bundleSize)) {
       response.end();
     } else {
       response.status(202).end();


### PR DESCRIPTION
This PR will cause the bundle-size app to retry reporting the bundle size of a PR every minute for 10 minutes, if the base SHA (i.e., branch point from master) is missing from the `ampproject/amphtml-build-artifacts` repo

This isn't going to block the PR checks on Travis for `ampproject/amphtml`, as the retries will happen in the background. The GitHub app will return an HTTP status of `200 OK` if successful immediately, or `202 CREATED` if it's going to retry instead