### PR TITLE
Remove emoji from human-encouragement title

### DIFF
--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -80,7 +80,7 @@ function formatBundleSizeDelta(delta) {
  */
 function successfulTitleMessage(delta, deltaFormatted) {
   if (delta <= HUMAN_ENCOURAGEMENT_MAX_DELTA) {
-    return `${deltaFormatted} 🎉 | no approval necessary`;
+    return `${deltaFormatted} (shrunk!) | no approval necessary`;
   }
   return `${deltaFormatted} | no approval necessary`;
 }

--- a/bundle-size/test/app.test.js
+++ b/bundle-size/test/app.test.js
@@ -300,7 +300,7 @@ describe('bundle-size', async () => {
   });
 
   test.each([
-    ['12.44KB', 'Δ -0.10KB 🎉 | no approval necessary'],
+    ['12.44KB', 'Δ -0.10KB (shrunk!) | no approval necessary'],
     ['12.34KB', 'Δ +0.00KB | no approval necessary'],
     ['12.24KB', 'Δ +0.10KB | no approval necessary'],
   ])('update a check on bundle-size report (report/base = 12.34KB/%s)',


### PR DESCRIPTION
Looks like including emoji breaks the title.

![image](https://user-images.githubusercontent.com/254946/54058614-3a030400-41ab-11e9-96fa-2b9d31ea6ff9.png)

So let's just remove it.