### PR TITLE
Add gcloud project to `npm run deploy` scripts

### DIFF
--- a/bundle-size/package.json
+++ b/bundle-size/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "dev": "nodemon",
-    "deploy": "gcloud config set project amp-bundle-size-bot && gcloud app deploy",
+    "deploy": "gcloud --project amp-bundle-size-bot app deploy",
     "setup-db": "node ./setup-db.js",
     "start": "probot run ./app.js",
     "test": "jest"

--- a/bundle-size/package.json
+++ b/bundle-size/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "dev": "nodemon",
-    "deploy": "gcloud app deploy",
+    "deploy": "gcloud config set project amp-bundle-size-bot && gcloud app deploy",
     "setup-db": "node ./setup-db.js",
     "start": "probot run ./app.js",
     "test": "jest"

--- a/test-status/package.json
+++ b/test-status/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "dev": "nodemon",
-    "deploy": "gcloud app deploy",
+    "deploy": "gcloud config set project amp-test-status-bot && gcloud app deploy",
     "setup-db": "node ./setup-db.js",
     "start": "probot run ./app.js",
     "test": "jest"

--- a/test-status/package.json
+++ b/test-status/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "dev": "nodemon",
-    "deploy": "gcloud config set project amp-test-status-bot && gcloud app deploy",
+    "deploy": "gcloud --project amp-test-status-bot app deploy",
     "setup-db": "node ./setup-db.js",
     "start": "probot run ./app.js",
     "test": "jest"


### PR DESCRIPTION
This will help ensure that we deploy to the correct project, since the `gcloud` tool does not allow per-directory configurations