### PR TITLE
Remove async keyword from test describes

### DIFF
--- a/bundle-size/test/app.test.js
+++ b/bundle-size/test/app.test.js
@@ -57,7 +57,7 @@ async function waitUntilNockScopeIsDone(nocks) {
   nocks.done();
 }
 
-describe('bundle-size', async () => {
+describe('bundle-size', () => {
   let probot;
   let app;
   const db = dbConnect();

--- a/test-status/test/api.test.js
+++ b/test-status/test/api.test.js
@@ -28,7 +28,7 @@ jest.setTimeout(5000);
 nock.disableNetConnect();
 nock.enableNetConnect('127.0.0.1');
 
-describe('test-status/api', async () => {
+describe('test-status/api', () => {
   let probot;
   let app;
   const db = dbConnect();

--- a/test-status/test/web.test.js
+++ b/test-status/test/web.test.js
@@ -29,7 +29,7 @@ jest.setTimeout(5000);
 nock.disableNetConnect();
 nock.enableNetConnect('127.0.0.1');
 
-describe('test-status/web', async () => {
+describe('test-status/web', () => {
   let probot;
   let app;
   const db = dbConnect();

--- a/test-status/test/webhooks.test.js
+++ b/test-status/test/webhooks.test.js
@@ -38,7 +38,7 @@ function getFixture(name) {
   return deepcopy(require(`./fixtures/${name}`));
 }
 
-describe('test-status/webhooks', async () => {
+describe('test-status/webhooks', () => {
   let probot;
   let app;
   const db = dbConnect();


### PR DESCRIPTION
Test describe functions are not promises. This fixes a deprecation error that will turn into a failing error in a future version of Jest: https://travis-ci.org/ampproject/amp-github-apps/builds/505340784#L243-L244