### PR TITLE
Add subtype to tests slug

### DIFF
--- a/test-status/README.md
+++ b/test-status/README.md
@@ -25,10 +25,10 @@ The App has the following API points, which are to be triggered from Travis CI
 runs. If the `TRAVIS_IP_ADDRESSES` environment variable is set, only requests
 from this comma separated list of IP addresses will be processed.
 
-* `POST /v0/tests/:headSha/:type/:status(queued|started|skipped)`
+* `POST /v0/tests/:headSha/:type/:subType/:status(queued|started|skipped)`
   * Creates a new check on the supplied head commit (for `status` = `queued` or
-    `skipped`) or reports that the `type` tests have started running.
-* `POST /v0/tests/:headSha/:type/report/:passed/:failed`
+    `skipped`) or reports that the `type/subType` tests have started running.
+* `POST /v0/tests/:headSha/:type/:subType/report/:passed/:failed`
   * Updates the equivalent check with the number of `passed` and `failed` tests
   * If `failed` is 0, sets the check's conclusion to `success`, which turns the
     check green
@@ -46,13 +46,13 @@ error page.
 
 The interface has the following paths:
 
-* `GET /:headSha/:type/status`
+* `GET /:headSha/:type/:subType/status`
   * Displays the status of the check as reported from Travis, and provides a
     link to skip these test
-* `GET /:headSha/:type/skip`
+* `GET /:headSha/:type/:subType/skip`
   * Displays the above, plus a form to add a reason for why they are skipping
     the tests
-* `POST /:headSha/:type/skip`
+* `POST /:headSha/:type/:subType/skip`
   * Updates the equivalent check's conclusion to `success` with the provided
     explanation from the form, and redirects the build cop back to the pull
     request

--- a/test-status/api.js
+++ b/test-status/api.js
@@ -38,7 +38,7 @@ function createNewCheckParams(pullRequestSnapshot, type, subType, status) {
         status: 'queued',
         output: {
           title: 'Tests are queued on Travis',
-          summary: `The ${type} (${subType}) tests are queued to run on ` +
+          summary: `The ${type} tests (${subType}) are queued to run on ` +
             'Travis. Watch this space for results in a few minutes!',
         },
       });
@@ -50,7 +50,7 @@ function createNewCheckParams(pullRequestSnapshot, type, subType, status) {
         started_at: new Date().toISOString(),
         output: {
           title: 'Tests are running on Travis',
-          summary: `The ${type} (${subType}) tests are running on Travis. ` +
+          summary: `The ${type} tests (${subType}) are running on Travis. ` +
           'Watch this space for results in a few minutes!',
         },
       });
@@ -63,7 +63,7 @@ function createNewCheckParams(pullRequestSnapshot, type, subType, status) {
         completed_at: new Date().toISOString(),
         output: {
           title: 'Tests were not required',
-          summary: `The ${type} (${subType}) tests were not required to run ` +
+          summary: `The ${type} tests (${subType}) were not required to run ` +
             'for this pull request.',
         },
       });
@@ -107,7 +107,7 @@ function createReportedCheckParams(
       conclusion: 'action_required',
       output: {
         title: `${failed} test${failed != 1 ? 's' : ''} failed`,
-        summary: `The ${type} (${subType}) tests finished running on Travis.`,
+        summary: `The ${type} tests (${subType}) finished running on Travis.`,
         text: `* *${passed}* test${passed != 1 ? 's' : ''} PASSED\n` +
           `* *${failed}* test${failed != 1 ? 's' : ''} FAILED\n\n` +
           'Please inspect the Travis build and fix any code changes that ' +
@@ -124,7 +124,7 @@ function createReportedCheckParams(
       conclusion: 'success',
       output: {
         title: `${passed} test${passed != 1 ? 's' : ''} passed`,
-        summary: `The ${type} (${subType}) tests finished running on Travis.`,
+        summary: `The ${type} tests (${subType}) finished running on Travis.`,
         text: `* *${passed}* test${passed != 1 ? 's' : ''} PASSED`,
       },
     });
@@ -158,7 +158,7 @@ function createErroredCheckParams(
     output: {
       title: `Tests have errored`,
       summary: `An unexpected error occurred while running ${type} ` +
-        `(${subType}) tests.`,
+        `tests (${subType}).`,
       text: 'Please inspect the Travis build for the details.\n\n' +
         'If you believe that this pull request was not the cause of this ' +
         // TODO(danielrozenberg): say who the weekly build cop is inline here:
@@ -186,7 +186,7 @@ exports.installApiRouter = (app, db) => {
         const {headSha, type, subType, status} = request.params;
         app.log(
             `Creating/updating a new GitHub check for the ${type} ` +
-            `(${subType}) tests for pull request with head commit SHA ` +
+            `tests (${subType}) for pull request with head commit SHA ` +
             `${headSha}, with a status of '${status}'`);
 
         const pullRequestSnapshot = await getPullRequestSnapshot(db, headSha);
@@ -229,7 +229,7 @@ exports.installApiRouter = (app, db) => {
       async (request, response) => {
         const {headSha, type, subType, passed, failed} = request.params;
         app.log(
-            `Reporting the results of the ${type} (${subType}) tests to the ` +
+            `Reporting the results of the ${type} tests (${subType}) to the ` +
             `GitHub check for pull request with head commit SHA ${headSha}`);
         app.log(`Passed: ${passed} | Failed: ${failed}`);
 
@@ -257,7 +257,7 @@ exports.installApiRouter = (app, db) => {
       async (request, response) => {
         const {headSha, type, subType} = request.params;
         app.log(
-            `Reporting that ${type} (${subType}) tests have errored to the ` +
+            `Reporting that ${type} tests (${subType}) have errored to the ` +
             `GitHub check for pull request with head commit SHA ${headSha}`);
 
         const pullRequestSnapshot = await getPullRequestSnapshot(db, headSha);

--- a/test-status/api.js
+++ b/test-status/api.js
@@ -20,15 +20,16 @@ const {getCheckRunId, getPullRequestSnapshot} = require('./db');
  * Create a parameters object for a new status check line.
  *
  * @param {string} pullRequestSnapshot pull request snapshot from database.
- * @param {string} type tests type slug.
+ * @param {string} type major tests type slug (e.g., unit, integration).
+ * @param {string} subType sub tests type slug (e.g., saucelabs, single-pass).
  * @param {string} status status action.
  * @return {!Object} a parameters object for github.checks.create|update.
  */
-function createNewCheckParams(pullRequestSnapshot, type, status) {
+function createNewCheckParams(pullRequestSnapshot, type, subType, status) {
   const params = {
     owner: pullRequestSnapshot.owner,
     repo: pullRequestSnapshot.repo,
-    name: `ampproject/tests/${type}`,
+    name: `ampproject/tests/${type} (${subType})`,
     head_sha: pullRequestSnapshot.head_sha,
   };
   switch (status) {
@@ -36,9 +37,9 @@ function createNewCheckParams(pullRequestSnapshot, type, status) {
       Object.assign(params, {
         status: 'queued',
         output: {
-          title: `${type} tests are queued on Travis`,
-          summary: `The ${type} tests are queued to run on Travis. Watch ` +
-            'this space for results in a few minutes!',
+          title: 'Tests are queued on Travis',
+          summary: `The ${type} (${subType}) tests are queued to run on ` +
+            'Travis. Watch this space for results in a few minutes!',
         },
       });
       break;
@@ -48,9 +49,9 @@ function createNewCheckParams(pullRequestSnapshot, type, status) {
         status: 'in_progress',
         started_at: new Date().toISOString(),
         output: {
-          title: `${type} tests are running on Travis`,
-          summary: `The ${type} tests are running on Travis. Watch this ` +
-            'space for results in a few minutes!',
+          title: 'Tests are running on Travis',
+          summary: `The ${type} (${subType}) tests are running on Travis. ` +
+          'Watch this space for results in a few minutes!',
         },
       });
       break;
@@ -61,9 +62,9 @@ function createNewCheckParams(pullRequestSnapshot, type, status) {
         conclusion: 'neutral',
         completed_at: new Date().toISOString(),
         output: {
-          title: `${type} tests were not required`,
-          summary: `The ${type} tests were not required to run for this pull ` +
-            'request.',
+          title: 'Tests were not required',
+          summary: `The ${type} (${subType}) tests were not required to run ` +
+            'for this pull request.',
         },
       });
       break;
@@ -80,14 +81,15 @@ function createNewCheckParams(pullRequestSnapshot, type, status) {
  * an existing GitHub status check.
  *
  * @param {string} pullRequestSnapshot pull request snapshot from database.
- * @param {string} type tests type slug.
+ * @param {string} type major tests type slug (e.g., unit, integration).
+ * @param {string} subType sub tests type slug (e.g., saucelabs, single-pass).
  * @param {number} checkRunId the existing check run ID.
  * @param {number} passed number of tests that passed.
  * @param {number} failed number of tests that failed.
  * @return {!Object} a parameters object for github.checks.update.
  */
 function createReportedCheckParams(
-  pullRequestSnapshot, type, checkRunId, passed, failed) {
+  pullRequestSnapshot, type, subType, checkRunId, passed, failed) {
   const {owner, repo, head_sha: headSha} = pullRequestSnapshot;
   const params = {
     owner,
@@ -98,13 +100,14 @@ function createReportedCheckParams(
   };
   if (failed > 0) {
     const detailsUrl = new URL(
-        `/tests/${headSha}/${type}/status`, process.env.WEB_UI_BASE_URL);
+        `/tests/${headSha}/${type}/${subType}/status`,
+        process.env.WEB_UI_BASE_URL);
     Object.assign(params, {
       details_url: detailsUrl.href,
       conclusion: 'action_required',
       output: {
-        title: `${failed} ${type} test${failed != 1 ? 's' : ''} failed`,
-        summary: `The ${type} tests finished running on Travis.`,
+        title: `${failed} test${failed != 1 ? 's' : ''} failed`,
+        summary: `The ${type} (${subType}) tests finished running on Travis.`,
         text: `* *${passed}* test${passed != 1 ? 's' : ''} PASSED\n` +
           `* *${failed}* test${failed != 1 ? 's' : ''} FAILED\n\n` +
           'Please inspect the Travis build and fix any code changes that ' +
@@ -120,8 +123,8 @@ function createReportedCheckParams(
     Object.assign(params, {
       conclusion: 'success',
       output: {
-        title: `${passed} ${type} test${passed != 1 ? 's' : ''} passed`,
-        summary: `The ${type} tests finished running on Travis.`,
+        title: `${passed} test${passed != 1 ? 's' : ''} passed`,
+        summary: `The ${type} (${subType}) tests finished running on Travis.`,
         text: `* *${passed}* test${passed != 1 ? 's' : ''} PASSED`,
       },
     });
@@ -134,14 +137,16 @@ function createReportedCheckParams(
  * GitHub status check.
  *
  * @param {string} pullRequestSnapshot pull request snapshot from database.
- * @param {string} type tests type slug.
+ * @param {string} type major tests type slug (e.g., unit, integration).
+ * @param {string} subType sub tests type slug (e.g., saucelabs, single-pass).
  * @param {number} checkRunId the existing check run ID.
  * @return {!Object} a parameters object for github.checks.update.
  */
-function createErroredCheckParams(pullRequestSnapshot, type, checkRunId) {
+function createErroredCheckParams(
+  pullRequestSnapshot, type, subType, checkRunId) {
   const {owner, repo, head_sha: headSha} = pullRequestSnapshot;
-  const detailsUrl = new URL(
-      `/tests/${headSha}/${type}/status`, process.env.WEB_UI_BASE_URL);
+  const detailsUrl = new URL(`/tests/${headSha}/${type}/${subType}/status`,
+      process.env.WEB_UI_BASE_URL);
   return {
     owner,
     repo,
@@ -151,8 +156,9 @@ function createErroredCheckParams(pullRequestSnapshot, type, checkRunId) {
     details_url: detailsUrl.href,
     conclusion: 'action_required',
     output: {
-      title: `${type} tests have errored`,
-      summary: `An unexpected error occurred while running ${type} tests.`,
+      title: `Tests have errored`,
+      summary: `An unexpected error occurred while running ${type} ` +
+        `(${subType}) tests.`,
       text: 'Please inspect the Travis build for the details.\n\n' +
         'If you believe that this pull request was not the cause of this ' +
         // TODO(danielrozenberg): say who the weekly build cop is inline here:
@@ -175,13 +181,13 @@ exports.installApiRouter = (app, db) => {
     }
   });
 
-  v0.post('/tests/:headSha/:type/:status(queued|started|skipped)',
+  v0.post('/tests/:headSha/:type/:subType/:status(queued|started|skipped)',
       async (request, response) => {
-        const {headSha, type, status} = request.params;
+        const {headSha, type, subType, status} = request.params;
         app.log(
-            `Creating/updating a new GitHub check for the ${type} tests for ` +
-            `pull request with head commit SHA ${headSha}, with a status of ` +
-            `'${status}'`);
+            `Creating/updating a new GitHub check for the ${type} ` +
+            `(${subType}) tests for pull request with head commit SHA ` +
+            `${headSha}, with a status of '${status}'`);
 
         const pullRequestSnapshot = await getPullRequestSnapshot(db, headSha);
         if (pullRequestSnapshot === undefined) {
@@ -190,11 +196,12 @@ exports.installApiRouter = (app, db) => {
 
         // Get the existing check run ID, or `undefined` if this is the first
         // time this head SHA is reported for this test type.
-        const checkRunId = await getCheckRunId(db, headSha, type);
+        const checkRunId = await getCheckRunId(db, headSha, type, subType);
 
         let params;
         try {
-          params = createNewCheckParams(pullRequestSnapshot, type, status);
+          params = createNewCheckParams(
+              pullRequestSnapshot, type, subType, status);
         } catch (error) {
           app.log(`ERROR: ${error}`);
           return response.status(400).end(error);
@@ -206,6 +213,7 @@ exports.installApiRouter = (app, db) => {
           await db('checks').insert({
             head_sha: headSha,
             type: type,
+            subType,
             check_run_id: check.data.id,
           });
         } else {
@@ -217,55 +225,58 @@ exports.installApiRouter = (app, db) => {
         return response.end();
       });
 
-  v0.post('/tests/:headSha/:type/report/:passed/:failed',
+  v0.post('/tests/:headSha/:type/:subType/report/:passed/:failed',
       async (request, response) => {
-        const {headSha, type, passed, failed} = request.params;
+        const {headSha, type, subType, passed, failed} = request.params;
         app.log(
-            `Reporting the results of the ${type} tests to the GitHub check ` +
-            `for pull request with head commit SHA ${headSha}`);
+            `Reporting the results of the ${type} (${subType}) tests to the ` +
+            `GitHub check for pull request with head commit SHA ${headSha}`);
         app.log(`Passed: ${passed} | Failed: ${failed}`);
 
         const pullRequestSnapshot = await getPullRequestSnapshot(db, headSha);
-        const checkRunId = await getCheckRunId(db, headSha, type);
+        const checkRunId = await getCheckRunId(db, headSha, type, subType);
         if (pullRequestSnapshot === undefined || checkRunId === null) {
           return response.status(404).end(
-              `No existing status check was found for ${headSha}/${type}`);
+              'No existing status check was found for ' +
+              `${headSha}/${type}/${subType}`);
         }
 
         const params = createReportedCheckParams(
-            pullRequestSnapshot, type, checkRunId, passed, failed);
+            pullRequestSnapshot, type, subType, checkRunId, passed, failed);
         const github = await app.auth(pullRequestSnapshot.installation_id);
         await github.checks.update(params);
 
         await db('checks')
             .update({passed, failed, errored: false})
-            .where({head_sha: headSha, type});
+            .where({head_sha: headSha, type, subType});
 
         return response.end();
       });
 
-  v0.post('/tests/:headSha/:type/report/errored', async (request, response) => {
-    const {headSha, type} = request.params;
-    app.log(
-        `Reporting that ${type} tests have errored to the GitHub check ` +
-        `for pull request with head commit SHA ${headSha}`);
+  v0.post('/tests/:headSha/:type/:subType/report/errored',
+      async (request, response) => {
+        const {headSha, type, subType} = request.params;
+        app.log(
+            `Reporting that ${type} (${subType}) tests have errored to the ` +
+            `GitHub check for pull request with head commit SHA ${headSha}`);
 
-    const pullRequestSnapshot = await getPullRequestSnapshot(db, headSha);
-    const checkRunId = await getCheckRunId(db, headSha, type);
-    if (pullRequestSnapshot === undefined || checkRunId === null) {
-      return response.status(404).end(
-          `No existing status check was found for ${headSha}/${type}`);
-    }
+        const pullRequestSnapshot = await getPullRequestSnapshot(db, headSha);
+        const checkRunId = await getCheckRunId(db, headSha, type, subType);
+        if (pullRequestSnapshot === undefined || checkRunId === null) {
+          return response.status(404).end(
+              'No existing status check was found for ' +
+              `${headSha}/${type}/${subType}`);
+        }
 
-    const params = createErroredCheckParams(
-        pullRequestSnapshot, type, checkRunId);
-    const github = await app.auth(pullRequestSnapshot.installation_id);
-    await github.checks.update(params);
+        const params = createErroredCheckParams(
+            pullRequestSnapshot, type, subType, checkRunId);
+        const github = await app.auth(pullRequestSnapshot.installation_id);
+        await github.checks.update(params);
 
-    await db('checks')
-        .update({passed: null, failed: null, errored: true})
-        .where({head_sha: headSha, type});
+        await db('checks')
+            .update({passed: null, failed: null, errored: true})
+            .where({head_sha: headSha, type, subType});
 
-    return response.end();
-  });
+        return response.end();
+      });
 };

--- a/test-status/setup-db.js
+++ b/test-status/setup-db.js
@@ -37,12 +37,13 @@ function setupDb(db) {
     table.comment('Checks (status lines) created on GitHub, referenced by ID');
     table.string('head_sha', 40);
     table.string('type', 255);
+    table.string('subType', 255);
     table.integer('check_run_id');
     table.integer('passed');
     table.integer('failed');
     table.boolean('errored');
 
-    table.primary(['head_sha', 'type']);
+    table.primary(['head_sha', 'type', 'subType']);
     table.foreign('head_sha')
         .references('pull_request_snapshots.head_sha')
         .onDelete('CASCADE');

--- a/test-status/test/web.test.js
+++ b/test-status/test/web.test.js
@@ -64,8 +64,8 @@ describe('test-status/web', () => {
   });
 
   test.each([
-    [0, 0, /No test failures reported for unit tests!/],
-    [10, 0, /No test failures reported for unit tests!/],
+    [0, 0, /No test failures reported for unit \(saucelabs\) tests!/],
+    [10, 0, /No test failures reported for unit \(saucelabs\) tests!/],
     [0, 10, /Skip these tests\?/],
     [10, 10, /Skip these tests\?/],
   ])('Request status page of a check with passed/failed = %d/%d',
@@ -80,6 +80,7 @@ describe('test-status/web', () => {
         await db('checks').insert({
           head_sha: HEAD_SHA,
           type: 'unit',
+          subType: 'saucelabs',
           check_run_id: 555555,
           passed,
           failed,
@@ -87,7 +88,7 @@ describe('test-status/web', () => {
         });
 
         await request(probot.server)
-            .get(`/tests/${HEAD_SHA}/unit/status`)
+            .get(`/tests/${HEAD_SHA}/unit/saucelabs/status`)
             .auth('buildcop')
             .expect(200, bodyMatches);
       });
@@ -103,6 +104,7 @@ describe('test-status/web', () => {
     await db('checks').insert({
       head_sha: HEAD_SHA,
       type: 'unit',
+      subType: 'saucelabs',
       check_run_id: 555555,
       passed: null,
       failed: null,
@@ -110,7 +112,7 @@ describe('test-status/web', () => {
     });
 
     await request(probot.server)
-        .get(`/tests/${HEAD_SHA}/unit/status`)
+        .get(`/tests/${HEAD_SHA}/unit/saucelabs/status`)
         .auth('buildcop')
         .expect(200, /Errored!/);
   });
@@ -126,6 +128,7 @@ describe('test-status/web', () => {
     await db('checks').insert({
       head_sha: HEAD_SHA,
       type: 'unit',
+      subType: 'saucelabs',
       check_run_id: 555555,
       passed: 10,
       failed: 10,
@@ -133,16 +136,16 @@ describe('test-status/web', () => {
     });
 
     await request(probot.server)
-        .get(`/tests/${HEAD_SHA}/unit/skip`)
+        .get(`/tests/${HEAD_SHA}/unit/saucelabs/skip`)
         .auth('buildcop')
         .expect(200, /Really skip!/);
   });
 
   test.each([
     ['10 failed tests', 10, 10, false,
-      'The unit tests have previously failed on Travis.'],
+      'The unit (saucelabs) tests have previously failed on Travis.'],
     ['tests have errored', null, null, true,
-      'The unit tests have previously errored on Travis.'],
+      'The unit (saucelabs) tests have previously errored on Travis.'],
   ])('Post skip form on %s', async (_, passed, failed, errored, summary) => {
     await db('pull_request_snapshots').insert({
       head_sha: HEAD_SHA,
@@ -154,6 +157,7 @@ describe('test-status/web', () => {
     await db('checks').insert({
       head_sha: HEAD_SHA,
       type: 'unit',
+      subType: 'saucelabs',
       check_run_id: 555555,
       passed,
       failed,
@@ -176,7 +180,7 @@ describe('test-status/web', () => {
         .reply(200);
 
     await request(probot.server)
-        .post(`/tests/${HEAD_SHA}/unit/skip`)
+        .post(`/tests/${HEAD_SHA}/unit/saucelabs/skip`)
         .type('form')
         .send({reason: 'flaky tests'})
         .auth('buildcop')
@@ -198,6 +202,7 @@ describe('test-status/web', () => {
     await db('checks').insert({
       head_sha: HEAD_SHA,
       type: 'unit',
+      subType: 'saucelabs',
       check_run_id: 555555,
       passed: 10,
       failed: 10,
@@ -205,7 +210,7 @@ describe('test-status/web', () => {
     });
 
     await request(probot.server)
-        .post(`/tests/${HEAD_SHA}/unit/skip`)
+        .post(`/tests/${HEAD_SHA}/unit/saucelabs/skip`)
         .auth('buildcop')
         .expect(200, /Reason must not be empty/);
   });
@@ -221,6 +226,7 @@ describe('test-status/web', () => {
     await db('checks').insert({
       head_sha: HEAD_SHA,
       type: 'unit',
+      subType: 'saucelabs',
       check_run_id: 555555,
       passed: 10,
       failed: 0,
@@ -228,14 +234,14 @@ describe('test-status/web', () => {
     });
 
     await request(probot.server)
-        .get(`/tests/${HEAD_SHA}/unit/skip`)
+        .get(`/tests/${HEAD_SHA}/unit/saucelabs/skip`)
         .auth('buildcop')
-        .expect(400, /unit tests for 26ddec3 have no failures/);
+        .expect(400, /unit \(saucelabs\) tests for 26ddec3 have no failures/);
 
     await request(probot.server)
-        .post(`/tests/${HEAD_SHA}/unit/skip`)
+        .post(`/tests/${HEAD_SHA}/unit/saucelabs/skip`)
         .auth('buildcop')
-        .expect(400, /unit tests for 26ddec3 have no failures/);
+        .expect(400, /unit \(saucelabs\) tests for 26ddec3 have no failures/);
   });
 
   test.each([
@@ -253,6 +259,7 @@ describe('test-status/web', () => {
         await db('checks').insert({
           head_sha: HEAD_SHA,
           type: 'unit',
+          subType: 'saucelabs',
           check_run_id: 555555,
           passed: null,
           failed: null,
@@ -260,7 +267,7 @@ describe('test-status/web', () => {
         });
 
         await request(probot.server)
-            .get(`/tests/${HEAD_SHA}/unit/${action}`)
+            .get(`/tests/${HEAD_SHA}/unit/saucelabs/${action}`)
             .auth('buildcop')
             .expect(404, /have not yet been reported/);
       });
@@ -270,7 +277,7 @@ describe('test-status/web', () => {
     'skip',
   ])('Request %s page of a head SHA that does not exist', async action => {
     await request(probot.server)
-        .get(`/tests/${HEAD_SHA}/unit/${action}`)
+        .get(`/tests/${HEAD_SHA}/unit/saucelabs/${action}`)
         .auth('buildcop')
         .expect(404, /have not yet been reported/);
   });
@@ -280,7 +287,7 @@ describe('test-status/web', () => {
     'skip',
   ])('Request %s page when not logged in', async action => {
     await request(probot.server)
-        .get(`/tests/${HEAD_SHA}/unit/${action}`)
+        .get(`/tests/${HEAD_SHA}/unit/saucelabs/${action}`)
         .expect(response => {
           expect(response.status).toBe(302);
           expect(response.get('location')).toBe('/login');
@@ -292,14 +299,14 @@ describe('test-status/web', () => {
     'skip',
   ])('Request %s page when logged in, but not as buildcop', async action => {
     await request(probot.server)
-        .get(`/tests/${HEAD_SHA}/unit/${action}`)
+        .get(`/tests/${HEAD_SHA}/unit/saucelabs/${action}`)
         .auth('notbuildcop')
         .expect(403, /You are logged in as <em>notbuildcop<\/em>/);
   });
 
   test('Post to skip page when not logged in', async () => {
     await request(probot.server)
-        .post(`/tests/${HEAD_SHA}/unit/skip`)
+        .post(`/tests/${HEAD_SHA}/unit/saucelabs/skip`)
         .expect(response => {
           expect(response.status).toBe(302);
           expect(response.get('location')).toBe('/login');

--- a/test-status/test/web.test.js
+++ b/test-status/test/web.test.js
@@ -64,8 +64,8 @@ describe('test-status/web', () => {
   });
 
   test.each([
-    [0, 0, /No test failures reported for unit \(saucelabs\) tests!/],
-    [10, 0, /No test failures reported for unit \(saucelabs\) tests!/],
+    [0, 0, /No test failures reported for unit tests \(saucelabs\)!/],
+    [10, 0, /No test failures reported for unit tests \(saucelabs\)!/],
     [0, 10, /Skip these tests\?/],
     [10, 10, /Skip these tests\?/],
   ])('Request status page of a check with passed/failed = %d/%d',
@@ -143,9 +143,9 @@ describe('test-status/web', () => {
 
   test.each([
     ['10 failed tests', 10, 10, false,
-      'The unit (saucelabs) tests have previously failed on Travis.'],
+      'The unit tests (saucelabs) have previously failed on Travis.'],
     ['tests have errored', null, null, true,
-      'The unit (saucelabs) tests have previously errored on Travis.'],
+      'The unit tests (saucelabs) have previously errored on Travis.'],
   ])('Post skip form on %s', async (_, passed, failed, errored, summary) => {
     await db('pull_request_snapshots').insert({
       head_sha: HEAD_SHA,
@@ -236,12 +236,12 @@ describe('test-status/web', () => {
     await request(probot.server)
         .get(`/tests/${HEAD_SHA}/unit/saucelabs/skip`)
         .auth('buildcop')
-        .expect(400, /unit \(saucelabs\) tests for 26ddec3 have no failures/);
+        .expect(400, /unit tests \(saucelabs\) for 26ddec3 have no failures/);
 
     await request(probot.server)
         .post(`/tests/${HEAD_SHA}/unit/saucelabs/skip`)
         .auth('buildcop')
-        .expect(400, /unit \(saucelabs\) tests for 26ddec3 have no failures/);
+        .expect(400, /unit tests \(saucelabs\) for 26ddec3 have no failures/);
   });
 
   test.each([

--- a/test-status/views/404.hbs
+++ b/test-status/views/404.hbs
@@ -11,7 +11,7 @@
     <div class="d-flex flex-column flex-justify-center flex-items-center text-center height-full">
       <div class="box-shadow rounded-2 border p-6 bg-white">
         <h1>AMP Test Status | 404 Not Found</h1>
-        <p>Results for the <em>{{ type }} ({{ subType }})</em> tests for <code>{{ headSha }}</code> have not yet been reported.</p>
+        <p>Results for the <em>{{ type }}</em> tests <em>({{ subType }})</em> for <code>{{ headSha }}</code> have not yet been reported.</p>
       </div>
     </div>
   </body>

--- a/test-status/views/404.hbs
+++ b/test-status/views/404.hbs
@@ -11,7 +11,7 @@
     <div class="d-flex flex-column flex-justify-center flex-items-center text-center height-full">
       <div class="box-shadow rounded-2 border p-6 bg-white">
         <h1>AMP Test Status | 404 Not Found</h1>
-        <p>Results for the <em>{{ type }}</em> tests for <code>{{ headSha }}</code> have not yet been reported.</p>
+        <p>Results for the <em>{{ type }} ({{ subType }})</em> tests for <code>{{ headSha }}</code> have not yet been reported.</p>
       </div>
     </div>
   </body>

--- a/test-status/views/status.hbs
+++ b/test-status/views/status.hbs
@@ -74,7 +74,7 @@
             {{else if errored }}
             <a href="/tests/{{ head_sha }}/{{ type }}/{{ subType }}/skip" class="btn btn-outline">Skip these tests?</a>
             {{else}}
-            <p>No test failures reported for {{ type }} ({{ subType }}) tests!</p>
+            <p>No test failures reported for {{ type }} tests ({{ subType }})!</p>
             {{/if}}
           </div>
         </div>

--- a/test-status/views/status.hbs
+++ b/test-status/views/status.hbs
@@ -44,7 +44,7 @@
             </tr>
             <tr>
               <td>Test type</td>
-              <td>{{ type }}</td>
+              <td>{{ type }} ({{ subType }})</td>
             </tr>
             <tr>
               <td>passed / failed</td>
@@ -60,7 +60,7 @@
         <div class="mt-4">
           <div class="d-flex flex-justify-center mt-2">
             {{#if is_skipping }}
-            <form action="/tests/{{ head_sha }}/{{ type }}/skip" method="post" enctype="application/x-www-form-urlencoded" accept-charset="utf-8">
+            <form action="/tests/{{ head_sha }}/{{ type }}/{{ subType }}/skip" method="post" enctype="application/x-www-form-urlencoded" accept-charset="utf-8">
               <p>Skip these tests?</p>
               <dl class="form-group{{#if errors.reason }} errored{{/if}}">
                 <dt><label for="reason">Reason for skipping</label></dt>
@@ -70,11 +70,11 @@
               <input type="submit" value="Really skip!" class="btn btn-outline">
             </form>
             {{else if failed }}
-            <a href="/tests/{{ head_sha }}/{{ type }}/skip" class="btn btn-outline">Skip these tests?</a>
+            <a href="/tests/{{ head_sha }}/{{ type }}/{{ subType }}/skip" class="btn btn-outline">Skip these tests?</a>
             {{else if errored }}
-            <a href="/tests/{{ head_sha }}/{{ type }}/skip" class="btn btn-outline">Skip these tests?</a>
+            <a href="/tests/{{ head_sha }}/{{ type }}/{{ subType }}/skip" class="btn btn-outline">Skip these tests?</a>
             {{else}}
-            <p>No test failures reported for {{ type }} tests!</p>
+            <p>No test failures reported for {{ type }} ({{ subType }}) tests!</p>
             {{/if}}
           </div>
         </div>

--- a/test-status/web.js
+++ b/test-status/web.js
@@ -33,7 +33,7 @@ let EXPRESS_SETTING_ARE_SET = false;
  * @return {!Object} a parameters object for github.checks.update.
  */
 function createSkippedCheckParams(request) {
-  const {type, passed, failed, errored} = request.check;
+  const {type, subType, passed, failed, errored} = request.check;
   const {user} = request.session.passport;
   const {reason} = request.body;
 
@@ -43,7 +43,8 @@ function createSkippedCheckParams(request) {
     text = `* *${passed}* test${passed != 1 ? 's' : ''} PASSED\n` +
       `* *${failed}* test${failed != 1 ? 's' : ''} FAILED\n\n`;
   }
-  text += `The ${summaryVerb} ${type} tests were skipped by @${user}.\n` +
+  text += `The ${summaryVerb} ${type} (${subType}) tests were skipped by ` +
+    `@${user}.\n` +
     `The reason given was: *${reason}*`;
 
   return {
@@ -54,7 +55,8 @@ function createSkippedCheckParams(request) {
     conclusion: 'success',
     output: {
       title: `Skipped by @${user}`,
-      summary: `The ${type} tests have previously ${summaryVerb} on Travis.`,
+      summary: `The ${type} (${subType}) tests have previously ` +
+        `${summaryVerb} on Travis.`,
       text,
     },
   };
@@ -90,49 +92,51 @@ exports.installWebUiRouter = (app, db) => {
     }
   });
 
-  tests.all('/:headSha/:type/:action(status|skip)',
+  tests.all('/:headSha/:type/:subType/:action(status|skip)',
       async (request, response, next) => {
-        const {headSha, type} = request.params;
+        const {headSha, type, subType} = request.params;
         request.short_head_sha = headSha.substr(0, 7);
-        const check = await getCheckRunResults(db, headSha, type);
+        const check = await getCheckRunResults(db, headSha, type, subType);
         if (check === null ||
             (!check.errored &&
               (check.passed === null || check.failed === null))) {
           return response.status(404).render('404', {
             headSha: request.short_head_sha,
             type,
+            subType,
           });
         }
         request.check = check;
         next();
       });
 
-  tests.get('/:headSha/:type/status', async (request, response) => {
+  tests.get('/:headSha/:type/:subType/status', async (request, response) => {
     response.render('status', Object.assign({
       short_head_sha: request.short_head_sha,
       is_skipping: false,
     }, request.check));
   });
 
-  tests.all('/:headSha/:type/skip', async (request, response, next) => {
-    if (request.check.failed == 0) {
-      return response.status(400).render('400', {
-        message:
-            `${request.params.type} tests for ${request.short_head_sha} have ` +
-            'no failures',
+  tests.all('/:headSha/:type/:subType/skip',
+      async (request, response, next) => {
+        if (request.check.failed == 0) {
+          return response.status(400).render('400', {
+            message:
+                `${request.params.type} (${request.params.subType}) tests ` +
+                `for ${request.short_head_sha} have no failures`,
+          });
+        }
+        next();
       });
-    }
-    next();
-  });
 
-  tests.get('/:headSha/:type/skip', async (request, response) => {
+  tests.get('/:headSha/:type/:subType/skip', async (request, response) => {
     response.render('status', Object.assign({
       short_head_sha: request.short_head_sha,
       is_skipping: true,
     }, request.check));
   });
 
-  tests.post('/:headSha/:type/skip', [
+  tests.post('/:headSha/:type/:subType/skip', [
     body('reason').isLength({min: 1}).withMessage('Reason must not be empty.'),
   ], async (request, response) => {
     const errors = validationResult(request);

--- a/test-status/web.js
+++ b/test-status/web.js
@@ -43,7 +43,7 @@ function createSkippedCheckParams(request) {
     text = `* *${passed}* test${passed != 1 ? 's' : ''} PASSED\n` +
       `* *${failed}* test${failed != 1 ? 's' : ''} FAILED\n\n`;
   }
-  text += `The ${summaryVerb} ${type} (${subType}) tests were skipped by ` +
+  text += `The ${summaryVerb} ${type} tests (${subType}) were skipped by ` +
     `@${user}.\n` +
     `The reason given was: *${reason}*`;
 
@@ -55,7 +55,7 @@ function createSkippedCheckParams(request) {
     conclusion: 'success',
     output: {
       title: `Skipped by @${user}`,
-      summary: `The ${type} (${subType}) tests have previously ` +
+      summary: `The ${type} tests (${subType}) have previously ` +
         `${summaryVerb} on Travis.`,
       text,
     },
@@ -122,7 +122,7 @@ exports.installWebUiRouter = (app, db) => {
         if (request.check.failed == 0) {
           return response.status(400).render('400', {
             message:
-                `${request.params.type} (${request.params.subType}) tests ` +
+                `${request.params.type} tests (${request.params.subType}) ` +
                 `for ${request.short_head_sha} have no failures`,
           });
         }


### PR DESCRIPTION
As suggested in https://github.com/ampproject/amphtml/pull/21407#discussion_r267410535

Note that I broke the database convention here from snake_case to camelCase, calling this field in the database `sub_type` to calling it `subType`. I'm planning on sending another PR soon to rename all of the database fields to camelCase so that they'll match the JavaScript style for variable names. I don't know why I didn't start that way, and since we don't have any real production data in this database yet I can just drop the tables and start over easily