### PR TITLE
Temporarily make all failures 'neutral' for test-status

### DIFF
--- a/test-status/api.js
+++ b/test-status/api.js
@@ -104,7 +104,8 @@ function createReportedCheckParams(
         process.env.WEB_UI_BASE_URL);
     Object.assign(params, {
       details_url: detailsUrl.href,
-      conclusion: 'action_required',
+      // TODO(#102, danielrozenberg): restore this to 'action_required'
+      conclusion: 'neutral',
       output: {
         title: `${failed} test${failed != 1 ? 's' : ''} failed`,
         summary: `The ${type} tests (${subType}) finished running on Travis.`,
@@ -154,7 +155,8 @@ function createErroredCheckParams(
     status: 'completed',
     completed_at: new Date().toISOString(),
     details_url: detailsUrl.href,
-    conclusion: 'action_required',
+    // TODO(#102, danielrozenberg): restore this to 'action_required'
+    conclusion: 'neutral',
     output: {
       title: `Tests have errored`,
       summary: `An unexpected error occurred while running ${type} ` +

--- a/test-status/test/api.test.js
+++ b/test-status/test/api.test.js
@@ -144,9 +144,11 @@ describe('test-status/api', () => {
   test.each([
     [0, 0, 'success', '0 tests passed', null],
     [1, 0, 'success', '1 test passed', null],
-    [5, 5, 'action_required', '5 tests failed',
+    // TODO(#102, danielrozenberg): restore this to 'action_required'
+    [5, 5, 'neutral', '5 tests failed',
       `http://localhost:3000/tests/${HEAD_SHA}/unit/saucelabs/status`],
-    [0, 1, 'action_required', '1 test failed',
+    // TODO(#102, danielrozenberg): restore this to 'action_required'
+    [0, 1, 'neutral', '1 test failed',
       `http://localhost:3000/tests/${HEAD_SHA}/unit/saucelabs/status`],
   ])('Update an existing check with /report/%d/%d action',
       async (passed, failed, conclusion, title, detailsUrl) => {
@@ -219,7 +221,8 @@ describe('test-status/api', () => {
         .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
           expect(body).toMatchObject({
             status: 'completed',
-            conclusion: 'action_required',
+            // TODO(#102, danielrozenberg): restore this to 'action_required'
+            conclusion: 'neutral',
             details_url: `http://localhost:3000/tests/${HEAD_SHA}/unit/` +
               'saucelabs/status',
             output: {


### PR DESCRIPTION
I don't want the failures of the test-status bot to scare off people at first. Let's get everyone used to just seeing the errors before we restore the red × mark.

Created #102 to track reverting this