### PR TITLE
Project Metrics: Add module to prune old data

### DIFF
--- a/project-metrics/metrics_service/pruning.py
+++ b/project-metrics/metrics_service/pruning.py
@@ -1,0 +1,14 @@
+"""Module to provide pruning for metric data tables."""
+
+import logging
+
+import db_engine
+import models
+
+
+def prune() -> None:
+  """Prune rows older than 90 days."""
+  logging.info('Pruning builds older than 90 days.')
+  session = db_engine.get_session()
+  deleted = models.Build.last_90_days(session, negate=True).delete()
+  logging.info('Removed %d old builds', deleted)

--- a/project-metrics/metrics_service/requirements.txt
+++ b/project-metrics/metrics_service/requirements.txt
@@ -19,6 +19,7 @@ networkx==2.3
 ninja==1.9.0.post1
 packaging==19.0
 pluggy==0.12.0
+public==2019.4.13
 py==1.8.0
 PyMySQL==0.9.3
 pyparsing==2.4.0
@@ -30,6 +31,7 @@ six==1.12.0
 SQLAlchemy==1.3.4
 stringcase==1.2.0
 TravisPy==0.3.5
+timedelta==2019.4.13
 typed-ast==1.4.0
 urllib3==1.25.3
 wcwidth==0.1.7


### PR DESCRIPTION
This will be used by a cron server endpoint to periodically prune the `builds` and `releases` tables.