### PR TITLE
Project Metrics: Add filters, metric registration, and cron configs to existing metrics

### DIFF
--- a/project-metrics/metrics_service/cron.yaml
+++ b/project-metrics/metrics_service/cron.yaml
@@ -10,3 +10,7 @@ cron:
 - description: "Update presubmit-latency metric."
   url: /_cron/recompute/PresubmitLatencyMetric
   schedule: every 24 hours
+
+- description: "Update travis-greenness metric."
+  url: /_cron/recompute/TravisGreennessMetric
+  schedule: every 24 hours

--- a/project-metrics/metrics_service/cron.yaml
+++ b/project-metrics/metrics_service/cron.yaml
@@ -3,6 +3,10 @@ cron:
   url: /_cron/recompute/IdentityMetric
   schedule: every 6 hours
 
+- description: "Update presubmit-ignored metric."
+  url: /_cron/recompute/PresubmitIgnoredMetric
+  schedule: every 24 hours
+
 - description: "Update presubmit-latency metric."
   url: /_cron/recompute/PresubmitLatencyMetric
   schedule: every 24 hours

--- a/project-metrics/metrics_service/cron.yaml
+++ b/project-metrics/metrics_service/cron.yaml
@@ -2,3 +2,7 @@ cron:
 - description: "Update dummy metric."
   url: /_cron/recompute/IdentityMetric
   schedule: every 6 hours
+
+- description: "Update presubmit-latency metric."
+  url: /_cron/recompute/PresubmitLatencyMetric
+  schedule: every 24 hours

--- a/project-metrics/metrics_service/metrics/__init__.py
+++ b/project-metrics/metrics_service/metrics/__init__.py
@@ -1,3 +1,3 @@
 """Import metric implementations so they can register themselves."""
 from . import base
-from . import dummy
+from . import example

--- a/project-metrics/metrics_service/metrics/base.py
+++ b/project-metrics/metrics_service/metrics/base.py
@@ -19,7 +19,7 @@ import db_engine
 import models
 
 
-class Metric(MetricDisplay):
+class Metric(object):
   """Abstract base class for health metrics."""
 
   __metaclass__ = abc.ABCMeta

--- a/project-metrics/metrics_service/metrics/example.py
+++ b/project-metrics/metrics_service/metrics/example.py
@@ -10,7 +10,7 @@ import models
 class IdentityMetric(base.PercentageMetric):
   """A metric which reports the value it is initialized with."""
 
-  def __init__(self, result: models.MetricResult = None, value: float):
+  def __init__(self, value: float, result: models.MetricResult = None):
     super(IdentityMetric, self).__init__(result)
     self._value = value
 

--- a/project-metrics/metrics_service/metrics/presubmit_ignored.py
+++ b/project-metrics/metrics_service/metrics/presubmit_ignored.py
@@ -1,4 +1,4 @@
-"""Presubmit-Ignored metric."""
+"""Presubmit Ignored metric."""
 
 import db_engine
 from metrics import base
@@ -33,8 +33,11 @@ class PresubmitIgnoredMetric(base.Metric):
       The number of failed or errored builds.
     """
     session = db_engine.get_session()
-    return session.query(models.Build).filter(
+    return models.Build.last_90_days(session).filter(
         models.Build.state.in_([
             models.TravisState.FAILED,
             models.TravisState.ERRORED,
         ])).count()
+
+
+base.Metric.register(PresubmitIgnoredMetric)

--- a/project-metrics/metrics_service/metrics/presubmit_latency.py
+++ b/project-metrics/metrics_service/metrics/presubmit_latency.py
@@ -1,4 +1,4 @@
-"""Presubmit-Latency metric."""
+"""Presubmit Latency metric."""
 
 import sqlalchemy
 from typing import Text
@@ -24,7 +24,6 @@ class PresubmitLatencyMetric(base.Metric):
     else:
       return models.MetricScore.EXCELLENT
 
-
   def _compute_value(self) -> float:
     """Computes the average duration of all completed builds.
 
@@ -38,8 +37,11 @@ class PresubmitLatencyMetric(base.Metric):
       The percentage of passing builds.
     """
     session = db_engine.get_session()
-    avg_seconds = session.query(sqlalchemy.func.avg(models.Build.duration)
-                               ).scalar()
+    avg_seconds = session.query(sqlalchemy.func.avg(
+        models.Build.duration)).filter(models.Build.is_last_90_days()).scalar()
     if avg_seconds:
       return float(avg_seconds)
     raise ValueError('No Travis builds to process.')
+
+
+base.Metric.register(PresubmitLatencyMetric)

--- a/project-metrics/metrics_service/metrics/travis_greenness.py
+++ b/project-metrics/metrics_service/metrics/travis_greenness.py
@@ -1,8 +1,8 @@
-"""Travis-Greenness metric."""
+"""Travis Greenness metric."""
 
-import datetime
+import logging
 import sqlalchemy
-from typing import Dict, Text
+from typing import Dict
 
 import db_engine
 from metrics import base
@@ -29,6 +29,7 @@ class TravisGreennessMetric(base.PercentageMetric):
     count_query = session.query(
         models.Build.state,
         sqlalchemy.func.count().label('state_count')
+        ).filter(models.Build.is_last_90_days()
         ).group_by(models.Build.state
         ).filter(models.Build.state.in_([
             models.TravisState.PASSED,
@@ -59,3 +60,6 @@ class TravisGreennessMetric(base.PercentageMetric):
     if total:
       return passed / total
     raise ValueError('No Travis builds to process.')
+
+
+models.Metric.register(TravisGreennessMetric)


### PR DESCRIPTION
Since these metric implementations were written while metric registration and the cron server were pending CLs, they did not include these things in order to unblock review. This PR adds a helper scope to Builds, configures each metric, and cleans up a couple bugs introduced in a previous "Code review fixes" commit.