### PR TITLE
Project Metrics: Add tests for API modules

### DIFF
--- a/project-metrics/metrics_service/apis/codecov.py
+++ b/project-metrics/metrics_service/apis/codecov.py
@@ -18,8 +18,8 @@ class CodecovApiError(Exception):
       status_code: HTTP status return code of the Codecov API response.
       err_msg: error message provided by the API.
     """
-    super(CodecovApiError, self).__init__('Codecov API Exception (HTTP %d): %s' %
-                                          (status_code, err_msg))
+    super(CodecovApiError, self).__init__(
+        'Codecov API Exception (HTTP %d): %s' % (status_code, err_msg))
 
 
 class CodecovApi(agithub_base.API):

--- a/project-metrics/metrics_service/apis/codecov_test.py
+++ b/project-metrics/metrics_service/apis/codecov_test.py
@@ -25,11 +25,7 @@ class TestCodecovApi(unittest.TestCase):
 
   def testGetAbsoluteCoverage(self):
     self.mock_request.return_value = (200, {
-        'commit': {
-            'totals': {
-                'c': '13.37'
-            }
-        }
+        'commit': {'totals': {'c': '13.37'} }
     })
     coverage = self.codecov_api.get_absolute_coverage()
 

--- a/project-metrics/metrics_service/apis/codecov_test.py
+++ b/project-metrics/metrics_service/apis/codecov_test.py
@@ -1,0 +1,46 @@
+"""Tests for Codecov API interface."""
+
+from agithub import base as agithub_base
+import unittest
+from unittest import mock
+
+import env
+from apis import codecov
+
+
+class TestCodecovApi(unittest.TestCase):
+
+  def setUp(self):
+    super(TestCodecovApi, self).setUp()
+
+    mock.patch.object(
+        env, 'get', side_effect={
+            'GITHUB_REPO': '__repo__',
+        }.get).start()
+    self.mock_request = mock.patch.object(
+        agithub_base.Client, 'request', autospec=True).start()
+    self.addCleanup(mock.patch.stopall)
+
+    self.codecov_api = codecov.CodecovApi()
+
+  def testGetAbsoluteCoverage(self):
+    self.mock_request.return_value = (200, {
+        'commit': {
+            'totals': {
+                'c': '13.37'
+            }
+        }
+    })
+    coverage = self.codecov_api.get_absolute_coverage()
+
+    self.assertEqual(coverage, 13.37)
+    self.mock_request.assert_called_once_with(
+        self.codecov_api.client, 'GET', '/__repo__/branch/master?limit=1',
+        mock.ANY, mock.ANY)
+
+  def testGetAbsoluteCoverageError(self):
+    self.mock_request.return_value = (404, {'error': {'reason': 'Not found.'}})
+    with self.assertRaises(
+        codecov.CodecovApiError,
+        msg='Codecov API Exception HTTP 404): Not found.'):
+      self.codecov_api.get_absolute_coverage()

--- a/project-metrics/metrics_service/apis/travis_test.py
+++ b/project-metrics/metrics_service/apis/travis_test.py
@@ -41,7 +41,8 @@ class TestTravisApi(unittest.TestCase):
 
     with self.assertRaisesRegex(
         travis.TravisApiError,
-        r'Travis API Exception \(HTTP 403\): Travis Auth API request failed with response: Unauthorized\.'
+        (r'Travis API Exception \(HTTP 403\): '
+          'Travis Auth API request failed with response: Unauthorized\.')
     ):
       travis.TravisApi()
 
@@ -82,6 +83,7 @@ class TestTravisApi(unittest.TestCase):
 
     with self.assertRaisesRegex(
         travis.TravisApiError,
-        r'Travis API Exception \(HTTP 500\): Travis Builds API request failed with response: Server error\.'
+        (r'Travis API Exception \(HTTP 500\): '
+          'Travis Builds API request failed with response: Server error\.')
     ):
       travis_api.fetch_builds(after_number=3)

--- a/project-metrics/metrics_service/apis/travis_test.py
+++ b/project-metrics/metrics_service/apis/travis_test.py
@@ -1,0 +1,87 @@
+"""Tests for Travis API interface."""
+
+import unittest
+from unittest import mock
+from agithub import base as agithub_base
+
+from apis import travis
+import env
+from database import models
+
+
+class TestTravisApi(unittest.TestCase):
+
+  def setUp(self):
+    super(TestTravisApi, self).setUp()
+
+    mock.patch.object(
+        env,
+        'get',
+        side_effect={
+            'GITHUB_REPO': '__repo__',
+            'GITHUB_API_ACCESS_TOKEN': '__github_token__',
+        }.get).start()
+    self.mock_request = mock.patch.object(
+        agithub_base.Client, 'request', autospec=True).start()
+
+    self.addCleanup(mock.patch.stopall)
+
+  def testGetTravisToken(self):
+    self.mock_request.return_value = (200, {'access_token': '__travis_token__'})
+
+    travis_api = travis.TravisApi()
+
+    self.assertEqual(travis_api._token, '__travis_token__')
+    self.mock_request.assert_called_once_with(
+        travis_api.client, 'POST', '/auth/github?github_token=__github_token__',
+        mock.ANY, mock.ANY)
+
+  def testGetTravisTokenError(self):
+    self.mock_request.return_value = (403, 'Unauthorized.')
+
+    with self.assertRaisesRegex(
+        travis.TravisApiError,
+        r'Travis API Exception \(HTTP 403\): Travis Auth API request failed with response: Unauthorized\.'
+    ):
+      unused = travis.TravisApi()
+
+  @mock.patch.object(
+      travis.TravisApi, '_get_travis_token', return_value='__travis_token__')
+  def testFetchBuilds(self, unused_mock_get_travis_token):
+    build = models.Build(duration=1000, state=models.TravisState.PASSED)
+    self.mock_request.return_value = (200, [build])
+
+    travis_api = travis.TravisApi()
+    fetched_builds = travis_api.fetch_builds()
+
+    self.assertEqual(fetched_builds, [build])
+    self.mock_request.assert_called_once_with(
+        travis_api.client, 'GET',
+        '/repos/__repo__/builds?event_type=pull_request', mock.ANY, mock.ANY)
+
+  @mock.patch.object(
+      travis.TravisApi, '_get_travis_token', return_value='__travis_token__')
+  def testFetchBuildsAfterNumber(self, unused_mock_get_travis_token):
+    build = models.Build(duration=1000, state=models.TravisState.PASSED)
+    self.mock_request.return_value = (200, [build])
+
+    travis_api = travis.TravisApi()
+    fetched_builds = travis_api.fetch_builds(after_number=3)
+
+    self.assertEqual(fetched_builds, [build])
+    self.mock_request.assert_called_once_with(
+        travis_api.client, 'GET',
+        '/repos/__repo__/builds?event_type=pull_request&after_number=3',
+        mock.ANY, mock.ANY)
+
+  @mock.patch.object(
+      travis.TravisApi, '_get_travis_token', return_value='__travis_token__')
+  def testFetchBuildsError(self, unused_mock_get_travis_token):
+    travis_api = travis.TravisApi()
+    self.mock_request.return_value = (500, 'Server error.')
+
+    with self.assertRaisesRegex(
+        travis.TravisApiError,
+        r'Travis API Exception \(HTTP 500\): Travis Builds API request failed with response: Server error\.'
+    ):
+      unused = travis_api.fetch_builds(after_number=3)

--- a/project-metrics/metrics_service/apis/travis_test.py
+++ b/project-metrics/metrics_service/apis/travis_test.py
@@ -5,8 +5,8 @@ from unittest import mock
 from agithub import base as agithub_base
 
 from apis import travis
-import env
 from database import models
+import env
 
 
 class TestTravisApi(unittest.TestCase):
@@ -43,7 +43,7 @@ class TestTravisApi(unittest.TestCase):
         travis.TravisApiError,
         r'Travis API Exception \(HTTP 403\): Travis Auth API request failed with response: Unauthorized\.'
     ):
-      unused = travis.TravisApi()
+      travis.TravisApi()
 
   @mock.patch.object(
       travis.TravisApi, '_get_travis_token', return_value='__travis_token__')
@@ -84,4 +84,4 @@ class TestTravisApi(unittest.TestCase):
         travis.TravisApiError,
         r'Travis API Exception \(HTTP 500\): Travis Builds API request failed with response: Server error\.'
     ):
-      unused = travis_api.fetch_builds(after_number=3)
+      travis_api.fetch_builds(after_number=3)


### PR DESCRIPTION
These are not beautiful, but they make it easy to compare to the API docs and confirm that the right endpoints are being called in the right way.