### PR TITLE
Update dependency express-validator to v6

### DIFF
--- a/test-status/package-lock.json
+++ b/test-status/package-lock.json
@@ -2380,12 +2380,19 @@
       }
     },
     "express-validator": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-5.3.1.tgz",
-      "integrity": "sha512-g8xkipBF6VxHbO1+ksC7nxUU7+pWif0+OZXjZTybKJ/V0aTVhuCoHbyhIPgSYVldwQLocGExPtB2pE0DqK4jsw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.0.0.tgz",
+      "integrity": "sha512-QDd7D96jULdQNNFw1lQKyRJtFIN+k/MN3e5fBW93AkxIk5RcV/B0BV+i4ka7fD0/2FsqOUvyQCKlx1mg6g/aXg==",
       "requires": {
-        "lodash": "^4.17.10",
-        "validator": "^10.4.0"
+        "lodash": "^4.17.11",
+        "validator": "^11.0.0"
+      },
+      "dependencies": {
+        "validator": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-11.0.0.tgz",
+          "integrity": "sha512-+wnGLYqaKV2++nUv60uGzUJyJQwYVOin6pn1tgEiFCeCQO60yeu3Og9/yPccbBX574kxIcEJicogkzx6s6eyag=="
+        }
       }
     },
     "extend": {
@@ -7893,7 +7900,8 @@
     "validator": {
       "version": "10.11.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
+      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==",
+      "dev": true
     },
     "vary": {
       "version": "1.1.2",

--- a/test-status/package.json
+++ b/test-status/package.json
@@ -23,7 +23,7 @@
     "body-parser": "1.19.0",
     "express": "4.17.1",
     "express-session": "1.16.2",
-    "express-validator": "5.3.1",
+    "express-validator": "6.0.0",
     "knex": "0.17.6",
     "pg": "7.11.0",
     "passport": "0.4.0",

--- a/test-status/web.js
+++ b/test-status/web.js
@@ -14,7 +14,7 @@
  */
 'use strict';
 
-const {body, validationResult} = require('express-validator/check');
+const {body, validationResult} = require('express-validator');
 const bodyParser = require('body-parser');
 const express = require('express');
 const {getBuildCop, getCheckRunResults} = require('./db');


### PR DESCRIPTION
Redoing #191 from @renovate-bot but with the required change to avoid deprecation warnings