### PR TITLE
Projec Metrics: Fix APi endpoint return values

### DIFF
--- a/project-metrics/metrics_service/server.py
+++ b/project-metrics/metrics_service/server.py
@@ -58,10 +58,10 @@ def list_metrics():
   try:
     results = base.Metric.get_latest().values()
   except Exception as error:
-    return flask.jsonify({'error': error.message}, status.HTTP_500_SERVER_ERROR)
+    return flask.jsonify({'error': error.message}), status.HTTP_500_SERVER_ERROR
 
-  return flask.jsonify({'metrics': [metric.serializable for metric in results]},
-                       status.HTTP_200_OK)
+  return flask.jsonify({'metrics': [metric.serializable for metric in results]
+                       }), status.HTTP_200_OK
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The return value should be a `(response, status_code)`,  but in the endpoints using `jsonify` the parenthesis was in the wrong place so the return value became `((response, status_code), None)`