### PR TITLE
Project Metrics: Use wall-clock time for Travis build duration

### DIFF
--- a/project-metrics/metrics_service/apis/travis.py
+++ b/project-metrics/metrics_service/apis/travis.py
@@ -55,11 +55,15 @@ class TravisApi(agithub_base.API):
     started_at = datetime.datetime.strptime(
         json_build['started_at'],
         '%Y-%m-%dT%H:%M:%SZ') if json_build['started_at'] else None
+    finished_at = datetime.datetime.strptime(
+        json_build['finished_at'],
+        '%Y-%m-%dT%H:%M:%SZ') if json_build['finished_at'] else None
+    duration = finished_at - started_at if started_at and finished_at else None
 
     return models.Build(
         id=json_build['id'],
         number=int(json_build['number']),
-        duration=json_build['duration'],
+        duration=duration.seconds if duration else None,
         state=models.TravisState(json_build['state']),
         started_at=started_at,
         commit_hash=json_build['commit']['sha'])

--- a/project-metrics/metrics_service/metrics/presubmit_latency.py
+++ b/project-metrics/metrics_service/metrics/presubmit_latency.py
@@ -15,13 +15,14 @@ class PresubmitLatencyMetric(base.Metric):
     return '%dm' % (avg_seconds // 60)
 
   def _score_value(self, avg_seconds: float) -> models.MetricScore:
-    if avg_seconds > 35:
+    avg_minutes = avg_seconds / 60
+    if avg_minutes > 35:
       return models.MetricScore.CRITICAL
-    elif avg_seconds > 25:
+    elif avg_minutes > 25:
       return models.MetricScore.POOR
-    elif avg_seconds > 15:
+    elif avg_minutes > 15:
       return models.MetricScore.MODERATE
-    elif avg_seconds > 10:
+    elif avg_minutes > 10:
       return models.MetricScore.GOOD
     else:
       return models.MetricScore.EXCELLENT

--- a/project-metrics/metrics_service/metrics/presubmit_latency_test.py
+++ b/project-metrics/metrics_service/metrics/presubmit_latency_test.py
@@ -45,15 +45,15 @@ class TestPresubmitLatencyMetric(metric_test_case.MetricTestCase):
 
   def testScore(self):
     self.assertEqual(self.metric.score, models.MetricScore.UNKNOWN)
-    self.assertValueHasScore(40, models.MetricScore.CRITICAL)
-    self.assertValueHasScore(35, models.MetricScore.POOR)
-    self.assertValueHasScore(30, models.MetricScore.POOR)
-    self.assertValueHasScore(25, models.MetricScore.MODERATE)
-    self.assertValueHasScore(20, models.MetricScore.MODERATE)
-    self.assertValueHasScore(15, models.MetricScore.GOOD)
-    self.assertValueHasScore(12, models.MetricScore.GOOD)
-    self.assertValueHasScore(10, models.MetricScore.EXCELLENT)
-    self.assertValueHasScore(5, models.MetricScore.EXCELLENT)
+    self.assertValueHasScore(60 * 40, models.MetricScore.CRITICAL)
+    self.assertValueHasScore(60 * 35, models.MetricScore.POOR)
+    self.assertValueHasScore(60 * 30, models.MetricScore.POOR)
+    self.assertValueHasScore(60 * 25, models.MetricScore.MODERATE)
+    self.assertValueHasScore(60 * 20, models.MetricScore.MODERATE)
+    self.assertValueHasScore(60 * 15, models.MetricScore.GOOD)
+    self.assertValueHasScore(60 * 12, models.MetricScore.GOOD)
+    self.assertValueHasScore(60 * 10, models.MetricScore.EXCELLENT)
+    self.assertValueHasScore(60 * 5, models.MetricScore.EXCELLENT)
 
   def testFormattedResult(self):
     self.assertEqual(self.metric.formatted_result, '?')


### PR DESCRIPTION
Also fixes scoring for presubmit-latency