### PR TITLE
Project Metrics: Enable support for metrics to compute historical metric results

### DIFF
--- a/project-metrics/metrics_service/apis/codecov_test.py
+++ b/project-metrics/metrics_service/apis/codecov_test.py
@@ -23,9 +23,13 @@ class TestCodecovApi(unittest.TestCase):
 
     self.codecov_api = codecov.CodecovApi()
 
-  def testGetAbsoluteCoverage(self):
+  def testGetAbsoluteCoverageForHead(self):
     self.mock_request.return_value = (200, {
-        'commit': {'totals': {'c': '13.37'} }
+        'commit': {
+            'totals': {
+                'c': '13.37'
+            }
+        }
     })
     coverage = self.codecov_api.get_absolute_coverage()
 
@@ -33,6 +37,21 @@ class TestCodecovApi(unittest.TestCase):
     self.mock_request.assert_called_once_with(
         self.codecov_api.client, 'GET', '/__repo__/branch/master?limit=1',
         mock.ANY, mock.ANY)
+
+  def testGetAbsoluteCoverageForCommit(self):
+    self.mock_request.return_value = (200, {
+        'commit': {
+            'totals': {
+                'c': '13.37'
+            }
+        }
+    })
+    coverage = self.codecov_api.get_absolute_coverage('test_commit_hash')
+
+    self.assertEqual(coverage, 13.37)
+    self.mock_request.assert_called_once_with(
+        self.codecov_api.client, 'GET',
+        '/__repo__/commits/test_commit_hash?limit=1', mock.ANY, mock.ANY)
 
   def testGetAbsoluteCoverageError(self):
     self.mock_request.return_value = (404, {'error': {'reason': 'Not found.'}})

--- a/project-metrics/metrics_service/database/models.py
+++ b/project-metrics/metrics_service/database/models.py
@@ -1,6 +1,6 @@
 """Defines ORM models for interactions with the DB."""
 
-from typing import Text
+from typing import Optional, Text
 import datetime
 import enum
 import sqlalchemy

--- a/project-metrics/metrics_service/metrics/absolute_coverage.py
+++ b/project-metrics/metrics_service/metrics/absolute_coverage.py
@@ -26,11 +26,11 @@ class AbsoluteCoverageMetric(base.PercentageMetric):
       The percentage of lines tested in HEAD.
     """
     session = db.Session()
-    head_commit = session.query(
-        models.Commit).filter(models.Commit.committed_at < self.now).order_by(
+    head_commit = session.query(models.Commit).filter(
+        models.Commit.committed_at < self.base_time).order_by(
             models.Commit.committed_at.desc()).first()
     if not head_commit:
-      raise ValueError('No commit available before %s' % self.now)
+      raise ValueError('No commit available before %s' % self.base_time)
     return codecov.CodecovApi().get_absolute_coverage(head_commit.hash) / 100
 
 

--- a/project-metrics/metrics_service/metrics/absolute_coverage.py
+++ b/project-metrics/metrics_service/metrics/absolute_coverage.py
@@ -24,6 +24,7 @@ class AbsoluteCoverageMetric(base.PercentageMetric):
     Returns:
       The percentage of lines tested in HEAD.
     """
+    # TODO(rcebulko): enable support for historical coverage
     return codecov.CodecovApi().get_absolute_coverage() / 100
 
 

--- a/project-metrics/metrics_service/metrics/base.py
+++ b/project-metrics/metrics_service/metrics/base.py
@@ -13,6 +13,7 @@ To create a new metric:
 """
 
 import abc
+import datetime
 import logging
 import sqlalchemy
 import stringcase
@@ -90,8 +91,11 @@ class Metric(object):
   def get_metric(cls, metric_cls_name) -> models.MetricResult:
     return cls._active_metrics[metric_cls_name]
 
-  def __init__(self, result: Optional[models.MetricResult] = None):
+  def __init__(self,
+               result: Optional[models.MetricResult] = None,
+               now: Optional[datetime.datetime] = None):
     self.result = result
+    self.now = now or datetime.datetime.now()
 
   def __str__(self) -> Text:
     return '%s: %s' % (self.label, self.formatted_result)
@@ -125,13 +129,14 @@ class Metric(object):
         'label': self.label,
         'formatted_result': self.formatted_result,
         'score': self.score.name,
+        'computed_at': str(self.result.computed_at),
     }
 
   def recompute(self) -> None:
     """Computes the metric and records the result in the `metrics` table."""
-    logging.info('Recomputing metric %s', self.name)
+    logging.info('Recomputing metric %s at %s', self.name, self.now)
     self.result = models.MetricResult(
-        value=self._compute_value(), name=self.name)
+        value=self._compute_value(), name=self.name, computed_at=self.now)
 
     logging.info('Updating metric %s value to %.3g', self.name,
                  self.result.value)

--- a/project-metrics/metrics_service/metrics/base.py
+++ b/project-metrics/metrics_service/metrics/base.py
@@ -93,9 +93,9 @@ class Metric(object):
 
   def __init__(self,
                result: Optional[models.MetricResult] = None,
-               now: Optional[datetime.datetime] = None):
+               base_time: Optional[datetime.datetime] = None):
     self.result = result
-    self.now = now or datetime.datetime.now()
+    self.base_time = base_time or datetime.datetime.now()
 
   def __str__(self) -> Text:
     return '%s: %s' % (self.label, self.formatted_result)
@@ -134,9 +134,9 @@ class Metric(object):
 
   def recompute(self) -> None:
     """Computes the metric and records the result in the `metrics` table."""
-    logging.info('Recomputing metric %s at %s', self.name, self.now)
+    logging.info('Recomputing metric %s at %s', self.name, self.base_time)
     self.result = models.MetricResult(
-        value=self._compute_value(), name=self.name, computed_at=self.now)
+        value=self._compute_value(), name=self.name, computed_at=self.base_time)
 
     logging.info('Updating metric %s value to %.3g', self.name,
                  self.result.value)

--- a/project-metrics/metrics_service/metrics/presubmit_latency.py
+++ b/project-metrics/metrics_service/metrics/presubmit_latency.py
@@ -42,7 +42,7 @@ class PresubmitLatencyMetric(base.Metric):
     session = db.Session()
     avg_seconds = session.query(sqlalchemy.func.avg(
         models.Build.duration)).filter(
-            models.Build.is_last_90_days(now=self.now)).scalar()
+            models.Build.is_last_90_days(base_time=self.base_time)).scalar()
     if avg_seconds:
       return float(avg_seconds)
     raise ValueError('No Travis builds to process.')

--- a/project-metrics/metrics_service/metrics/presubmit_latency.py
+++ b/project-metrics/metrics_service/metrics/presubmit_latency.py
@@ -41,7 +41,8 @@ class PresubmitLatencyMetric(base.Metric):
     """
     session = db.Session()
     avg_seconds = session.query(sqlalchemy.func.avg(
-        models.Build.duration)).filter(models.Build.is_last_90_days()).scalar()
+        models.Build.duration)).filter(
+            models.Build.is_last_90_days(now=self.now)).scalar()
     if avg_seconds:
       return float(avg_seconds)
     raise ValueError('No Travis builds to process.')

--- a/project-metrics/metrics_service/metrics/release_cherrypick_count.py
+++ b/project-metrics/metrics_service/metrics/release_cherrypick_count.py
@@ -37,7 +37,7 @@ class ReleaseCherrypickCountMetric(base.Metric):
     logging.info('Counting cherry-picks')
     session = db.Session()
     return session.query(models.Cherrypick).join(models.Release).filter(
-        models.Release.is_last_90_days(now=self.now)).count()
+        models.Release.is_last_90_days(base_time=self.base_time)).count()
 
 
 base.Metric.register(ReleaseCherrypickCountMetric)

--- a/project-metrics/metrics_service/metrics/release_cherrypick_count.py
+++ b/project-metrics/metrics_service/metrics/release_cherrypick_count.py
@@ -37,7 +37,7 @@ class ReleaseCherrypickCountMetric(base.Metric):
     logging.info('Counting cherry-picks')
     session = db.Session()
     return session.query(models.Cherrypick).join(models.Release).filter(
-        models.Release.is_last_90_days()).count()
+        models.Release.is_last_90_days(now=self.now)).count()
 
 
 base.Metric.register(ReleaseCherrypickCountMetric)

--- a/project-metrics/metrics_service/metrics/release_granularity.py
+++ b/project-metrics/metrics_service/metrics/release_granularity.py
@@ -43,7 +43,7 @@ class ReleaseGranularityMetric(base.Metric):
     logging.info('Counting commits per release')
     session = db.Session()
     releases = session.query(models.Release).filter(
-        models.Release.is_last_90_days(now=self.now)).all()
+        models.Release.is_last_90_days(base_time=self.base_time)).all()
     release_count = len(releases)
 
     if release_count < 2:

--- a/project-metrics/metrics_service/metrics/release_granularity.py
+++ b/project-metrics/metrics_service/metrics/release_granularity.py
@@ -43,7 +43,7 @@ class ReleaseGranularityMetric(base.Metric):
     logging.info('Counting commits per release')
     session = db.Session()
     releases = session.query(models.Release).filter(
-        models.Release.is_last_90_days()).all()
+        models.Release.is_last_90_days(now=self.now)).all()
     release_count = len(releases)
 
     if release_count < 2:

--- a/project-metrics/metrics_service/metrics/travis_flakiness.py
+++ b/project-metrics/metrics_service/metrics/travis_flakiness.py
@@ -40,7 +40,7 @@ class TravisFlakinessMetric(base.PercentageMetric):
     logging.info('Counting flaky builds')
     session = db.Session()
     builds = models.Build.scope(
-        session, now=self.now).filter(
+        session, base_time=self.base_time).filter(
             models.Build.state.in_([
                 models.TravisState.PASSED,
                 models.TravisState.FAILED,

--- a/project-metrics/metrics_service/metrics/travis_flakiness.py
+++ b/project-metrics/metrics_service/metrics/travis_flakiness.py
@@ -39,12 +39,13 @@ class TravisFlakinessMetric(base.PercentageMetric):
     """
     logging.info('Counting flaky builds')
     session = db.Session()
-    builds = models.Build.scope(session).filter(
-        models.Build.state.in_([
-            models.TravisState.PASSED,
-            models.TravisState.FAILED,
-            models.TravisState.ERRORED,
-        ])).all()
+    builds = models.Build.scope(
+        session, now=self.now).filter(
+            models.Build.state.in_([
+                models.TravisState.PASSED,
+                models.TravisState.FAILED,
+                models.TravisState.ERRORED,
+            ])).all()
     build_count = len(builds)
 
     if build_count == 0:

--- a/project-metrics/metrics_service/metrics/travis_greenness.py
+++ b/project-metrics/metrics_service/metrics/travis_greenness.py
@@ -31,7 +31,7 @@ class TravisGreennessMetric(base.PercentageMetric):
     count_query = session.query(
         models.Build.state,
         sqlalchemy.func.count().label('state_count')).filter(
-            models.Build.is_last_90_days(now=self.now)).group_by(
+            models.Build.is_last_90_days(base_time=self.base_time)).group_by(
                 models.Build.state).filter(
                     models.Build.state.in_([
                         models.TravisState.PASSED,

--- a/project-metrics/metrics_service/metrics/travis_greenness.py
+++ b/project-metrics/metrics_service/metrics/travis_greenness.py
@@ -31,12 +31,13 @@ class TravisGreennessMetric(base.PercentageMetric):
     count_query = session.query(
         models.Build.state,
         sqlalchemy.func.count().label('state_count')).filter(
-            models.Build.is_last_90_days()).group_by(models.Build.state).filter(
-                models.Build.state.in_([
-                    models.TravisState.PASSED,
-                    models.TravisState.FAILED,
-                    models.TravisState.ERRORED,
-                ]))
+            models.Build.is_last_90_days(now=self.now)).group_by(
+                models.Build.state).filter(
+                    models.Build.state.in_([
+                        models.TravisState.PASSED,
+                        models.TravisState.FAILED,
+                        models.TravisState.ERRORED,
+                    ]))
     state_counts = count_query.all()
     return dict(state_counts)
 


### PR DESCRIPTION
The accuracy of results will depend on historical data being present, which is yet to be scraped. Historical metric computation will be a one-off backfill once the necessary historical data is scraped. 