### PR TITLE
 Project Metrics: Clean up DB session leak

### DIFF
--- a/project-metrics/metrics_service/bootstrap.py
+++ b/project-metrics/metrics_service/bootstrap.py
@@ -72,12 +72,15 @@ def _compute_all_at_time(metrics: Sequence[base_metric.MetricImplementation],
 def compute_all(metrics: Sequence[base_metric.MetricImplementation]):
   """Compute metric results for each week going back one year."""
   one_year_ago = datetime.datetime.now() - ONE_YEAR
+  metric_names = [metric.name for metric in metrics]
   logging.info('Backfilling results to %s', one_year_ago.strftime('%Y-%m-%d'))
 
-  metric_names = [metric.name for metric in metrics]
-  earliest_result = db.Session().query(models.MetricResult).filter(
+  session = db.Session()
+  earliest_result = session.query(models.MetricResult).filter(
       models.MetricResult.name in metric_names).order_by(
           models.MetricResult.computed_at.asc()).first()
+  session.close()
+
   earliest_result_time = (
       earliest_result.computed_at
       if earliest_result else datetime.datetime.now())

--- a/project-metrics/metrics_service/metrics/absolute_coverage.py
+++ b/project-metrics/metrics_service/metrics/absolute_coverage.py
@@ -29,6 +29,7 @@ class AbsoluteCoverageMetric(base.PercentageMetric):
     head_commit = session.query(models.Commit).filter(
         models.Commit.committed_at < self.base_time).order_by(
             models.Commit.committed_at.desc()).first()
+    session.close()
     if not head_commit:
       raise ValueError('No commit available before %s' % self.base_time)
     return codecov.CodecovApi().get_absolute_coverage(head_commit.hash) / 100

--- a/project-metrics/metrics_service/metrics/base.py
+++ b/project-metrics/metrics_service/metrics/base.py
@@ -82,10 +82,12 @@ class Metric(object):
             metric_results.c.name == max_dates_query.c.name,
             metric_results.c.computed_at == max_dates_query.c.max_computed_at))
 
-    return {
+    results = {
         result.name: cls.__from_result(result)
         for result in latest_results_query
     }
+    session.close()
+    return results
 
   @classmethod
   def get_metric(cls, metric_cls_name) -> models.MetricResult:
@@ -147,6 +149,7 @@ class Metric(object):
     session = db.Session()
     session.add(self.result)
     session.commit()
+    session.close()
 
   @abc.abstractmethod
   def _format_value(self, value: float) -> Text:

--- a/project-metrics/metrics_service/metrics/presubmit_latency.py
+++ b/project-metrics/metrics_service/metrics/presubmit_latency.py
@@ -43,6 +43,8 @@ class PresubmitLatencyMetric(base.Metric):
     avg_seconds = session.query(sqlalchemy.func.avg(
         models.Build.duration)).filter(
             models.Build.is_last_90_days(base_time=self.base_time)).scalar()
+    session.close()
+
     if avg_seconds:
       return float(avg_seconds)
     raise ValueError('No Travis builds to process.')

--- a/project-metrics/metrics_service/metrics/release_cherrypick_count.py
+++ b/project-metrics/metrics_service/metrics/release_cherrypick_count.py
@@ -36,8 +36,10 @@ class ReleaseCherrypickCountMetric(base.Metric):
     """
     logging.info('Counting cherry-picks')
     session = db.Session()
-    return session.query(models.Cherrypick).join(models.Release).filter(
+    result = session.query(models.Cherrypick).join(models.Release).filter(
         models.Release.is_last_90_days(base_time=self.base_time)).count()
+    session.close()
+    return result
 
 
 base.Metric.register(ReleaseCherrypickCountMetric)

--- a/project-metrics/metrics_service/metrics/release_granularity.py
+++ b/project-metrics/metrics_service/metrics/release_granularity.py
@@ -56,6 +56,7 @@ class ReleaseGranularityMetric(base.Metric):
     commits_count = session.query(models.Commit).filter(
         models.Commit.committed_at.between(first_release_date,
                                            last_release_date)).count()
+    session.close()
 
     # Subtract one from release count since commits from the last release are
     # not included.

--- a/project-metrics/metrics_service/metrics/travis_flakiness.py
+++ b/project-metrics/metrics_service/metrics/travis_flakiness.py
@@ -46,6 +46,7 @@ class TravisFlakinessMetric(base.PercentageMetric):
                 models.TravisState.FAILED,
                 models.TravisState.ERRORED,
             ])).all()
+    session.close()
     build_count = len(builds)
 
     if build_count == 0:

--- a/project-metrics/metrics_service/metrics/travis_greenness.py
+++ b/project-metrics/metrics_service/metrics/travis_greenness.py
@@ -39,6 +39,8 @@ class TravisGreennessMetric(base.PercentageMetric):
                         models.TravisState.ERRORED,
                     ]))
     state_counts = count_query.all()
+
+    session.close()
     return dict(state_counts)
 
   def _compute_value(self) -> float:

--- a/project-metrics/metrics_service/scrapers/build_scraper.py
+++ b/project-metrics/metrics_service/scrapers/build_scraper.py
@@ -22,6 +22,9 @@ class BuildScraper(object):
     self.travis = travis.TravisApi()
     self.session = db.Session()
 
+  def __del__(self):
+    self.session.close()
+
   def _get_latest_build_number(self) -> Optional[int]:
     build = self.session.query(models.Build).order_by(
         models.Build.number.desc()).first()

--- a/project-metrics/metrics_service/scrapers/cherrypick_scraper.py
+++ b/project-metrics/metrics_service/scrapers/cherrypick_scraper.py
@@ -21,6 +21,9 @@ class CherrypickScraper(object):
         self.session.query(models.Cherrypick.hash)).all()
     self.seen_commit_hashes = set(commit.hash for commit in commits)
 
+  def __del__(self):
+    self.session.close()
+
   def scrape_release_cherrypicks(
       self, release: models.Release) -> Sequence[models.Cherrypick]:
     """Determines the commit SHAs of cherrypick commits in a release.

--- a/project-metrics/metrics_service/scrapers/commit_scraper.py
+++ b/project-metrics/metrics_service/scrapers/commit_scraper.py
@@ -22,6 +22,9 @@ class CommitScraper(object):
     self.session = db.Session()
     self.cursor = None
 
+  def __del__(self):
+    self.session.close()
+
   def _get_latest_commit_timestamp(self) -> datetime.datetime:
     commit = self.session.query(models.Commit).order_by(
         models.Commit.committed_at.desc()).first()

--- a/project-metrics/metrics_service/scrapers/release_scraper.py
+++ b/project-metrics/metrics_service/scrapers/release_scraper.py
@@ -24,6 +24,9 @@ class ReleaseScraper(object):
     self.session = db.Session()
     self.cursor = None
 
+  def __del__(self):
+    self.session.close()
+
   def _get_latest_release_timestamp(self) -> datetime.datetime:
     release = self.session.query(models.Release).order_by(
         models.Release.published_at.desc()).first()


### PR DESCRIPTION
I had thought `sqlalchemy.orm.scoped_session` was handling this, but it does not.