### PR TITLE
[pr-deploy] Update POST route and downgrade to nodejs10 for App Engine standard env

### DIFF
--- a/pr-deploy/env.example
+++ b/pr-deploy/env.example
@@ -1,0 +1,32 @@
+# Google Cloud Project Name
+PROJECT_ID=my-gcs-project
+
+# Google Cloud Service Account Key Path
+GOOGLE_APPLICATION_CREDENTIALS=./my-gcs-sa-key.json
+
+# Google Cloud Serving Bucket Name
+SERVE_BUCKET=my-serving-bucket
+
+# Google Cloud Build Artifact Bucket Name
+BUILD_BUCKET=my-build-bucket
+
+# GitHub App ID
+APP_ID=00000
+
+# GitHub App Base64 Encoded PRivate Key
+PRIVATE_KEY=0123456789abcdefghijklmnopqrstuvwxyz
+
+# GitHub App Webhook Secret
+WEBHOOK_SECRET=00000
+
+# GitHub App Installation ID
+INSTALLATION_ID=00000
+
+# GitHub Repository Name (that app is installed on)
+GH_REPO=my-repo
+
+# GitHub Repository Owner (that app is installed on)
+GH_OWNER=ownerusername
+
+# GitHub App Check Name
+GH_CHECK=my-pr-deploy-check

--- a/pr-deploy/package-lock.json
+++ b/pr-deploy/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "amp-pr-deploy-app",
+  "name": "amp-pr-deploy-bot",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/pr-deploy/package.json
+++ b/pr-deploy/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "amp-pr-deploy-app",
+  "name": "amp-pr-deploy-bot",
   "description": "A GitHub App that deploys a PR branch when you ask it to",
   "version": "0.0.1",
   "private": true,
@@ -10,7 +10,7 @@
     "url": "https://github.com/ampproject/amp-github-apps.git"
   },
   "engines": {
-    "node": "10.16.0"
+    "node": "^10.0.0"
   },
   "scripts": {
     "build": "node ~/src/TypeScript/built/local/tsc.js ./src/*.ts --esModuleInterop",

--- a/pr-deploy/src/github.ts
+++ b/pr-deploy/src/github.ts
@@ -23,9 +23,10 @@ const ACTION: Octokit.ChecksUpdateParamsActions = {
   description: 'Serves the minified output of this PR.',
   identifier: 'deploy-me-action',
 };
-const CHECK_NAME: string = 'pr-deploy-check';
-const OWNER = process.env.GH_OWNER;
-const REPO = process.env.GH_REPO;
+
+const check_name = process.env.GH_CHECK;
+const owner = process.env.GH_OWNER;
+const repo = process.env.GH_REPO;
 
 export class PullRequest {
   private github: GitHubAPI;
@@ -51,8 +52,8 @@ export class PullRequest {
     const check = await this.getCheck_();
 
     const params: ChecksUpdateParams = {
-      owner: OWNER,
-      repo: REPO,
+      owner,
+      repo,
       check_run_id: check.id,
       status: 'completed',
       conclusion: 'neutral',
@@ -76,8 +77,8 @@ export class PullRequest {
     const check = await this.getCheck_();
 
     const params: ChecksUpdateParams = {
-      owner: OWNER,
-      repo: REPO,
+      owner,
+      repo,
       check_run_id: check.id,
       status: 'in_progress',
       output: {
@@ -99,8 +100,8 @@ export class PullRequest {
     const check = await this.getCheck_();
 
     const params: ChecksUpdateParams = {
-      owner: OWNER,
-      repo: REPO,
+      owner,
+      repo,
       check_run_id: check.id,
       status: 'completed',
       actions: [],
@@ -121,8 +122,8 @@ export class PullRequest {
     const check = await this.getCheck_();
 
     const params: ChecksUpdateParams = {
-      owner: OWNER,
-      repo: REPO,
+      owner,
+      repo,
       check_run_id: check.id,
       status: 'completed',
       conclusion: 'neutral',
@@ -142,8 +143,8 @@ export class PullRequest {
     const check = await this.getCheck_();
 
     const params: ChecksUpdateParams = {
-      owner: OWNER,
-      repo: REPO,
+      owner,
+      repo,
       check_run_id: check.id,
       status: 'completed',
       conclusion: 'neutral',
@@ -173,9 +174,9 @@ export class PullRequest {
    */
   private async createCheck_() {
     const params: Octokit.ChecksCreateParams = {
-      owner: OWNER,
-      repo: REPO,
-      name: CHECK_NAME,
+      owner,
+      repo,
+      name: check_name,
       head_sha: this.headSha,
       status: 'queued',
       output: {
@@ -204,8 +205,8 @@ export class PullRequest {
     }
 
     const params: ChecksUpdateParams = {
-      owner: OWNER,
-      repo: REPO,
+      owner,
+      repo,
       check_run_id: check.id,
       status: 'queued',
       output,
@@ -218,10 +219,10 @@ export class PullRequest {
    */
   private async getCheck_() {
     const params: ChecksListForRefParams = {
-      owner: OWNER,
-      repo: REPO,
+      owner,
+      repo,
       ref: this.headSha,
-      check_name: CHECK_NAME,
+      check_name,
     };
 
     const checks = await this.github.checks.listForRef(params);

--- a/pr-deploy/src/zipper.ts
+++ b/pr-deploy/src/zipper.ts
@@ -23,10 +23,10 @@ import {Storage} from '@google-cloud/storage';
  * AMP Travis Build Storage bucket, unzips and writes to
  * a test website bucket that serves the files publicly.
  */
-export async function unzipAndMove(prId: number): Promise<string> {
+export async function unzipAndMove(id: number): Promise<string> {
   const storage = new Storage({projectId: process.env.PROJECT_ID});
   const serveBucket = storage.bucket(process.env.SERVE_BUCKET);
-  const buildFileName = `amp_dist_${prId}`;
+  const buildFileName = `amp_dist_${id}`;
   const buildFile =
     storage.bucket(process.env.BUILD_BUCKET).file(`${buildFileName}.zip`);
 

--- a/pr-deploy/test/app.test.ts
+++ b/pr-deploy/test/app.test.ts
@@ -17,7 +17,7 @@
 // mock unzipAndMove dependency before importing '../src/app'
 jest.mock('../src/zipper', () => {
   return {
-    unzipAndMove: jest.fn().mockReturnValue(Promise.resolve('gs://serving-bucket/prId')),
+    unzipAndMove: jest.fn().mockReturnValue(Promise.resolve('gs://serving-bucket/travisBuildNumber')),
   };
 });
 
@@ -98,7 +98,7 @@ describe('test pr deploy app', () => {
     );
 
     request(server)
-      .post('/v0/pr-deploy/owners/1/repos/2/headshas/3/0')
+      .post('/v0/pr-deploy/travisbuilds/1/headshas/3/0')
       .expect(() => { expect(github.checks.update).toHaveBeenCalledTimes(1);})
       .expect(200, done);
   });
@@ -106,7 +106,9 @@ describe('test pr deploy app', () => {
   test('deploys the PR check when action is triggered', async() => {
     // make sure a check already exists
     github.checks.listForRef.mockReturnValue(
-      {data: {total_count: 1, check_runs: [{id: 12345}]}}
+      {data: {total_count: 1, check_runs: [
+        {id: 12345, output: {text: 'Travis build number: 3'}},
+      ]}}
     );
 
     const requestedActionEvent:


### PR DESCRIPTION
Updates the route URL to `travisbuilds` because that's how zipped build artifacts are named, `amp_dist_${travisBuildNumber}`.

Downgrades to nodejs10 because App Engine's standard environment only supports specific versions of nodejs, unlike the flexible environment which can support any of them. Opted for using the standard environment because it's :heavy_dollar_sign: free.99

Moved repo `owner` and `repo` to env variables because they're the same every time.