### PR TITLE
Read .br files instead of gzipped (no extension) files

### DIFF
--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -186,7 +186,7 @@ module.exports = app => {
 
     try {
       const baseBundleSize = parseFloat(
-        await getBuildArtifactsFile(github, baseSha)
+        await getBuildArtifactsFile(github, `${baseSha}.br`)
       );
       const bundleSizeDelta = bundleSize - baseBundleSize;
       const bundleSizeDeltaFormatted = formatBundleSizeDelta(bundleSizeDelta);
@@ -507,15 +507,20 @@ module.exports = app => {
         .end('POST request to /report must have commit SHA field "baseSha"');
     }
     if (
-      !('bundleSize' in request.body) ||
-      typeof request.body.bundleSize != 'number'
+      !('brotliBundleSize' in request.body) ||
+      typeof request.body.brotliBundleSize != 'number'
     ) {
       return response
         .status(400)
-        .end('POST request to /report must have numeric field "bundleSize"');
+        .end(
+          'POST request to /report must have numeric field "brotliBundleSize"'
+        );
     }
     const {headSha} = request.params;
-    const {baseSha, bundleSize} = request.body;
+    // TODO(#142): restore the default bundleSize field name here once the
+    // ampproject/amphtml runner starts reporting Brotli sizes in the bundleSize
+    // field.
+    const {baseSha, brotliBundleSize: bundleSize} = request.body;
 
     const check = await getCheckFromDatabase(headSha);
     if (!check) {

--- a/bundle-size/test/app.test.js
+++ b/bundle-size/test/app.test.js
@@ -338,7 +338,7 @@ describe('bundle-size', () => {
       const nocks = nock('https://api.github.com')
         .get(
           '/repos/ampproject/amphtml-build-artifacts/contents/' +
-            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33'
+            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'
         )
         .reply(200, baseBundleSizeFixture)
         .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
@@ -357,6 +357,8 @@ describe('bundle-size', () => {
         .send({
           baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
           bundleSize: 12.34,
+          gzippedBundleSize: 12.34,
+          brotliBundleSize: 12.34,
         })
         .set('Content-Type', 'application/json')
         .set('Accept', 'application/json')
@@ -386,7 +388,7 @@ describe('bundle-size', () => {
       const nocks = nock('https://api.github.com')
         .get(
           '/repos/ampproject/amphtml-build-artifacts/contents/' +
-            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33'
+            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'
         )
         .reply(200, baseBundleSizeFixture)
         .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
@@ -419,6 +421,8 @@ describe('bundle-size', () => {
         .send({
           baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
           bundleSize: 12.34,
+          gzippedBundleSize: 12.34,
+          brotliBundleSize: 12.34,
         })
         .set('Content-Type', 'application/json')
         .set('Accept', 'application/json')
@@ -448,7 +452,7 @@ describe('bundle-size', () => {
       const nocks = nock('https://api.github.com')
         .get(
           '/repos/ampproject/amphtml-build-artifacts/contents/' +
-            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33'
+            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'
         )
         .reply(200, baseBundleSizeFixture)
         .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
@@ -481,6 +485,8 @@ describe('bundle-size', () => {
         .send({
           baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
           bundleSize: 12.34,
+          gzippedBundleSize: 12.34,
+          brotliBundleSize: 12.34,
         })
         .set('Content-Type', 'application/json')
         .set('Accept', 'application/json')
@@ -512,7 +518,7 @@ describe('bundle-size', () => {
       const nocks = nock('https://api.github.com')
         .get(
           '/repos/ampproject/amphtml-build-artifacts/contents/' +
-            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33'
+            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'
         )
         .reply(200, baseBundleSizeFixture)
         .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
@@ -535,6 +541,8 @@ describe('bundle-size', () => {
         .send({
           baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
           bundleSize: 12.34,
+          gzippedBundleSize: 12.34,
+          brotliBundleSize: 12.34,
         })
         .set('Content-Type', 'application/json')
         .set('Accept', 'application/json')
@@ -564,13 +572,13 @@ describe('bundle-size', () => {
       const nocks = nock('https://api.github.com')
         .get(
           '/repos/ampproject/amphtml-build-artifacts/contents/' +
-            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33'
+            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'
         )
         .times(2)
         .reply(404)
         .get(
           '/repos/ampproject/amphtml-build-artifacts/contents/' +
-            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33'
+            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'
         )
         .reply(200, baseBundleSizeFixture)
         .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
@@ -589,6 +597,8 @@ describe('bundle-size', () => {
         .send({
           baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
           bundleSize: 12.34,
+          gzippedBundleSize: 12.34,
+          brotliBundleSize: 12.34,
         })
         .set('Content-Type', 'application/json')
         .set('Accept', 'application/json')
@@ -618,13 +628,13 @@ describe('bundle-size', () => {
       const nocks = nock('https://api.github.com')
         .get(
           '/repos/ampproject/amphtml-build-artifacts/contents/' +
-            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33'
+            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'
         )
         .times(2)
         .reply(404)
         .get(
           '/repos/ampproject/amphtml-build-artifacts/contents/' +
-            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33'
+            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'
         )
         .reply(200, baseBundleSizeFixture)
         .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
@@ -657,6 +667,8 @@ describe('bundle-size', () => {
         .send({
           baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
           bundleSize: 12.34,
+          gzippedBundleSize: 12.34,
+          brotliBundleSize: 12.34,
         })
         .set('Content-Type', 'application/json')
         .set('Accept', 'application/json')
@@ -679,7 +691,7 @@ describe('bundle-size', () => {
     const nocks = nock('https://api.github.com')
       .get(
         '/repos/ampproject/amphtml-build-artifacts/contents/' +
-          'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33'
+          'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'
       )
       .times(60)
       .reply(404)
@@ -713,6 +725,8 @@ describe('bundle-size', () => {
       .send({
         baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
         bundleSize: 12.34,
+        gzippedBundleSize: 12.34,
+        brotliBundleSize: 12.34,
       })
       .set('Content-Type', 'application/json')
       .set('Accept', 'application/json')
@@ -726,6 +740,8 @@ describe('bundle-size', () => {
       .send({
         baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
         bundleSize: 12.34,
+        gzippedBundleSize: 12.34,
+        brotliBundleSize: 12.34,
       })
       .set('Content-Type', 'application/json')
       .set('Accept', 'application/json')


### PR DESCRIPTION
Step 2.ii. in https://github.com/ampproject/amphtml/issues/21275
(repo-local issue: #142)

Do not merge until September 9th to let the repository collect a large enough set of base Brotli sizes