### PR TITLE
[pr-deploy] Fix the URL when a test site is deployed

### DIFF
--- a/pr-deploy/src/app.ts
+++ b/pr-deploy/src/app.ts
@@ -82,9 +82,9 @@ function initializeDeployment(app: Application) {
     );
     await pr.deploymentInProgress();
     const travisBuild = await pr.getTravisBuildNumber();
-    unzipAndMove(travisBuild)
+    await unzipAndMove(travisBuild)
       .then(serveUrl => {
-        pr.deploymentCompleted(serveUrl);
+        pr.deploymentCompleted(serveUrl, travisBuild);
       })
       .catch(e => {
         pr.deploymentErrored(e);

--- a/pr-deploy/src/app.ts
+++ b/pr-deploy/src/app.ts
@@ -84,7 +84,7 @@ function initializeDeployment(app: Application) {
     const travisBuild = await pr.getTravisBuildNumber();
     await unzipAndMove(travisBuild)
       .then(serveUrl => {
-        pr.deploymentCompleted(serveUrl, travisBuild);
+        pr.deploymentCompleted(serveUrl);
       })
       .catch(e => {
         pr.deploymentErrored(e);

--- a/pr-deploy/src/github.ts
+++ b/pr-deploy/src/github.ts
@@ -71,7 +71,7 @@ export class PullRequest {
    * Set check to 'completed' and remove the 'Deploy Me' action once
    * deployment is finished. Display the serve url in the check's output.
    */
-  async deploymentCompleted(serveUrl: string) {
+  async deploymentCompleted(serveUrl: string, travisBuild: number) {
     const check = await this.getCheck_();
 
     const params: ChecksUpdateParams = {
@@ -84,7 +84,7 @@ export class PullRequest {
       details_url: serveUrl,
       output: {
         title: 'Success! A test site was created.',
-        summary: `You can find it here: ${serveUrl}`,
+        summary: `You can find it under amp_dist_${travisBuild}: ${serveUrl}`,
         text: serveUrl,
       },
     };

--- a/pr-deploy/src/github.ts
+++ b/pr-deploy/src/github.ts
@@ -71,7 +71,7 @@ export class PullRequest {
    * Set check to 'completed' and remove the 'Deploy Me' action once
    * deployment is finished. Display the serve url in the check's output.
    */
-  async deploymentCompleted(serveUrl: string, travisBuild: number) {
+  async deploymentCompleted(serveUrl: string) {
     const check = await this.getCheck_();
 
     const params: ChecksUpdateParams = {
@@ -84,7 +84,7 @@ export class PullRequest {
       details_url: serveUrl,
       output: {
         title: 'Success! A test site was created.',
-        summary: `You can find it under amp_dist_${travisBuild}: ${serveUrl}`,
+        summary: `You can find it here: ${serveUrl}`,
         text: serveUrl,
       },
     };

--- a/pr-deploy/src/zipper.ts
+++ b/pr-deploy/src/zipper.ts
@@ -44,7 +44,7 @@ export async function unzipAndMove(id: number): Promise<string> {
             .on('error', reject));
       })
       .on('close', async() => {
-        return resolve(`https://console.cloud.google.com/storage/browser/amp-test-website-1/${buildFileName}`);
+        return resolve(`https://console.cloud.google.com/storage/browser/${process.env.SERVE_BUCKET}/${buildFileName}`);
       });
   });
 };

--- a/pr-deploy/src/zipper.ts
+++ b/pr-deploy/src/zipper.ts
@@ -37,14 +37,14 @@ export async function unzipAndMove(id: number): Promise<string> {
       .on('entry', entry => {
         const serveFileName = entry.path;
         const serveFile = serveBucket.file(`${buildFileName}/${serveFileName}`);
+        const contentType =
+          mime.lookup(serveFileName) || 'application/octet-stream';
         entry.pipe(
-          serveFile.createWriteStream(
-            {metadata: {contentType: mime.lookup(serveFileName)}})
+          serveFile.createWriteStream({metadata: {contentType}})
             .on('error', reject));
       })
       .on('close', async() => {
-        //TODO(estherkim): return uploaded URL (point to examples?)
-        return resolve(`https://storage.googleapis.com/${process.env.SERVE_BUCKET}/${buildFileName}/view.html`);
+        return resolve('https://console.cloud.google.com/storage/browser/amp-test-website-1');
       });
   });
 };

--- a/pr-deploy/src/zipper.ts
+++ b/pr-deploy/src/zipper.ts
@@ -44,7 +44,7 @@ export async function unzipAndMove(id: number): Promise<string> {
             .on('error', reject));
       })
       .on('close', async() => {
-        return resolve('https://console.cloud.google.com/storage/browser/amp-test-website-1');
+        return resolve(`https://console.cloud.google.com/storage/browser/amp-test-website-1/${buildFileName}`);
       });
   });
 };


### PR DESCRIPTION
When a test site is deployed, the bot gives the user the working link, which is `https://console.cloud.google.com/storage/browser/amp-test-website-1/amp_dist_<travisbuildnumber>`