### PR TITLE
Fix name of PullRequestEvent

### DIFF
--- a/owners/index.js
+++ b/owners/index.js
@@ -22,7 +22,7 @@ const {Owner} = require('./src/owner');
 const GITHUB_CHECKRUN_DELAY = 2000;
 
 module.exports = app => {
-  app.on(['pull_request.opened', 'pull_request.synchronized'], onPullRequest);
+  app.on(['pull_request.opened', 'pull_request.synchronize'], onPullRequest);
   app.on('check_run.rerequested', onCheckRunRerequest);
   app.on('pull_request_review.submitted', onPullRequestReview);
 


### PR DESCRIPTION
The `synchronize` event is whenever a PR is changed or commits are added. We had `synchronized`, so it wasn't re-triggering the owners check.