### PR TITLE
Create failed check-run if an error occurs

### DIFF
--- a/owners/index.js
+++ b/owners/index.js
@@ -53,8 +53,10 @@ module.exports = app => {
       latestCheckRun = ownersCheck.buildCheckRun(fileOwners, approvers);
     } catch (error) {
       // If anything goes wrong, report a failing check.
-      latestCheckRun =
-          new CheckRun(false, 'OWNERS check encountered an error: ' + error)
+      latestCheckRun = new CheckRun(
+        false,
+        'OWNERS check encountered an error: ' + error
+      );
     }
 
     if (checkRunId) {

--- a/owners/index.js
+++ b/owners/index.js
@@ -16,7 +16,7 @@
 
 const sleep = require('sleep-promise');
 const {GitHub, PullRequest} = require('./src/github');
-const {OwnersCheck} = require('./src/owners_check');
+const {CheckRun, OwnersCheck} = require('./src/owners_check');
 const {Owner} = require('./src/owner');
 
 const GITHUB_CHECKRUN_DELAY = 2000;
@@ -43,11 +43,19 @@ module.exports = app => {
    */
   async function runOwnersCheck(github, pr) {
     const ownersCheck = new OwnersCheck(github, pr);
-    const fileOwners = await Owner.getOwners(github, pr.number);
-    const approvers = await ownersCheck.getApprovers();
+    let checkRunId;
+    let latestCheckRun;
 
-    const checkRunId = await github.getCheckRunId(pr.headSha);
-    const latestCheckRun = ownersCheck.buildCheckRun(fileOwners, approvers);
+    try {
+      const approvers = await ownersCheck.getApprovers();
+      checkRunId = await github.getCheckRunId(pr.headSha);
+      const fileOwners = await Owner.getOwners(github, pr.number);
+      latestCheckRun = ownersCheck.buildCheckRun(fileOwners, approvers);
+    } catch (error) {
+      // If anything goes wrong, report a failing check.
+      latestCheckRun =
+          new CheckRun(false, 'OWNERS check encountered an error: ' + error)
+    }
 
     if (checkRunId) {
       await github.updateCheckRun(checkRunId, latestCheckRun);


### PR DESCRIPTION
There are a couple bugs in the existing OWNERS check (somewhere in `findClosestOwnersFile`, though I haven't yet identified the cause/fix) which result in an error being thrown when finding owners for a PR. Whatever the cause, the error results in no owners check ever being added to the PR. This PR catches any error and ensures a check-run is still added, but with a failure message and the error that was encountered.

The detail of this check-run (its status and text) will change soon as the bot becomes a blocking check/starts assigning reviewers, but since that won't be ready until the design review of the [reviewer selection algorithm](https://github.com/ampproject/amphtml/issues/24338), this will at least ensure that all PRs get owners checks and any errors are visible instead of silent.