### PR TITLE
Pull main logic into OwnersCheck class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 pr-deploy/src/*.js
 release-tagging/src/*.js
+coverage/

--- a/owners/index.js
+++ b/owners/index.js
@@ -55,7 +55,7 @@ module.exports = app => {
       // become just `const latestCheckRun = ownersCheck.run();`
       await ownersCheck.init();
       const fileOwners = await Owner.getOwners(ownersCheck);
-      const latestCheckRun = ownersCheck.buildCheckRun(fileOwners);
+      latestCheckRun = ownersCheck.buildCheckRun(fileOwners);
     } catch (error) {
       // If anything goes wrong, report a failing check.
       latestCheckRun = new CheckRun(

--- a/owners/index.js
+++ b/owners/index.js
@@ -47,10 +47,18 @@ module.exports = app => {
     let latestCheckRun;
 
     try {
-      const approvers = await ownersCheck.getApprovers();
       checkRunId = await github.getCheckRunId(pr.headSha);
-      const fileOwners = await Owner.getOwners(github, pr.number);
-      latestCheckRun = ownersCheck.buildCheckRun(fileOwners, approvers);
+
+      // TODO: Once OwnersCheck swallows the remaining logic in Owner, this can
+      // become just `const latestCheckRun = ownersCheck.run();`
+
+      const approvers = await ownersCheck.getApprovers();
+      const {fileOwners, ownersTree} = await Owner.getOwners(github, pr.number);
+      latestCheckRun = ownersCheck.buildCheckRun(
+        fileOwners,
+        approvers,
+        ownersTree
+      );
     } catch (error) {
       // If anything goes wrong, report a failing check.
       latestCheckRun = new CheckRun(

--- a/owners/index.js
+++ b/owners/index.js
@@ -51,8 +51,8 @@ module.exports = app => {
       const ownersCheck = new OwnersCheck(localRepo, github, pr);
       checkRunId = await github.getCheckRunId(pr.headSha);
 
-      // TODO: Once OwnersCheck swallows the remaining logic in Owner, this can
-      // become just `const latestCheckRun = ownersCheck.run();`
+      // TODO(rcebulko): Once OwnersCheck swallows the remaining logic in Owner,
+      // this can become just `const latestCheckRun = ownersCheck.run();`
       await ownersCheck.init();
       const fileOwners = await Owner.getOwners(ownersCheck);
       latestCheckRun = ownersCheck.buildCheckRun(fileOwners);

--- a/owners/index.js
+++ b/owners/index.js
@@ -54,16 +54,8 @@ module.exports = app => {
       // TODO: Once OwnersCheck swallows the remaining logic in Owner, this can
       // become just `const latestCheckRun = ownersCheck.run();`
       await ownersCheck.init();
-      const fileOwners = await Owner.getOwners(
-        github,
-        pr.number,
-        ownersCheck.parser
-      );
-      latestCheckRun = ownersCheck.buildCheckRun(
-        fileOwners,
-        ownersCheck.approvers,
-        ownersCheck.tree
-      );
+      const fileOwners = await Owner.getOwners(ownersCheck);
+      const latestCheckRun = ownersCheck.buildCheckRun(fileOwners);
     } catch (error) {
       // If anything goes wrong, report a failing check.
       latestCheckRun = new CheckRun(

--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -192,8 +192,7 @@ class GitHub {
    * @param {!CheckRun} checkRun check-run data to update.
    */
   async updateCheckRun(id, checkRun) {
-    const status = checkRun.passing ? 'passing' : 'failing';
-    this.logger.info(`Updating check-run with ID ${id} (${status})`);
+    this.logger.info(`Updating check-run with ID ${id} (${checkRun.summary})`);
     this.logger.debug('[updateCheckRun]', id, checkRun);
 
     return await this.client.checks.update(

--- a/owners/src/owner.js
+++ b/owners/src/owner.js
@@ -66,21 +66,19 @@ class Owner {
   static async parseOwnersMap(parser) {
     const ownersRules = await parser.parseAllOwnersRules();
     const ownersList = ownersRules.map(
-      rule => new Owner(rule.owners, process.env.GITHUB_REPO_DIR, rule.filePath)
-    );
+        rule =>
+            new Owner(rule.owners, process.env.GITHUB_REPO_DIR, rule.filePath));
     return createOwnersMap(ownersList);
   }
 
   /**
-   * @param {!GitHub} github GitHub API interface.
-   * @param {!number} prNumber pull request number
-   * @param {!OwnersParser} parser ownership rules parser.
+   * @param {!OwnersCheck} ownersCheck ownership approval check.
    * @return {object}
    */
-  static async getOwners(github, prNumber, parser) {
-    const filenames = await github.listFiles(prNumber);
-    const repoFiles = filenames.map(filename => new RepoFile(filename));
-    const ownersMap = await this.parseOwnersMap(parser);
+  static async getOwners(ownersCheck) {
+    const repoFiles =
+        ownersCheck.changedFiles.map(filename => new RepoFile(filename));
+    const ownersMap = await this.parseOwnersMap(ownersCheck.parser);
 
     return findOwners(repoFiles, ownersMap);
   }

--- a/owners/src/owner.js
+++ b/owners/src/owner.js
@@ -87,9 +87,10 @@ class Owner {
     const filenames = await github.listFiles(prNumber);
     const repoFiles = filenames.map(filename => new RepoFile(filename));
     const ownersMap = await this.parseOwnersMap(parser);
-    const owners = findOwners(repoFiles, ownersMap);
+    const fileOwners = findOwners(repoFiles, ownersMap);
+    const ownersTree = await parser.parseOwnersTree();
 
-    return owners;
+    return {fileOwners, ownersTree};
   }
 }
 

--- a/owners/src/owner.js
+++ b/owners/src/owner.js
@@ -66,8 +66,8 @@ class Owner {
   static async parseOwnersMap(parser) {
     const ownersRules = await parser.parseAllOwnersRules();
     const ownersList = ownersRules.map(
-        rule =>
-            new Owner(rule.owners, process.env.GITHUB_REPO_DIR, rule.filePath));
+      rule => new Owner(rule.owners, process.env.GITHUB_REPO_DIR, rule.filePath)
+    );
     return createOwnersMap(ownersList);
   }
 
@@ -76,8 +76,9 @@ class Owner {
    * @return {object}
    */
   static async getOwners(ownersCheck) {
-    const repoFiles =
-        ownersCheck.changedFiles.map(filename => new RepoFile(filename));
+    const repoFiles = ownersCheck.changedFiles.map(
+      filename => new RepoFile(filename)
+    );
     const ownersMap = await this.parseOwnersMap(ownersCheck.parser);
 
     return findOwners(repoFiles, ownersMap);

--- a/owners/src/owner.js
+++ b/owners/src/owner.js
@@ -17,8 +17,6 @@
 const path = require('path');
 // TODO: Replace the RepoFile class and uses with LocalRepo.
 const {RepoFile} = require('./repo-file');
-const {LocalRepository} = require('./local_repo');
-const {OwnersParser} = require('./owners');
 
 /**
  * @file Contains classes and functions in relation to "OWNER" files
@@ -76,21 +74,15 @@ class Owner {
   /**
    * @param {!GitHub} github GitHub API interface.
    * @param {!number} prNumber pull request number
+   * @param {!OwnersParser} parser ownership rules parser.
    * @return {object}
    */
-  static async getOwners(github, prNumber) {
-    // Update the local target repository of the latest from master
-    const localRepo = new LocalRepository(process.env.GITHUB_REPO_DIR);
-    const parser = new OwnersParser(localRepo, github.logger);
-    await localRepo.checkout();
-
+  static async getOwners(github, prNumber, parser) {
     const filenames = await github.listFiles(prNumber);
     const repoFiles = filenames.map(filename => new RepoFile(filename));
     const ownersMap = await this.parseOwnersMap(parser);
-    const fileOwners = findOwners(repoFiles, ownersMap);
-    const ownersTree = await parser.parseOwnersTree();
 
-    return {fileOwners, ownersTree};
+    return findOwners(repoFiles, ownersMap);
   }
 }
 

--- a/owners/src/owner.js
+++ b/owners/src/owner.js
@@ -62,12 +62,10 @@ class Owner {
   /**
    * Parse all OWNERS files into Owner objects.
    *
-   * @param {!LocalRepository} localRepo local repository to read from.
-   * @param {!Logger} logger logging interface
+   * @param {!OwnersParser} parser OWNERS file parser.
    * @return {object} map of owners.
    */
-  static async parseOwnersMap(localRepo, logger) {
-    const parser = new OwnersParser(localRepo, logger);
+  static async parseOwnersMap(parser) {
     const ownersRules = await parser.parseAllOwnersRules();
     const ownersList = ownersRules.map(
       rule => new Owner(rule.owners, process.env.GITHUB_REPO_DIR, rule.filePath)
@@ -83,11 +81,12 @@ class Owner {
   static async getOwners(github, prNumber) {
     // Update the local target repository of the latest from master
     const localRepo = new LocalRepository(process.env.GITHUB_REPO_DIR);
+    const parser = new OwnersParser(localRepo, github.logger);
     await localRepo.checkout();
 
     const filenames = await github.listFiles(prNumber);
     const repoFiles = filenames.map(filename => new RepoFile(filename));
-    const ownersMap = await this.parseOwnersMap(localRepo, github.logger);
+    const ownersMap = await this.parseOwnersMap(parser);
     const owners = findOwners(repoFiles, ownersMap);
 
     return owners;

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -25,11 +25,11 @@ class CheckRun {
   /**
    * Constructor.
    *
-   * @param {!string} passing whether or not the check-run is passing/approved.
+   * @param {!string} summary check-run summary text to show in PR.
    * @param {!string} text description of check-run results.
    */
-  constructor(passing, text) {
-    Object.assign(this, {passing, text});
+  constructor(summary, text) {
+    Object.assign(this, {summary, text});
   }
 
   /**
@@ -45,7 +45,7 @@ class CheckRun {
       completed_at: new Date(),
       output: {
         title: GITHUB_CHECKRUN_NAME,
-        summary: `The check was a ${this.passing ? 'success' : 'failure'}!`,
+        summary: this.summary,
         text: this.text,
       },
     };
@@ -70,14 +70,15 @@ class OwnersCheck {
    * Builds a check-run.
    *
    * @param {!object} fileOwners ownership rules.
-   * @param {!string[]} approvers list of usernames that approved this PR.
+   * @param {string[]} approvers list of usernames that approved this PR.
    * @param {!OwnersTree} ownersTree file ownership tree.
    * @return {CheckRun} a check-run based on the approval state.
    */
   buildCheckRun(fileOwners, approvers, ownersTree) {
     const passing = this._allFilesApproved(fileOwners, approvers);
     const text = this._buildOutputText(fileOwners, approvers);
-    return new CheckRun(passing, text);
+    const summary = `The check was a ${passing ? 'success' : 'failure'}!`;
+    return new CheckRun(summary, text);
   }
 
   /**

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -70,10 +70,11 @@ class OwnersCheck {
    * Builds a check-run.
    *
    * @param {!object} fileOwners ownership rules.
-   * @param {!object} approvers list of usernames that approved this PR.
+   * @param {!string[]} approvers list of usernames that approved this PR.
+   * @param {!OwnersTree} ownersTree file ownership tree.
    * @return {CheckRun} a check-run based on the approval state.
    */
-  buildCheckRun(fileOwners, approvers) {
+  buildCheckRun(fileOwners, approvers, ownersTree) {
     const passing = this._allFilesApproved(fileOwners, approvers);
     const text = this._buildOutputText(fileOwners, approvers);
     return new CheckRun(passing, text);

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -81,7 +81,7 @@ class OwnersCheck {
   async init() {
     await this.repo.checkout();
     this.tree = await this.parser.parseOwnersTree();
-    this.approvers = await this.getApprovers();
+    this.approvers = await this._getApprovers();
     this.changedFiles = await this.github.listFiles(this.pr.number);
     this.initialized = true;
   }
@@ -92,9 +92,10 @@ class OwnersCheck {
    * Also includes the author, unless the author has explicitly left a blocking
    * review.
    *
+   * @private
    * @return {string[]} list of usernames.
    */
-  async getApprovers() {
+  async _getApprovers() {
     const reviews = await this.github.getReviews(this.pr.number);
     // Sort by the latest submitted_at date to get the latest review.
     const sortedReviews = reviews.sort((a, b) => b.submittedAt - a.submittedAt);
@@ -127,7 +128,7 @@ class OwnersCheck {
   /**
    * Tests if all files are approved by at least one owner.
    *
-   * TODO: Replace legacy check-run code used by old Owner class.
+   * TODO(rcebulko): Replace legacy check-run code used by old Owner class.
    *
    * @private
    * @param {!object} fileOwners ownership rules.
@@ -142,7 +143,7 @@ class OwnersCheck {
   /**
    * Build the check-run output comment.
    *
-   * TODO: Replace legacy check-run code used by old Owner class.
+   * TODO(rcebulko): Replace legacy check-run code used by old Owner class.
    *
    * @private
    * @param {!object} fileOwners ownership rules.

--- a/owners/test/github.test.js
+++ b/owners/test/github.test.js
@@ -195,7 +195,7 @@ describe('GitHub API', () => {
             conclusion: 'neutral',
             output: {
               title: 'ampproject/owners-check',
-              summary: 'The check was a success!',
+              summary: 'Test summary',
               text: 'Test text',
             },
           });
@@ -206,7 +206,7 @@ describe('GitHub API', () => {
       await withContext(async (context, github) => {
         await github.createCheckRun(
           '_test_hash_',
-          new CheckRun(true, 'Test text')
+          new CheckRun('Test summary', 'Test text')
         );
       })();
     });
@@ -262,7 +262,7 @@ describe('GitHub API', () => {
             conclusion: 'neutral',
             output: {
               title: 'ampproject/owners-check',
-              summary: 'The check was a failure!',
+              summary: 'Test summary',
               text: 'Test text',
             },
           });
@@ -271,28 +271,10 @@ describe('GitHub API', () => {
         .reply(200);
 
       await withContext(async (context, github) => {
-        await github.updateCheckRun(1337, new CheckRun(false, 'Test text'));
-      })();
-    });
-
-    it('sets the summary based on the status', async () => {
-      nock('https://api.github.com')
-        .patch('/repos/test_owner/test_repo/check-runs/1337', body => {
-          expect(body.output.summary).toEqual('The check was a failure!');
-          return true;
-        })
-        .reply(200);
-
-      nock('https://api.github.com')
-        .patch('/repos/test_owner/test_repo/check-runs/42', body => {
-          expect(body.output.summary).toEqual('The check was a success!');
-          return true;
-        })
-        .reply(200);
-
-      await withContext(async (context, github) => {
-        await github.updateCheckRun(1337, new CheckRun(false, 'Test text'));
-        await github.updateCheckRun(42, new CheckRun(true, 'Test text'));
+        await github.updateCheckRun(
+          1337,
+          new CheckRun('Test summary', 'Test text')
+        );
       })();
     });
   });

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -21,6 +21,7 @@ const {Probot} = require('probot');
 const sinon = require('sinon');
 const {LocalRepository} = require('../src/local_repo');
 const {Owner} = require('../src/owner');
+const {OwnersParser} = require('../src/owners');
 
 const opened35 = require('./fixtures/actions/opened.35');
 const opened36 = require('./fixtures/actions/opened.36.author-is-owner');
@@ -90,6 +91,7 @@ describe('owners bot', () => {
     sandbox = sinon.createSandbox();
     // Disabled execution of `git pull` for testing.
     sandbox.stub(LocalRepository.prototype, 'checkout');
+    sandbox.stub(OwnersParser.prototype, 'parseAllOwnersRules').returns([]);
     sandbox.stub(Owner, 'parseOwnersMap').returns(ownersYamlStruct);
 
     probot = new Probot({});

--- a/owners/test/owners.test.js
+++ b/owners/test/owners.test.js
@@ -128,8 +128,9 @@ describe('owners tree', () => {
 
     it('returns the nearest tree with a rule', () => {
       tree.addRule(childDirRule);
+      tree.addRule(descendantDirRule);
 
-      expect(tree.atPath('foo/bar/baz').dirPath).toEqual('foo');
+      expect(tree.atPath('foo/bar/okay.txt').dirPath).toEqual('foo');
     });
   });
 

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -20,26 +20,15 @@ const {CheckRun, OwnersCheck} = require('../src/owners_check');
 describe('check run', () => {
   describe('json', () => {
     it('produces a JSON object in the GitHub API format', () => {
-      const checkRun = new CheckRun(true, 'Test text');
+      const checkRun = new CheckRun('Test summary', 'Test text');
       const checkRunJson = checkRun.json;
 
       expect(checkRunJson.name).toEqual('ampproject/owners-check');
       expect(checkRunJson.status).toEqual('completed');
       expect(checkRunJson.conclusion).toEqual('neutral');
       expect(checkRunJson.output.title).toEqual('ampproject/owners-check');
+      expect(checkRunJson.output.summary).toEqual('Test summary');
       expect(checkRunJson.output.text).toEqual('Test text');
-    });
-
-    it('produces a the output summary based on the passing status', () => {
-      const passingCheckRun = new CheckRun(true, '');
-      const failingCheckRun = new CheckRun(false, '');
-
-      expect(passingCheckRun.json.output.summary).toEqual(
-        'The check was a success!'
-      );
-      expect(failingCheckRun.json.output.summary).toEqual(
-        'The check was a failure!'
-      );
     });
   });
 });

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -116,14 +116,14 @@ describe('owners check', () => {
         new FakeGithub([approval, otherApproval]),
         pr
       );
-      const approvers = await ownersCheck.getApprovers();
+      const approvers = await ownersCheck._getApprovers();
 
       expect(approvers).toContain('approver', 'other_approver');
     });
 
     it('includes the author', async () => {
       const ownersCheck = new OwnersCheck(repo, new FakeGithub([]), pr);
-      const approvers = await ownersCheck.getApprovers();
+      const approvers = await ownersCheck._getApprovers();
 
       expect(approvers).toContain('the_author');
     });
@@ -134,7 +134,7 @@ describe('owners check', () => {
         new FakeGithub([approval, approval, authorApproval]),
         pr
       );
-      const approvers = await ownersCheck.getApprovers();
+      const approvers = await ownersCheck._getApprovers();
 
       expect(approvers).toEqual(['approver', 'the_author']);
     });
@@ -145,7 +145,7 @@ describe('owners check', () => {
         new FakeGithub([approval, rejection]),
         pr
       );
-      const approvers = await ownersCheck.getApprovers();
+      const approvers = await ownersCheck._getApprovers();
 
       expect(approvers).not.toContain('rejector');
     });

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -37,17 +37,17 @@ describe('check run', () => {
 });
 
 describe('owners check', () => {
-  /* eslint-disable-next-line require-jsdoc */
+  /* eslint-disable require-jsdoc */
   class FakeGithub {
-    /* eslint-disable-next-line require-jsdoc */
     constructor(reviews) {
       this.getReviews = () => reviews;
     }
-    
-    async listFiles () {
+
+    async listFiles() {
       return ['changed_file1.js', 'changed_file2.js'];
     }
   }
+  /* eslint-enable require-jsdoc */
 
   const sandbox = sinon.createSandbox();
   const repo = new LocalRepository('path/to/repo');
@@ -96,8 +96,10 @@ describe('owners check', () => {
       await ownersCheck.init();
 
       sandbox.assert.calledWith(ownersCheck.github.listFiles, 35);
-      expect(ownersCheck.changedFiles)
-          .toContain('changed_file1.js', 'changed_file2.js');
+      expect(ownersCheck.changedFiles).toContain(
+        'changed_file1.js',
+        'changed_file2.js'
+      );
     });
 
     it('sets `initialized` to true', async () => {
@@ -108,9 +110,12 @@ describe('owners check', () => {
   });
 
   describe('getApprovers', () => {
-    it('returns the reviewers\' usernames', async () => {
-      const ownersCheck =
-          new OwnersCheck(repo, new FakeGithub([approval, otherApproval]), pr);
+    it("returns the reviewers' usernames", async () => {
+      const ownersCheck = new OwnersCheck(
+        repo,
+        new FakeGithub([approval, otherApproval]),
+        pr
+      );
       const approvers = await ownersCheck.getApprovers();
 
       expect(approvers).toContain('approver', 'other_approver');
@@ -125,15 +130,21 @@ describe('owners check', () => {
 
     it('produces unique usernames', async () => {
       const ownersCheck = new OwnersCheck(
-          repo, new FakeGithub([approval, approval, authorApproval]), pr);
+        repo,
+        new FakeGithub([approval, approval, authorApproval]),
+        pr
+      );
       const approvers = await ownersCheck.getApprovers();
 
       expect(approvers).toEqual(['approver', 'the_author']);
     });
 
     it('includes only reviewers who approved the review', async () => {
-      const ownersCheck =
-          new OwnersCheck(repo, new FakeGithub([approval, rejection]), pr);
+      const ownersCheck = new OwnersCheck(
+        repo,
+        new FakeGithub([approval, rejection]),
+        pr
+      );
       const approvers = await ownersCheck.getApprovers();
 
       expect(approvers).not.toContain('rejector');


### PR DESCRIPTION
One more (much smaller) refactor PR, pulling steps from the `Owner` class and `index.js` into the `OwnersCheck` class