### PR TITLE
Set up owners tree/rules/check to filter rules that match the file being tested

### DIFF
--- a/owners/src/owners.js
+++ b/owners/src/owners.js
@@ -99,6 +99,19 @@ class OwnersTree {
     const segments = filePath.split(path.sep);
     let subtree = this;
 
+    if (!this.isRoot) {
+      const treeSegments = this.dirPath.split(path.sep);
+      while (treeSegments.length) {
+        const nextTreeDir = treeSegments.shift();
+        const nextDir = segments.shift();
+        if (nextTreeDir !== nextDir) {
+          throw new Error(
+            `Tried to find subtree at path "${filePath}" on a subtree at path "${this.dirPath}"`
+          );
+        }
+      }
+    }
+
     while (segments.length) {
       const nextDir = segments.shift();
       if (!subtree.get(nextDir)) {

--- a/owners/src/owners.js
+++ b/owners/src/owners.js
@@ -148,7 +148,9 @@ class OwnersTree {
    * @return {boolean} true of the user is an owner of the file.
    */
   fileHasOwner(filename, username) {
-    return this.atPath(filename).hasOwner(username);
+    const allRules = this.atPath(filename).allRules;
+    const fileRules = allRules.filter(rule => rule.matchesFile(filename));
+    return fileRules.some(rule => rule.owners.includes(username));
   }
 
   /**
@@ -216,31 +218,14 @@ class OwnersRule {
   /**
    * Test if a file is matched by the rule.
    *
-   * Currently only tests directory hierarchy; may be modified to test
-   * filetypes, globs, special cases like package.json, etc.
+   * Currently is always true, as it assumes that the rule is being tested on;
+   * files within its hierarchy; may be modified to test filetypes, globs,
+   * special cases like package.json, etc.
    *
    * @param {!string} filePath relative path in repo to the file being checked.
    * @return {boolean} true if the rule applies to the file.
    */
   matchesFile(filePath) {
-    const filePathDir = path.dirname(filePath);
-    const filePathSegments = filePathDir
-      .split(path.sep)
-      .filter(segment => segment != '.');
-    const rulePathSegments = this.dirPath
-      .split(path.sep)
-      .filter(segment => segment != '.');
-
-    if (filePathSegments.length < rulePathSegments.length) {
-      return false;
-    }
-
-    for (let i = 0; i < rulePathSegments.length; ++i) {
-      if (rulePathSegments[i] !== filePathSegments[i]) {
-        return false;
-      }
-    }
-
     return true;
   }
 }

--- a/owners/src/owners.js
+++ b/owners/src/owners.js
@@ -128,6 +128,17 @@ class OwnersTree {
   }
 
   /**
+   * Tests if a user is in the ownership path of a file.
+   *
+   * @param {!string} filename file to test ownership for.
+   * @param {!string} username user to check ownership of.
+   * @return {boolean} true of the user is an owner of the file.
+   */
+  fileHasOwner(filename, username) {
+    return this.atPath(filename).hasOwner(username);
+  }
+
+  /**
    * Builds the map from filenames to ownership subtrees.
    *
    * @param {string[]} filenames list of changed files.

--- a/owners/src/owners.js
+++ b/owners/src/owners.js
@@ -128,19 +128,6 @@ class OwnersTree {
   }
 
   /**
-   * Tests if a user is in the ownership path of the tree.
-   *
-   * @param {!string} username user to check ownership of.
-   * @return {boolean} true of the username is in this or an ancestor's OWNERS.
-   */
-  hasOwner(username) {
-    const allOwners = this.allRules
-      .map(rule => rule.owners)
-      .reduce((left, right) => left.concat(right), []);
-    return allOwners.includes(username);
-  }
-
-  /**
    * Tests if a user is in the ownership path of a file.
    *
    * @param {!string} filename file to test ownership for.

--- a/owners/src/owners.js
+++ b/owners/src/owners.js
@@ -132,7 +132,7 @@ class OwnersTree {
    *
    * @param {!string} filename file to test ownership for.
    * @param {!string} username user to check ownership of.
-   * @return {boolean} true of the user is an owner of the file.
+   * @return {boolean} true if the user is an owner of the file.
    */
   fileHasOwner(filename, username) {
     const allRules = this.atPath(filename).allRules;
@@ -208,6 +208,8 @@ class OwnersRule {
    * Currently is always true, as it assumes that the rule is being tested on;
    * files within its hierarchy; may be modified to test filetypes, globs,
    * special cases like package.json, etc.
+   *
+   * TODO(Issue #278): Implement pattern matching.
    *
    * @param {!string} filePath relative path in repo to the file being checked.
    * @return {boolean} true if the rule applies to the file.

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -130,7 +130,9 @@ class OwnersCheck {
    * @return {boolean} if the file is approved
    */
   _hasOwnersApproval(filename, subtree) {
-    return this.approvers.some(approver => this.tree.fileHasOwner(filename, approver));
+    return this.approvers.some(approver =>
+      this.tree.fileHasOwner(filename, approver)
+    );
   }
 
   /**

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -130,7 +130,7 @@ class OwnersCheck {
    * @return {boolean} if the file is approved
    */
   _hasOwnersApproval(filename, subtree) {
-    return this.approvers.some(approver => subtree.hasOwner(approver));
+    return this.approvers.some(approver => this.tree.fileHasOwner(filename, approver));
   }
 
   /**
@@ -169,7 +169,7 @@ class OwnersCheck {
     const allFilesText = Object.entries(fileTreeMap)
       .map(([filename, subtree]) => {
         const fileApprovers = this.approvers.filter(approver =>
-          subtree.hasOwner(approver)
+          this.tree.fileHasOwner(filename, approver)
         );
 
         if (fileApprovers.length) {

--- a/owners/src/reviewer_selection.js
+++ b/owners/src/reviewer_selection.js
@@ -94,7 +94,7 @@ class ReviewerSelection {
    */
   static _filesOwnedByReviewer(fileTreeMap, reviewer) {
     return Object.entries(fileTreeMap)
-      .filter(([filename, tree]) => tree.hasOwner(reviewer))
+      .filter(([filename, tree]) => tree.fileHasOwner(filename, reviewer))
       .map(([filename, tree]) => filename);
   }
 

--- a/owners/test/owners.test.js
+++ b/owners/test/owners.test.js
@@ -164,6 +164,36 @@ describe('owners tree', () => {
     });
   });
 
+  describe('fileHasOwner', () => {
+    beforeEach(() => {
+      tree.addRule(rootDirRule);
+      tree.addRule(childDirRule);
+      tree.addRule(descendantDirRule);
+    });
+
+    it('should be true for owners in the same directory', () => {
+      expect(tree.fileHasOwner('foo/bar.txt', 'child')).toBe(true);
+    });
+
+    it('should be true for owners in the parent directory', () => {
+      expect(tree.fileHasOwner('foo/bar.txt', 'root')).toBe(true);
+    });
+
+    it('should be true for owners an ancestor directory', () => {
+      expect(tree.fileHasOwner('foo/bar.txt', 'root')).toBe(true);
+    });
+
+    it('should be false for owners a child directory', () => {
+      expect(tree.fileHasOwner('foo/bar/baz/buzz.txt', 'descendant')).toBe(
+        true
+      );
+    });
+
+    it('should be false for non-existant owners', () => {
+      expect(tree.fileHasOwner('foo/bar.txt', 'not_an_owner')).toBe(false);
+    });
+  });
+
   describe('buildFileTreeMap', () => {
     it('builds a map from filenames to subtrees', () => {
       const dirTrees = {

--- a/owners/test/owners.test.js
+++ b/owners/test/owners.test.js
@@ -132,6 +132,21 @@ describe('owners tree', () => {
 
       expect(tree.atPath('foo/bar/okay.txt').dirPath).toEqual('foo');
     });
+
+    it('works on a non-root subtree', () => {
+      tree.addRule(rootDirRule);
+      const childTree = tree.addRule(childDirRule);
+      tree.addRule(descendantDirRule);
+
+      expect(childTree.atPath('foo/bar/baz/okay.txt').dirPath).toEqual('foo/bar/baz');
+    });
+
+    it('throws an error when requesting a path not under the subtree', () => {
+      const childTree = tree.addRule(childDirRule);
+
+      expect(() => childTree.atPath('not/in/foo.txt')).toThrow(
+        'Tried to find subtree at path "not/in/foo.txt" on a subtree at path "foo"');
+    });
   });
 
   describe('hasOwner', () => {

--- a/owners/test/owners.test.js
+++ b/owners/test/owners.test.js
@@ -138,14 +138,17 @@ describe('owners tree', () => {
       const childTree = tree.addRule(childDirRule);
       tree.addRule(descendantDirRule);
 
-      expect(childTree.atPath('foo/bar/baz/okay.txt').dirPath).toEqual('foo/bar/baz');
+      expect(childTree.atPath('foo/bar/baz/okay.txt').dirPath).toEqual(
+        'foo/bar/baz'
+      );
     });
 
     it('throws an error when requesting a path not under the subtree', () => {
       const childTree = tree.addRule(childDirRule);
 
       expect(() => childTree.atPath('not/in/foo.txt')).toThrow(
-        'Tried to find subtree at path "not/in/foo.txt" on a subtree at path "foo"');
+        'Tried to find subtree at path "not/in/foo.txt" on a subtree at path "foo"'
+      );
     });
   });
 

--- a/owners/test/owners.test.js
+++ b/owners/test/owners.test.js
@@ -152,36 +152,6 @@ describe('owners tree', () => {
     });
   });
 
-  describe('hasOwner', () => {
-    beforeEach(() => {
-      tree.addRule(rootDirRule);
-      tree.addRule(childDirRule);
-      tree.addRule(descendantDirRule);
-    });
-
-    it('should be true for owners in the same directory', () => {
-      expect(tree.atPath('foo/bar.txt').hasOwner('child')).toBe(true);
-    });
-
-    it('should be true for owners in the parent directory', () => {
-      expect(tree.atPath('foo/bar.txt').hasOwner('root')).toBe(true);
-    });
-
-    it('should be true for owners an ancestor directory', () => {
-      expect(tree.atPath('foo/bar.txt').hasOwner('root')).toBe(true);
-    });
-
-    it('should be false for owners a child directory', () => {
-      expect(tree.atPath('foo/bar/baz/buzz.txt').hasOwner('descendant')).toBe(
-        true
-      );
-    });
-
-    it('should be false for non-existant owners', () => {
-      expect(tree.atPath('foo/bar.txt').hasOwner('not_an_owner')).toBe(false);
-    });
-  });
-
   describe('fileHasOwner', () => {
     beforeEach(() => {
       tree.addRule(rootDirRule);
@@ -266,40 +236,28 @@ describe('owners tree', () => {
 });
 
 describe('owners rules', () => {
-  describe('matchesFile', () => {
-    expect.extend({
-      toMatchFile(receivedOwnersPath, filePath) {
-        const rule = new OwnersRule(receivedOwnersPath, []);
-        const matches = rule.matchesFile(filePath);
-        const matchStr = this.isNot ? 'not match' : 'match';
+  expect.extend({
+    toMatchFile(receivedOwnersPath, filePath) {
+      const rule = new OwnersRule(receivedOwnersPath, []);
+      const matches = rule.matchesFile(filePath);
+      const matchStr = this.isNot ? 'not match' : 'match';
 
-        return {
-          pass: matches,
-          message: () =>
-            `Expected rules in '${receivedOwnersPath}' to ` +
-            `${matchStr} file '${filePath}'.`,
-        };
-      },
-    });
+      return {
+        pass: matches,
+        message: () =>
+          `Expected rules in '${receivedOwnersPath}' to ` +
+          `${matchStr} file '${filePath}'.`,
+      };
+    },
+  });
 
-    it('matches a file in the same directory', () => {
-      expect('src/OWNERS.yaml').toMatchFile('src/foo.txt');
-    });
-
-    it('matches a file in a child directory', () => {
-      expect('src/OWNERS.yaml').toMatchFile('src/foo/bar.txt');
-    });
-
-    it('matches a file in an descendant directory', () => {
-      expect('src/OWNERS.yaml').toMatchFile('src/foo/bar/baz.txt');
-    });
-
-    it('does not match a file in a parent directory', () => {
-      expect('src/OWNERS.yaml').not.toMatchFile('foo.txt');
-    });
-
-    it('does not match a file in a sibling directory', () => {
-      expect('src/OWNERS.yaml').not.toMatchFile('test/foo.txt');
+  describe('basic directory ownership', () => {
+    describe('matchesFile', () => {
+      it('matches all files', () => {
+        expect('src/OWNERS.yaml').toMatchFile('src/foo.txt');
+        expect('src/OWNERS.yaml').toMatchFile('src/foo/bar.txt');
+        expect('src/OWNERS.yaml').toMatchFile('src/foo/bar/baz.txt');
+      });
     });
   });
 });

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -172,7 +172,7 @@ describe('owners check', () => {
 
       describe('for a fully-approved PR', () => {
         beforeEach(() => {
-          sandbox.stub(OwnersTree.prototype, 'hasOwner').returns(true);
+          sandbox.stub(OwnersTree.prototype, 'fileHasOwner').returns(true);
         });
 
         it('has a passing summary', async () => {


### PR DESCRIPTION
Rules themselves are strictly hierarchical, and since they'll only be applied to files that are already limited by ownership subtree, re-matching the path is redundant, repetitive, and redundant. `matchesFile` will now act as a filter, such as for globs and patterns. Basic owners rules have no filters, but upcoming rules supporting filetypes and filenames and other patterns will extend the `OwnersRule` class and may override the `matchesFile` test.