### PR TITLE
Adds a health-check server with app status, owners tree, and PR tests

### DIFF
--- a/owners/index.js
+++ b/owners/index.js
@@ -22,6 +22,7 @@ const {OwnersParser} = require('./src/owners');
 module.exports = app => {
   const localRepo = new LocalRepository(process.env.GITHUB_REPO_DIR);
   const ownersBot = new OwnersBot(localRepo);
+  const treeCache = new OneDayCache();
   const router = app.route('/admin');
 
   // Probot does not stream properly to GCE logs so we need to hook into
@@ -32,16 +33,21 @@ module.exports = app => {
     level: process.env.LOG_LEVEL || 'info',
   });
 
+  /** Health check server endpoints **/
   router.get('/status', (req, res) => {
     res.send('The OWNERS bot is live and running!');
   });
 
   router.get('/tree', async (req, res) => {
-    const parser = new OwnersParser(localRepo, req.log);
-    const tree = await parser.parseOwnersTree();
-    res.send(`<pre>${tree.toString()}</pre>`);
+    const ownersTree = await treeCache.wrapAsync(async () => {
+      const parser = new OwnersParser(localRepo, req.log);
+      return await parser.parseOwnersTree();
+    });
+
+    res.send(`<pre>${ownersTree.toString()}</pre>`);
   });
 
+  /** Probot request handlers **/
   app.on(['pull_request.opened', 'pull_request.synchronize'], async context => {
     await ownersBot.runOwnersCheck(
       GitHub.fromContext(context),
@@ -69,3 +75,45 @@ module.exports = app => {
     );
   });
 };
+
+/**
+ * Simple one-day cache for endpoints that do Git commands and file reads.
+ *
+ * TODO(rcebulko): Replace with a real caching solution once the health-check
+ * server gets real functionality.
+ */
+class OneDayCache {
+  /**
+   * Constructor.
+   */
+  constructor() {
+    this.lastUpdate = this.yesterday;
+    this.lastValue = null;
+  }
+
+  /**
+   * Get the date 24 hours ago.
+   *
+   * @return {Date} yesterday's date.
+   */
+  get yesterday() {
+    const date = new Date();
+    date.setDate(date.getDate() - 1);
+    return date;
+  }
+
+  /**
+   * Wraps an async function with the cache.
+   *
+   * @param {!function} asyncFn function to wrap.
+   * @return {any} computed or cached result.
+   */
+  async wrapAsync(asyncFn) {
+    if (this.lastValue === null || this.lastUpdate < this.yesterday) {
+      this.lastUpdate = new Date();
+      this.lastValue = await asyncFn();
+    }
+
+    return this.lastValue;
+  }
+}

--- a/owners/index.js
+++ b/owners/index.js
@@ -15,8 +15,8 @@
  */
 
 const {GitHub, PullRequest} = require('./src/github');
-const {LocalRepository} = require('./src/local_repo')
-const {OwnersBot} = require('./src/owners_bot')
+const {LocalRepository} = require('./src/local_repo');
+const {OwnersBot} = require('./src/owners_bot');
 
 module.exports = app => {
   const localRepo = new LocalRepository(process.env.GITHUB_REPO_DIR);
@@ -54,7 +54,10 @@ module.exports = app => {
     const payload = context.payload;
     const prNumber = payload.check_run.check_suite.pull_requests[0].number;
 
-    await ownersBot.runOwnersCheckOnPrNumber(GitHub.fromContext(context), prNumber);
+    await ownersBot.runOwnersCheckOnPrNumber(
+      GitHub.fromContext(context),
+      prNumber
+    );
   }
 
   /**
@@ -66,6 +69,9 @@ module.exports = app => {
     const payload = context.payload;
     const prNumber = payload.pull_request.number;
 
-    await ownersBot.runOwnersCheckOnPrNumber(GitHub.fromContext(context), prNumber);
+    await ownersBot.runOwnersCheckOnPrNumber(
+      GitHub.fromContext(context),
+      prNumber
+    );
   }
 };

--- a/owners/index.js
+++ b/owners/index.js
@@ -17,6 +17,7 @@
 const {GitHub, PullRequest} = require('./src/github');
 const {LocalRepository} = require('./src/local_repo');
 const {OwnersBot} = require('./src/owners_bot');
+const {OwnersParser} = require('./src/owners');
 
 module.exports = app => {
   const localRepo = new LocalRepository(process.env.GITHUB_REPO_DIR);
@@ -33,6 +34,12 @@ module.exports = app => {
 
   router.get('/status', (req, res) => {
     res.send('The OWNERS bot is live and running!');
+  });
+
+  router.get('/tree', async (req, res) => {
+    const parser = new OwnersParser(localRepo, req.log);
+    const tree = await parser.parseOwnersTree();
+    res.send(`<pre>${tree.toString()}</pre>`);
   });
 
   app.on(['pull_request.opened', 'pull_request.synchronize'], async context => {

--- a/owners/index.js
+++ b/owners/index.js
@@ -42,11 +42,13 @@ module.exports = app => {
   // TODO(rcebulko): Implement GitHub authentication to prevent spamming any of
   // these endpoints.
   adminRouter.get('/status', (req, res) => {
-    res.send([
-      'The OWNERS bot is live and running!'
-      `Project: ${process.env.GOOGLE_CLOUD_PROJECT || 'UNKNOWN'}`
-      `Version: ${process.env.GAE_VERSION || 'UNKNOWN'}`
-    ].join('<br>'));
+    res.send(
+      [
+        'The OWNERS bot is live and running!'`Project: ${process.env
+          .GOOGLE_CLOUD_PROJECT || 'UNKNOWN'}``Version: ${process.env
+          .GAE_VERSION || 'UNKNOWN'}`,
+      ].join('<br>')
+    );
   });
 
   adminRouter.get('/tree', async (req, res) => {
@@ -58,7 +60,12 @@ module.exports = app => {
 
   adminRouter.get('/check/:prNumber', async (req, res) => {
     const octokit = new Octokit({auth: `token ${GITHUB_TOKEN}`});
-    const github = new GitHub(octokit, GITHUB_REPO_OWNER, GITHUB_REPO_NAME, app.log);
+    const github = new GitHub(
+      octokit,
+      GITHUB_REPO_OWNER,
+      GITHUB_REPO_NAME,
+      app.log
+    );
     const pr = await github.getPullRequest(req.params.prNumber);
     const ownersCheck = new OwnersCheck(localRepo, github, pr);
     const checkRun = await ownersCheck.run();

--- a/owners/index.js
+++ b/owners/index.js
@@ -37,6 +37,8 @@ module.exports = app => {
   });
 
   /** Health check server endpoints **/
+  // TODO(rcebulko): Implement GitHub authentication to prevent spamming any of
+  // these endpoints.
   router.get('/status', (req, res) => {
     res.send('The OWNERS bot is live and running!');
   });

--- a/owners/src/owners.js
+++ b/owners/src/owners.js
@@ -162,8 +162,8 @@ class OwnersTree {
   toString() {
     const lines = [];
 
-    const rulePrefix = '-';
-    const childPrefix = '└---';
+    const rulePrefix = ' *';
+    const childPrefix = '└───';
     const indent = Math.max(0, this.depth - 1) * childPrefix.length;
     const prefix = this.isRoot ? '' : `${' '.repeat(indent)}${childPrefix}`;
     const dirName = this.isRoot

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -15,11 +15,13 @@
  */
 
 const sleep = require('sleep-promise');
-const {LocalRepository} = require('./local_repo');
-const {CheckRun, OwnersCheck} = require('./owners_check');
+const {OwnersCheck} = require('./owners_check');
 
 const GITHUB_CHECKRUN_DELAY = 2000;
 
+/**
+ * Bot to run the owners check and create/update the GitHub check-run.
+ */
 class OwnersBot {
   /**
    * Constructor.
@@ -28,6 +30,8 @@ class OwnersBot {
    */
   constructor(repo) {
     this.repo = repo;
+    // Defined as a property, to allow overriding in tests.
+    this.GITHUB_CHECKRUN_DELAY = GITHUB_CHECKRUN_DELAY;
   }
 
   /**
@@ -48,7 +52,7 @@ class OwnersBot {
       // We need to add a delay on the PR creation and check creation since
       // GitHub might not be ready.
       // TODO: Verify this is still needed.
-      await sleep(GITHUB_CHECKRUN_DELAY);
+      await sleep(this.GITHUB_CHECKRUN_DELAY);
       await github.createCheckRun(pr.headSha, latestCheckRun);
     }
   }

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -39,11 +39,10 @@ class OwnersBot {
    */
   async runOwnersCheck(github, pr) {
     const ownersCheck = new OwnersCheck(this.repo, github, pr);
-    let checkRunId;
+    let checkRunId = await github.getCheckRunId(pr.headSha);
     let latestCheckRun;
 
     try {
-      checkRunId = await github.getCheckRunId(pr.headSha);
       latestCheckRun = await ownersCheck.run();
     } catch (error) {
       // If anything goes wrong, report a failing check.

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2019 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const sleep = require('sleep-promise');
+const {LocalRepository} = require('./local_repo');
+const {CheckRun, OwnersCheck} = require('./owners_check');
+
+const GITHUB_CHECKRUN_DELAY = 2000;
+
+class OwnersBot {
+  /**
+   * Constructor.
+   *
+   * @param {!LocalRepository} repo local copy of the repository.
+   */
+  constructor(repo) {
+    this.repo = repo;
+  }
+
+  /**
+   * Runs the steps to create or update an owners-bot check-run on a GitHub Pull
+   * Request.
+   *
+   * @param {!GitHub} github GitHub API interface.
+   * @param {!PullRequest} pr pull request to run owners check on.
+   */
+  async runOwnersCheck(github, pr) {
+    const ownersCheck = new OwnersCheck(this.repo, github, pr);
+    let checkRunId;
+    let latestCheckRun;
+
+    try {
+      checkRunId = await github.getCheckRunId(pr.headSha);
+      latestCheckRun = await ownersCheck.run();
+    } catch (error) {
+      // If anything goes wrong, report a failing check.
+      latestCheckRun = new CheckRun(
+        'The check encountered an error!',
+        'OWNERS check encountered an error:\n' + error
+      );
+    }
+
+    if (checkRunId) {
+      await github.updateCheckRun(checkRunId, latestCheckRun);
+    } else {
+      // We need to add a delay on the PR creation and check creation since
+      // GitHub might not be ready.
+      // TODO: Verify this is still needed.
+      await sleep(GITHUB_CHECKRUN_DELAY);
+      await github.createCheckRun(pr.headSha, latestCheckRun);
+    }
+  }
+
+  /**
+   * Runs the steps to create or update an owners-bot check-run on a GitHub Pull
+   * Request.
+   *
+   * @param {!GitHub} github GitHub API interface.
+   * @param {!number} prNumber pull request number.
+   */
+  async runOwnersCheckOnPrNumber(github, prNumber) {
+    const pr = await github.getPullRequest(prNumber);
+    await this.runOwnersCheck(github, pr);
+  }
+}
+
+module.exports = {OwnersBot};

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -51,7 +51,7 @@ class OwnersBot {
     } else {
       // We need to add a delay on the PR creation and check creation since
       // GitHub might not be ready.
-      // TODO: Verify this is still needed.
+      // TODO(rcebulko): Verify this is still needed.
       await sleep(this.GITHUB_CHECKRUN_DELAY);
       await github.createCheckRun(pr.headSha, latestCheckRun);
     }

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -39,18 +39,8 @@ class OwnersBot {
    */
   async runOwnersCheck(github, pr) {
     const ownersCheck = new OwnersCheck(this.repo, github, pr);
-    let checkRunId = await github.getCheckRunId(pr.headSha);
-    let latestCheckRun;
-
-    try {
-      latestCheckRun = await ownersCheck.run();
-    } catch (error) {
-      // If anything goes wrong, report a failing check.
-      latestCheckRun = new CheckRun(
-        'The check encountered an error!',
-        'OWNERS check encountered an error:\n' + error
-      );
-    }
+    const checkRunId = await github.getCheckRunId(pr.headSha);
+    const latestCheckRun = await ownersCheck.run();
 
     if (checkRunId) {
       await github.updateCheckRun(checkRunId, latestCheckRun);

--- a/owners/test/github.test.js
+++ b/owners/test/github.test.js
@@ -227,7 +227,7 @@ describe('GitHub API', () => {
       })();
     });
 
-    it('returns undefined if the list has no matching check-run', async () => {
+    it('returns null if the list has no matching check-run', async () => {
       nock('https://api.github.com')
         .get('/repos/test_owner/test_repo/commits/_missing_hash_/check-runs')
         .reply(200, checkRunsListResponse);
@@ -239,10 +239,25 @@ describe('GitHub API', () => {
       })();
     });
 
-    it('returns undefined if the list is empty', async () => {
+    it('returns null if the list is empty', async () => {
       nock('https://api.github.com')
         .get('/repos/test_owner/test_repo/commits/_test_hash_/check-runs')
         .reply(200, checkRunsEmptyResponse);
+
+      await withContext(async (context, github) => {
+        const checkRun = await github.getCheckRunId('_test_hash_');
+
+        expect(checkRun).toBeNull();
+      })();
+    });
+
+    it('returns null if there is an error querying GitHub', async () => {
+      nock('https://api.github.com')
+        .get('/repos/test_owner/test_repo/commits/_test_hash_/check-runs')
+        .replyWithError({
+          message: 'Not found',
+          code: 404,
+        });
 
       await withContext(async (context, github) => {
         const checkRun = await github.getCheckRunId('_test_hash_');

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2019 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const sinon = require('sinon');
+const {GitHub, PullRequest} = require('../src/github');
+const {LocalRepository} = require('../src/local_repo');
+const {OwnersBot} = require('../src/owners_bot');
+const {CheckRun, OwnersCheck} = require('../src/owners_check');
+
+describe.only('owners bot', () => {
+  let sandbox;
+  const fakeGithub = new GitHub({}, 'ampproject', 'amphtml', console);
+  const pr = new PullRequest(1337, 'author_user', 'test_sha');
+  const localRepo = new LocalRepository('path/to/repo');
+  const ownersBot = new OwnersBot(localRepo);
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    ownersBot.GITHUB_CHECKRUN_DELAY = 0;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('runOwnersCheck', () => {
+    const checkRun = new CheckRun('Success!', 'The owners check passed.');
+    let getCheckRunIdStub;
+
+    beforeEach(() => {
+      getCheckRunIdStub = sandbox.stub(GitHub.prototype, 'getCheckRunId');
+      sandbox.stub(OwnersCheck.prototype, 'run').returns(checkRun);
+      sandbox.stub(GitHub.prototype, 'updateCheckRun');
+      sandbox.stub(GitHub.prototype, 'createCheckRun');
+    });
+
+    it('attempts to fetch the existing check-run ID', async () => {
+      await ownersBot.runOwnersCheck(fakeGithub, pr);
+      sandbox.assert.calledWith(fakeGithub.getCheckRunId, 'test_sha');
+    });
+
+    it('runs the owners check', async () => {
+      await ownersBot.runOwnersCheck(fakeGithub, pr);
+      sandbox.assert.calledOnce(OwnersCheck.prototype.run);
+    });
+
+    describe('when a check-run exists', () => {
+      it('updates the existing check-run', async () => {
+        getCheckRunIdStub.returns(42);
+        await ownersBot.runOwnersCheck(fakeGithub, pr);
+
+        sandbox.assert.calledWith(
+          GitHub.prototype.updateCheckRun,
+          42,
+          checkRun
+        );
+      });
+    });
+
+    describe('when no check-run exists yet', () => {
+      it('creates a new check-run', async () => {
+        getCheckRunIdStub.returns(null);
+        await ownersBot.runOwnersCheck(fakeGithub, pr);
+
+        sandbox.assert.calledWith(
+          GitHub.prototype.createCheckRun,
+          'test_sha',
+          checkRun
+        );
+      });
+    });
+  });
+
+  describe('runOwnersCheckOnPrNumber', () => {
+    beforeEach(() => {
+      sandbox.stub(OwnersBot.prototype, 'runOwnersCheck');
+      sandbox.stub(GitHub.prototype, 'getPullRequest').returns(pr);
+    });
+
+    it('fetches the PR from GitHub', async () => {
+      await ownersBot.runOwnersCheckOnPrNumber(fakeGithub, 1337);
+      sandbox.assert.calledWith(fakeGithub.getPullRequest, 1337);
+    });
+
+    it('runs the owners check on the retrieved PR', async () => {
+      await ownersBot.runOwnersCheckOnPrNumber(fakeGithub, 1337);
+      sandbox.assert.calledWith(ownersBot.runOwnersCheck, fakeGithub, pr);
+    });
+  });
+});

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -175,6 +175,13 @@ describe('owners check', () => {
           sandbox.stub(OwnersTree.prototype, 'fileHasOwner').returns(true);
         });
 
+        // TODO(rcebulko): Update once this is changed to a blocking check.
+        it('has a neutral conclusion', async () => {
+          const checkRun = await ownersCheck.run();
+
+          expect(checkRun.json.conclusion).toEqual('neutral');
+        });
+
         it('has a passing summary', async () => {
           const checkRun = await ownersCheck.run();
 
@@ -197,6 +204,13 @@ describe('owners check', () => {
       });
 
       describe('for a PR requiring approvals', () => {
+        // TODO(rcebulko): Update once this is changed to a blocking check.
+        it('has a neutral conclusion', async () => {
+          const checkRun = await ownersCheck.run();
+
+          expect(checkRun.json.conclusion).toEqual('neutral');
+        });
+
         it('has a failing summary', async () => {
           const checkRun = await ownersCheck.run();
 
@@ -217,6 +231,35 @@ describe('owners check', () => {
           const checkRun = await ownersCheck.run();
 
           expect(checkRun.text).toContain('%% REVIEW SUGGESTIONS %%');
+        });
+      });
+
+      describe('if an error occurs', () => {
+        beforeEach(() => {
+          sandbox
+            .stub(OwnersCheck.prototype, 'buildCurrentCoverageText')
+            .throws(new Error('Something is wrong'));
+        });
+
+        // TODO(rcebulko): Update once this is changed to a blocking check.
+        it('has a neutral conclusion', async () => {
+          const checkRun = await ownersCheck.run();
+
+          expect(checkRun.json.conclusion).toEqual('neutral');
+        });
+
+        it('has an error summary', async () => {
+          const checkRun = await ownersCheck.run();
+
+          expect(checkRun.summary).toEqual('The check encountered an error!');
+        });
+
+        it('contains error details in the output', async () => {
+          const checkRun = await ownersCheck.run();
+
+          expect(checkRun.text).toEqual(
+            'OWNERS check encountered an error:\nError: Something is wrong'
+          );
         });
       });
     });


### PR DESCRIPTION
This PR:
- Separates owners bot functionality out of `index.js`
- Adds a status check page (`/admin/status`)
- Adds a page to view the current OWNERS hierarchy (`/admin/tree`)
    - *I cached this to prevent it being spammed and causing trouble, but I'm not sure if that's a real risk or not, and it's pretty hard to avoid with the next endpoint; opinions?
- Adds a page that generates the check-run for any PR, for testing/validation purposes.