### PR TITLE
Add file matching for pattern-based rules

### DIFF
--- a/owners/src/owners.js
+++ b/owners/src/owners.js
@@ -165,7 +165,7 @@ class OwnersTree {
   toString() {
     const lines = [];
 
-    const rulePrefix = ' *';
+    const rulePrefix = ' •';
     const childPrefix = '└───';
     const indent = Math.max(0, this.depth - 1) * childPrefix.length;
     const prefix = this.isRoot ? '' : `${' '.repeat(indent)}${childPrefix}`;

--- a/owners/src/owners.js
+++ b/owners/src/owners.js
@@ -175,7 +175,7 @@ class OwnersTree {
     lines.push(`${prefix}${dirName}`);
     this.rules.forEach(rule => {
       lines.push(
-        `${' '.repeat(indent)}${rulePrefix} ${rule.owners.join(', ')}`
+        `${' '.repeat(indent)}${rulePrefix} ${rule}`
       );
     });
 
@@ -206,6 +206,7 @@ class OwnersRule {
     this.dirPath = path.dirname(ownersPath);
     this.wildcardOwner = owners.includes('*');
     this.owners = this.wildcardOwner ? ['*'] : owners;
+    this.label = 'All';
   }
 
   /**
@@ -222,6 +223,16 @@ class OwnersRule {
    */
   matchesFile(filePath) {
     return true;
+  }
+
+  /**
+   * Describe the rule.
+   *
+   * @return {string} description of the rule.
+   */
+  toString() {
+    const ownersList = this.owners.length ? this.owners.join(', ') : '-';
+    return `${this.label}: ${ownersList}`;
   }
 }
 
@@ -243,6 +254,7 @@ class PatternOwnersRule extends OwnersRule {
   constructor(ownersPath, owners, pattern) {
     super(ownersPath, owners);
     this.pattern = pattern;
+    this.label = pattern;
     this.regex = new RegExp(
       pattern
         .split('*')

--- a/owners/src/rules.js
+++ b/owners/src/rules.js
@@ -59,8 +59,7 @@ class OwnersRule {
    * @return {string} description of the rule.
    */
   toString() {
-    const ownersList = this.owners.length ? this.owners.join(', ') : '-';
-    return `${this.label}: ${ownersList}`;
+    return `${this.label}: ${this.owners.join(', ')}`;
   }
 }
 

--- a/owners/src/rules.js
+++ b/owners/src/rules.js
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2019 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const path = require('path');
+
+/**
+ * A rule describing ownership for a directory.
+ */
+class OwnersRule {
+  /**
+   * Constructor.
+   *
+   * If a rule's owners includes the `*` wildcard, all other owners will be
+   * ignored, and the rule will be satisfied by any reviewer.
+   *
+   * @param {!string} ownersPath path to OWNERS file.
+   * @param {string[]} owners list of GitHub usernames of owners.
+   */
+  constructor(ownersPath, owners) {
+    this.filePath = ownersPath;
+    this.dirPath = path.dirname(ownersPath);
+    this.wildcardOwner = owners.includes('*');
+    this.owners = this.wildcardOwner ? ['*'] : owners;
+    this.label = 'All';
+  }
+
+  /**
+   * Test if a file is matched by the rule.
+   *
+   * Currently is always true, as it assumes that the rule is being tested on;
+   * files within its hierarchy; may be modified to test filetypes, globs,
+   * special cases like package.json, etc.
+   *
+   * TODO(Issue #278): Implement pattern matching.
+   *
+   * @param {!string} filePath relative path in repo to the file being checked.
+   * @return {boolean} true if the rule applies to the file.
+   */
+  matchesFile(filePath) {
+    return true;
+  }
+
+  /**
+   * Describe the rule.
+   *
+   * @return {string} description of the rule.
+   */
+  toString() {
+    const ownersList = this.owners.length ? this.owners.join(', ') : '-';
+    return `${this.label}: ${ownersList}`;
+  }
+}
+
+/**
+ * A pattern-based ownership rule applying to all matching files in the
+ * directory and all subdirectories.
+ *
+ * Treats `*` as a wildcard glob pattern; all other characters are treated as
+ * literals.
+ */
+class PatternOwnersRule extends OwnersRule {
+  /**
+   * Constructor.
+   *
+   * @param {!string} ownersPath path to OWNERS file.
+   * @param {string[]} owners list of GitHub usernames of owners.
+   * @param {!string} pattern filename/type pattern.
+   */
+  constructor(ownersPath, owners, pattern) {
+    super(ownersPath, owners);
+    this.pattern = pattern;
+    this.label = pattern;
+    this.regex = new RegExp(
+      pattern
+        .split('*')
+        .map(PatternOwnersRule.escapeRegexChars)
+        .join('.*?')
+        .split(/\s*,\s*/)
+        .join('|')
+    );
+  }
+
+  /**
+   * Escapes all regex characters in a string.
+   *
+   * @param {!string} str string to escape.
+   * @return {string} copy of the string that can be used in a regex.
+   */
+  static escapeRegexChars(str) {
+    return str.replace(/[[\]{}()*+?.\\^$|]/g, '\\$&');
+  }
+
+  /**
+   * Test if a file is matched by the pattern rule.
+   *
+   * @param {!string} filePath relative path in repo to the file being checked.
+   * @return {boolean} true if the rule applies to the file.
+   */
+  matchesFile(filePath) {
+    return this.regex.test(path.basename(filePath));
+  }
+}
+
+module.exports = {OwnersRule, PatternOwnersRule};

--- a/owners/src/rules.js
+++ b/owners/src/rules.js
@@ -88,8 +88,6 @@ class PatternOwnersRule extends OwnersRule {
         .split('*')
         .map(PatternOwnersRule.escapeRegexChars)
         .join('.*?')
-        .split(/\s*,\s*/)
-        .join('|')
     );
   }
 

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -20,7 +20,8 @@ const owners = require('..');
 const {Probot} = require('probot');
 const sinon = require('sinon');
 const {LocalRepository} = require('../src/local_repo');
-const {OwnersRule, OwnersParser} = require('../src/owners');
+const {OwnersParser} = require('../src/owners');
+const {OwnersRule} = require('../src/rules');
 
 const opened35 = require('./fixtures/actions/opened.35');
 const opened36 = require('./fixtures/actions/opened.36.author-is-owner');

--- a/owners/test/owners.test.js
+++ b/owners/test/owners.test.js
@@ -16,12 +16,8 @@
 
 const sinon = require('sinon');
 const {LocalRepository} = require('../src/local_repo');
-const {
-  OwnersParser,
-  OwnersRule,
-  PatternOwnersRule,
-  OwnersTree,
-} = require('../src/owners');
+const {OwnersParser, OwnersTree} = require('../src/owners');
+const {OwnersRule} = require('../src/rules');
 
 describe('owners tree', () => {
   let tree;
@@ -242,140 +238,6 @@ describe('owners tree', () => {
           ' * All: child',
         ].join('\n')
       );
-    });
-  });
-});
-
-describe('owners rules', () => {
-  expect.extend({
-    toMatchFile(rule, filePath) {
-      const matches = rule.matchesFile(filePath);
-      const matchStr = this.isNot ? 'not match' : 'match';
-
-      return {
-        pass: matches,
-        message: () =>
-          `Expected rules in '${rule.filePath}' to ` +
-          `${matchStr} file '${filePath}'.`,
-      };
-    },
-  });
-
-  describe('with a wildcard (*) owner', () => {
-    it('sets the wildcardOwner flag', () => {
-      const rule = new OwnersRule('OWNERS.yaml', ['*']);
-
-      expect(rule.wildcardOwner).toBe(true);
-    });
-
-    it('ignores any other owners', () => {
-      const rule = new OwnersRule('OWNERS.yaml', ['a_user', '*', 'someone']);
-
-      expect(rule.owners).toEqual(['*']);
-    });
-  });
-
-  describe('basic directory ownership', () => {
-    describe('matchesFile', () => {
-      it('matches all files', () => {
-        const rule = new OwnersRule('src/OWNERS.yaml', []);
-
-        expect(rule).toMatchFile('src/foo.txt');
-        expect(rule).toMatchFile('src/foo/bar.txt');
-        expect(rule).toMatchFile('src/foo/bar/baz.txt');
-      });
-    });
-
-    describe('toString', () => {
-      it('lists all owners', () => {
-        const rule = new OwnersRule('OWNERS.yaml', ['rcebulko', 'erwinmombay']);
-
-        expect(rule.toString()).toEqual('All: rcebulko, erwinmombay');
-      });
-
-      it('shows when there are no owners', () => {
-        const rule = new OwnersRule('OWNERS.yaml', []);
-        
-        expect(rule.toString()).toEqual('All: -');
-      });
-    });
-  });
-
-  describe('with glob patterns', () => {
-    describe('constructor', () => {
-      it.each([
-        ['file.txt', /file\.txt/],
-        ['package*.json', /package.*?\.json/],
-        ['*.css, *.js', /.*?\.css|.*?\.js/],
-      ])(
-        'converts the pattern "%p" into regex "%p"',
-        (pattern, expectedRegex) => {
-          const rule = new PatternOwnersRule('OWNERS.yaml', [], pattern);
-          expect(rule.regex).toEqual(expectedRegex);
-        }
-      );
-    });
-
-    describe('regexEscape', () => {
-      it.each([
-        ['file.txt', 'file\\.txt'],
-        ['this+that.txt', 'this\\+that\\.txt'],
-        ['*.css, *.js', '\\*\\.css, \\*\\.js'],
-        ['with space.txt', 'with space\\.txt'],
-        ['with-hyphen.txt', 'with-hyphen\\.txt'],
-      ])('escapes "%p" as "%p"', (text, expected) => {
-        expect(PatternOwnersRule.escapeRegexChars(text)).toEqual(expected);
-      });
-    });
-
-    describe('matchesFile', () => {
-      it('matches literal filenames', () => {
-        const rule = new PatternOwnersRule('OWNERS.yaml', [], 'package.json');
-
-        expect(rule).toMatchFile('package.json');
-      });
-
-      it('matches glob patterns', () => {
-        const rule = new PatternOwnersRule('OWNERS.yaml', [], '*.js');
-
-        expect(rule).toMatchFile('main.js');
-      });
-
-      it('matches comma-separated patterns', () => {
-        const rule = new PatternOwnersRule('OWNERS.yaml', [], '*.js, *.css');
-
-        expect(rule).toMatchFile('main.js');
-        expect(rule).toMatchFile('style.css');
-      });
-
-      it('matches files in subdirectories', () => {
-        expect(
-          new PatternOwnersRule('OWNERS.yaml', [], 'package.json')
-        ).toMatchFile('foo/package.json');
-
-        expect(new PatternOwnersRule('OWNERS.yaml', [], '*.js')).toMatchFile(
-          'bar/main.js'
-        );
-
-        expect(
-          new PatternOwnersRule('OWNERS.yaml', [], '*.js, *.css')
-        ).toMatchFile('foo/baz/main.js');
-        expect(
-          new PatternOwnersRule('OWNERS.yaml', [], '*.js, *.css')
-        ).toMatchFile('foo/bar/baz/style.css');
-      });
-    });
-
-    describe('toString', () => {
-      it('lists all owners for the pattern', () => {
-        const rule = new PatternOwnersRule(
-          'OWNERS.yaml',
-          ['rcebulko', 'erwinmombay'],
-          '*.js, *.css',
-        );
-
-        expect(rule.toString()).toEqual('*.js, *.css: rcebulko, erwinmombay');
-      });
     });
   });
 });

--- a/owners/test/owners.test.js
+++ b/owners/test/owners.test.js
@@ -28,7 +28,11 @@ describe('owners tree', () => {
     'descendant',
   ]);
   const wildcardDirRule = new OwnersRule('shared/OWNERS.yaml', ['*']);
-  const testFileRule = new PatternOwnersRule('OWNERS.yaml', ['testers'], '*.test.js');
+  const testFileRule = new PatternOwnersRule(
+    'OWNERS.yaml',
+    ['testers'],
+    '*.test.js'
+  );
 
   beforeEach(() => {
     tree = new OwnersTree();
@@ -237,15 +241,15 @@ describe('owners tree', () => {
       expect(tree.toString()).toEqual(
         [
           'ROOT',
-          ' * All: root',
-          ' * *.test.js: testers',
+          ' • All: root',
+          ' • *.test.js: testers',
           '└───foo',
-          ' * All: child',
+          ' • All: child',
           '    └───bar',
           '        └───baz',
-          '         * All: descendant',
+          '         • All: descendant',
           '└───biz',
-          ' * All: child',
+          ' • All: child',
         ].join('\n')
       );
     });

--- a/owners/test/owners.test.js
+++ b/owners/test/owners.test.js
@@ -232,14 +232,14 @@ describe('owners tree', () => {
       expect(tree.toString()).toEqual(
         [
           'ROOT',
-          ' * root',
+          ' * All: root',
           '└───foo',
-          ' * child',
+          ' * All: child',
           '    └───bar',
           '        └───baz',
-          '         * descendant',
+          '         * All: descendant',
           '└───biz',
-          ' * child',
+          ' * All: child',
         ].join('\n')
       );
     });
@@ -283,6 +283,20 @@ describe('owners rules', () => {
         expect(rule).toMatchFile('src/foo.txt');
         expect(rule).toMatchFile('src/foo/bar.txt');
         expect(rule).toMatchFile('src/foo/bar/baz.txt');
+      });
+    });
+
+    describe('toString', () => {
+      it('lists all owners', () => {
+        const rule = new OwnersRule('OWNERS.yaml', ['rcebulko', 'erwinmombay']);
+
+        expect(rule.toString()).toEqual('All: rcebulko, erwinmombay');
+      });
+
+      it('shows when there are no owners', () => {
+        const rule = new OwnersRule('OWNERS.yaml', []);
+        
+        expect(rule.toString()).toEqual('All: -');
       });
     });
   });
@@ -349,6 +363,18 @@ describe('owners rules', () => {
         expect(
           new PatternOwnersRule('OWNERS.yaml', [], '*.js, *.css')
         ).toMatchFile('foo/bar/baz/style.css');
+      });
+    });
+
+    describe('toString', () => {
+      it('lists all owners for the pattern', () => {
+        const rule = new PatternOwnersRule(
+          'OWNERS.yaml',
+          ['rcebulko', 'erwinmombay'],
+          '*.js, *.css',
+        );
+
+        expect(rule.toString()).toEqual('*.js, *.css: rcebulko, erwinmombay');
       });
     });
   });

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -22,7 +22,8 @@ const {
   CheckRunConclusion,
   OwnersCheck,
 } = require('../src/owners_check');
-const {OwnersRule, OwnersTree} = require('../src/owners');
+const {OwnersTree} = require('../src/owners');
+const {OwnersRule} = require('../src/rules');
 const {ReviewerSelection} = require('../src/reviewer_selection');
 
 describe('check run', () => {

--- a/owners/test/reviewer_selection.test.js
+++ b/owners/test/reviewer_selection.test.js
@@ -16,7 +16,8 @@
 
 const sinon = require('sinon');
 const {ReviewerSelection} = require('../src/reviewer_selection');
-const {OwnersRule, OwnersTree} = require('../src/owners');
+const {OwnersTree} = require('../src/owners');
+const {OwnersRule} = require('../src/rules');
 
 describe('reviewer selection', () => {
   const sandbox = sinon.createSandbox();

--- a/owners/test/rules.test.js
+++ b/owners/test/rules.test.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2019 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {OwnersRule, PatternOwnersRule} = require('../src/rules');
+
+describe('owners rules', () => {
+  expect.extend({
+    toMatchFile(rule, filePath) {
+      const matches = rule.matchesFile(filePath);
+      const matchStr = this.isNot ? 'not match' : 'match';
+
+      return {
+        pass: matches,
+        message: () =>
+          `Expected rules in '${rule.filePath}' to ` +
+          `${matchStr} file '${filePath}'.`,
+      };
+    },
+  });
+
+  describe('basic directory ownership', () => {
+    describe('matchesFile', () => {
+      it('matches all files', () => {
+        const rule = new OwnersRule('src/OWNERS.yaml', []);
+
+        expect(rule).toMatchFile('src/foo.txt');
+        expect(rule).toMatchFile('src/foo/bar.txt');
+        expect(rule).toMatchFile('src/foo/bar/baz.txt');
+      });
+    });
+
+    describe('toString', () => {
+      it('lists all owners', () => {
+        const rule = new OwnersRule('OWNERS.yaml', ['rcebulko', 'erwinmombay']);
+
+        expect(rule.toString()).toEqual('All: rcebulko, erwinmombay');
+      });
+
+      it('shows when there are no owners', () => {
+        const rule = new OwnersRule('OWNERS.yaml', []);
+
+        expect(rule.toString()).toEqual('All: -');
+      });
+    });
+  });
+
+  describe('with glob patterns', () => {
+    describe('constructor', () => {
+      it.each([
+        ['file.txt', /file\.txt/],
+        ['package*.json', /package.*?\.json/],
+        ['*.css, *.js', /.*?\.css|.*?\.js/],
+      ])(
+        'converts the pattern "%p" into regex "%p"',
+        (pattern, expectedRegex) => {
+          const rule = new PatternOwnersRule('OWNERS.yaml', [], pattern);
+          expect(rule.regex).toEqual(expectedRegex);
+        }
+      );
+    });
+
+    describe('regexEscape', () => {
+      it.each([
+        ['file.txt', 'file\\.txt'],
+        ['this+that.txt', 'this\\+that\\.txt'],
+        ['*.css, *.js', '\\*\\.css, \\*\\.js'],
+        ['with space.txt', 'with space\\.txt'],
+        ['with-hyphen.txt', 'with-hyphen\\.txt'],
+      ])('escapes "%p" as "%p"', (text, expected) => {
+        expect(PatternOwnersRule.escapeRegexChars(text)).toEqual(expected);
+      });
+    });
+
+    describe('matchesFile', () => {
+      it('matches literal filenames', () => {
+        const rule = new PatternOwnersRule('OWNERS.yaml', [], 'package.json');
+
+        expect(rule).toMatchFile('package.json');
+      });
+
+      it('matches glob patterns', () => {
+        const rule = new PatternOwnersRule('OWNERS.yaml', [], '*.js');
+
+        expect(rule).toMatchFile('main.js');
+      });
+
+      it('matches comma-separated patterns', () => {
+        const rule = new PatternOwnersRule('OWNERS.yaml', [], '*.js, *.css');
+
+        expect(rule).toMatchFile('main.js');
+        expect(rule).toMatchFile('style.css');
+      });
+
+      it('matches files in subdirectories', () => {
+        expect(
+          new PatternOwnersRule('OWNERS.yaml', [], 'package.json')
+        ).toMatchFile('foo/package.json');
+
+        expect(new PatternOwnersRule('OWNERS.yaml', [], '*.js')).toMatchFile(
+          'bar/main.js'
+        );
+
+        expect(
+          new PatternOwnersRule('OWNERS.yaml', [], '*.js, *.css')
+        ).toMatchFile('foo/baz/main.js');
+        expect(
+          new PatternOwnersRule('OWNERS.yaml', [], '*.js, *.css')
+        ).toMatchFile('foo/bar/baz/style.css');
+      });
+    });
+
+    describe('toString', () => {
+      it('lists all owners for the pattern', () => {
+        const rule = new PatternOwnersRule(
+          'OWNERS.yaml',
+          ['rcebulko', 'erwinmombay'],
+          '*.js, *.css'
+        );
+
+        expect(rule.toString()).toEqual('*.js, *.css: rcebulko, erwinmombay');
+      });
+    });
+  });
+});

--- a/owners/test/rules.test.js
+++ b/owners/test/rules.test.js
@@ -48,12 +48,6 @@ describe('owners rules', () => {
 
         expect(rule.toString()).toEqual('All: rcebulko, erwinmombay');
       });
-
-      it('shows when there are no owners', () => {
-        const rule = new OwnersRule('OWNERS.yaml', []);
-
-        expect(rule.toString()).toEqual('All: -');
-      });
     });
   });
 
@@ -63,7 +57,7 @@ describe('owners rules', () => {
         ['file.txt', /file\.txt/],
         ['package*.json', /package.*?\.json/],
       ])(
-        'converts the pattern "%p" into regex "%p"',
+        'converts the pattern %p into regex %p',
         (pattern, expectedRegex) => {
           const rule = new PatternOwnersRule('OWNERS.yaml', [], pattern);
           expect(rule.regex).toEqual(expectedRegex);
@@ -73,11 +67,7 @@ describe('owners rules', () => {
 
     describe('regexEscape', () => {
       it.each([
-        ['file.txt', 'file\\.txt'],
-        ['this+that.txt', 'this\\+that\\.txt'],
-        ['with space.txt', 'with space\\.txt'],
-        ['with-hyphen.txt', 'with-hyphen\\.txt'],
-      ])('escapes "%p" as "%p"', (text, expected) => {
+      ])('escapes %p as %p', (text, expected) => {
         expect(PatternOwnersRule.escapeRegexChars(text)).toEqual(expected);
       });
     });
@@ -95,18 +85,29 @@ describe('owners rules', () => {
         expect(rule).toMatchFile('main.js');
       });
 
-      it('matches files in subdirectories', () => {
-        expect(
-          new PatternOwnersRule('OWNERS.yaml', [], 'package.json')
-        ).toMatchFile('foo/package.json');
+      it.each([
+        ['file.txt', 'file.txt'],
+        ['this+that.txt', 'this+that.txt'],
+        ['with space.txt', 'with space.txt'],
+        ['with-hyphen.txt', 'with-hyphen.txt'],
+        ])('simple file name %p matches file %p', (pattern, filePath) => {
+          expect(new PatternOwnersRule('OWNERS.yaml', [], pattern)).toMatchFile(filePath);
+        });
 
-        expect(new PatternOwnersRule('OWNERS.yaml', [], '*.js')).toMatchFile(
-          'bar/main.js'
-        );
+      it.each([
+        ['*.txt', 'file.txt'],
+        ['*.test.txt', 'file.test.txt'],
+        ['package*.json', 'package.lock.json'],
+        ])('pattern %p matches file %p', (pattern, filePath) => {
+          expect(new PatternOwnersRule('OWNERS.yaml', [], pattern)).toMatchFile(filePath);
+        });
 
-        expect(new PatternOwnersRule('OWNERS.yaml', [], '*.css')).toMatchFile(
-          'foo/bar/baz/style.css'
-        );
+      it.each([
+        ['package.json', 'foo/package.json'],
+        ['*.js', 'bar/main.js'],
+        ['*.css', 'foo/bar/baz/style.css'],
+        ])('pattern %p matches nested file %p', (pattern, filePath) => {
+          expect(new PatternOwnersRule('OWNERS.yaml', [], pattern)).toMatchFile(filePath);
       });
     });
 

--- a/owners/test/rules.test.js
+++ b/owners/test/rules.test.js
@@ -56,18 +56,14 @@ describe('owners rules', () => {
       it.each([
         ['file.txt', /file\.txt/],
         ['package*.json', /package.*?\.json/],
-      ])(
-        'converts the pattern %p into regex %p',
-        (pattern, expectedRegex) => {
-          const rule = new PatternOwnersRule('OWNERS.yaml', [], pattern);
-          expect(rule.regex).toEqual(expectedRegex);
-        }
-      );
+      ])('converts the pattern %p into regex %p', (pattern, expectedRegex) => {
+        const rule = new PatternOwnersRule('OWNERS.yaml', [], pattern);
+        expect(rule.regex).toEqual(expectedRegex);
+      });
     });
 
     describe('regexEscape', () => {
-      it.each([
-      ])('escapes %p as %p', (text, expected) => {
+      it.each([])('escapes %p as %p', (text, expected) => {
         expect(PatternOwnersRule.escapeRegexChars(text)).toEqual(expected);
       });
     });
@@ -90,24 +86,30 @@ describe('owners rules', () => {
         ['this+that.txt', 'this+that.txt'],
         ['with space.txt', 'with space.txt'],
         ['with-hyphen.txt', 'with-hyphen.txt'],
-        ])('simple file name %p matches file %p', (pattern, filePath) => {
-          expect(new PatternOwnersRule('OWNERS.yaml', [], pattern)).toMatchFile(filePath);
-        });
+      ])('simple file name %p matches file %p', (pattern, filePath) => {
+        expect(new PatternOwnersRule('OWNERS.yaml', [], pattern)).toMatchFile(
+          filePath
+        );
+      });
 
       it.each([
         ['*.txt', 'file.txt'],
         ['*.test.txt', 'file.test.txt'],
         ['package*.json', 'package.lock.json'],
-        ])('pattern %p matches file %p', (pattern, filePath) => {
-          expect(new PatternOwnersRule('OWNERS.yaml', [], pattern)).toMatchFile(filePath);
-        });
+      ])('pattern %p matches file %p', (pattern, filePath) => {
+        expect(new PatternOwnersRule('OWNERS.yaml', [], pattern)).toMatchFile(
+          filePath
+        );
+      });
 
       it.each([
         ['package.json', 'foo/package.json'],
         ['*.js', 'bar/main.js'],
         ['*.css', 'foo/bar/baz/style.css'],
-        ])('pattern %p matches nested file %p', (pattern, filePath) => {
-          expect(new PatternOwnersRule('OWNERS.yaml', [], pattern)).toMatchFile(filePath);
+      ])('pattern %p matches nested file %p', (pattern, filePath) => {
+        expect(new PatternOwnersRule('OWNERS.yaml', [], pattern)).toMatchFile(
+          filePath
+        );
       });
     });
 

--- a/owners/test/rules.test.js
+++ b/owners/test/rules.test.js
@@ -104,9 +104,9 @@ describe('owners rules', () => {
           'bar/main.js'
         );
 
-        expect(
-          new PatternOwnersRule('OWNERS.yaml', [], '*.css')
-        ).toMatchFile('foo/bar/baz/style.css');
+        expect(new PatternOwnersRule('OWNERS.yaml', [], '*.css')).toMatchFile(
+          'foo/bar/baz/style.css'
+        );
       });
     });
 

--- a/owners/test/rules.test.js
+++ b/owners/test/rules.test.js
@@ -62,7 +62,6 @@ describe('owners rules', () => {
       it.each([
         ['file.txt', /file\.txt/],
         ['package*.json', /package.*?\.json/],
-        ['*.css, *.js', /.*?\.css|.*?\.js/],
       ])(
         'converts the pattern "%p" into regex "%p"',
         (pattern, expectedRegex) => {
@@ -76,7 +75,6 @@ describe('owners rules', () => {
       it.each([
         ['file.txt', 'file\\.txt'],
         ['this+that.txt', 'this\\+that\\.txt'],
-        ['*.css, *.js', '\\*\\.css, \\*\\.js'],
         ['with space.txt', 'with space\\.txt'],
         ['with-hyphen.txt', 'with-hyphen\\.txt'],
       ])('escapes "%p" as "%p"', (text, expected) => {
@@ -97,13 +95,6 @@ describe('owners rules', () => {
         expect(rule).toMatchFile('main.js');
       });
 
-      it('matches comma-separated patterns', () => {
-        const rule = new PatternOwnersRule('OWNERS.yaml', [], '*.js, *.css');
-
-        expect(rule).toMatchFile('main.js');
-        expect(rule).toMatchFile('style.css');
-      });
-
       it('matches files in subdirectories', () => {
         expect(
           new PatternOwnersRule('OWNERS.yaml', [], 'package.json')
@@ -114,10 +105,7 @@ describe('owners rules', () => {
         );
 
         expect(
-          new PatternOwnersRule('OWNERS.yaml', [], '*.js, *.css')
-        ).toMatchFile('foo/baz/main.js');
-        expect(
-          new PatternOwnersRule('OWNERS.yaml', [], '*.js, *.css')
+          new PatternOwnersRule('OWNERS.yaml', [], '*.css')
         ).toMatchFile('foo/bar/baz/style.css');
       });
     });
@@ -127,10 +115,10 @@ describe('owners rules', () => {
         const rule = new PatternOwnersRule(
           'OWNERS.yaml',
           ['rcebulko', 'erwinmombay'],
-          '*.js, *.css'
+          '*.css'
         );
 
-        expect(rule.toString()).toEqual('*.js, *.css: rcebulko, erwinmombay');
+        expect(rule.toString()).toEqual('*.css: rcebulko, erwinmombay');
       });
     });
   });


### PR DESCRIPTION
First step towards #278 

This PR adds the rule class that handles matching files based on a glob pattern. It also splits the definition of rule classes into a separate `rules` module.

Note that the parser does not yet create these pattern-based rules.

@danielrozenberg Again, this looks like a lot if you look at the files alone, but 90% of this PR is tests and moving code out into a new module.