### PR TITLE
Support same-directory only ownership rule patterns

### DIFF
--- a/owners/src/rules.js
+++ b/owners/src/rules.js
@@ -127,4 +127,30 @@ class PatternOwnersRule extends OwnersRule {
   }
 }
 
-module.exports = {OwnersRule, PatternOwnersRule};
+/**
+ * A pattern-based ownership rule applying only to files in the same directory.
+ */
+class SameDirPatternOwnersRule extends PatternOwnersRule {
+  /**
+   * The label to use when describing the rule.
+   *
+   * @return {string} the label for the rule.
+   */
+  get label() {
+    return `./${this.pattern}`;
+  }
+
+  /**
+   * Test if a file is in the rule directory and matched by the pattern rule.
+   *
+   * @param {!string} filePath relative path in repo to the file being checked.
+   * @return {boolean} true if the rule applies to the file.
+   */
+  matchesFile(filePath) {
+    return (
+      super.matchesFile(filePath) && this.dirPath === path.dirname(filePath)
+    );
+  }
+}
+
+module.exports = {OwnersRule, PatternOwnersRule, SameDirPatternOwnersRule};

--- a/owners/src/rules.js
+++ b/owners/src/rules.js
@@ -34,7 +34,15 @@ class OwnersRule {
     this.dirPath = path.dirname(ownersPath);
     this.wildcardOwner = owners.includes('*');
     this.owners = this.wildcardOwner ? ['*'] : owners;
-    this.label = 'All';
+  }
+
+  /**
+   * The label to use when describing the rule.
+   *
+   * @return {string} the label for the rule.
+   */
+  get label() {
+    return 'All files';
   }
 
   /**
@@ -81,13 +89,21 @@ class PatternOwnersRule extends OwnersRule {
   constructor(ownersPath, owners, pattern) {
     super(ownersPath, owners);
     this.pattern = pattern;
-    this.label = pattern;
     this.regex = new RegExp(
       pattern
         .split('*')
         .map(PatternOwnersRule.escapeRegexChars)
         .join('.*?')
     );
+  }
+
+  /**
+   * The label to use when describing the rule.
+   *
+   * @return {string} the label for the rule.
+   */
+  get label() {
+    return this.pattern;
   }
 
   /**

--- a/owners/src/rules.js
+++ b/owners/src/rules.js
@@ -103,7 +103,7 @@ class PatternOwnersRule extends OwnersRule {
    * @return {string} the label for the rule.
    */
   get label() {
-    return this.pattern;
+    return `**/${this.pattern}`;
   }
 
   /**

--- a/owners/test/owners.test.js
+++ b/owners/test/owners.test.js
@@ -241,15 +241,15 @@ describe('owners tree', () => {
       expect(tree.toString()).toEqual(
         [
           'ROOT',
-          ' • All: root',
+          ' • All files: root',
           ' • *.test.js: testers',
           '└───foo',
-          ' • All: child',
+          ' • All files: child',
           '    └───bar',
           '        └───baz',
-          '         • All: descendant',
+          '         • All files: descendant',
           '└───biz',
-          ' • All: child',
+          ' • All files: child',
         ].join('\n')
       );
     });

--- a/owners/test/owners.test.js
+++ b/owners/test/owners.test.js
@@ -17,7 +17,11 @@
 const sinon = require('sinon');
 const {LocalRepository} = require('../src/local_repo');
 const {OwnersParser, OwnersTree} = require('../src/owners');
-const {OwnersRule, PatternOwnersRule, SameDirPatternOwnersRule} = require('../src/rules');
+const {
+  OwnersRule,
+  PatternOwnersRule,
+  SameDirPatternOwnersRule,
+} = require('../src/rules');
 
 describe('owners tree', () => {
   let tree;
@@ -33,7 +37,11 @@ describe('owners tree', () => {
     ['testers'],
     '*.test.js'
   );
-  const packageJsonRule = new SameDirPatternOwnersRule('OWNERS.yaml', ['anyone'], 'package.json');
+  const packageJsonRule = new SameDirPatternOwnersRule(
+    'OWNERS.yaml',
+    ['anyone'],
+    'package.json'
+  );
 
   beforeEach(() => {
     tree = new OwnersTree();

--- a/owners/test/owners.test.js
+++ b/owners/test/owners.test.js
@@ -250,7 +250,7 @@ describe('owners tree', () => {
         [
           'ROOT',
           ' • All files: root',
-          ' • *.test.js: testers',
+          ' • **/*.test.js: testers',
           ' • ./package.json: anyone',
           '└───foo',
           ' • All files: child',

--- a/owners/test/rules.test.js
+++ b/owners/test/rules.test.js
@@ -42,11 +42,19 @@ describe('owners rules', () => {
       });
     });
 
+    describe('label', () => {
+      it('is "All files"', () => {
+        const rule = new OwnersRule('OWNERS.yaml', []);
+
+        expect(rule.label).toEqual('All files');
+      });
+    });
+
     describe('toString', () => {
       it('lists all owners', () => {
         const rule = new OwnersRule('OWNERS.yaml', ['rcebulko', 'erwinmombay']);
 
-        expect(rule.toString()).toEqual('All: rcebulko, erwinmombay');
+        expect(rule.toString()).toEqual('All files: rcebulko, erwinmombay');
       });
     });
   });
@@ -110,6 +118,14 @@ describe('owners rules', () => {
         expect(new PatternOwnersRule('OWNERS.yaml', [], pattern)).toMatchFile(
           filePath
         );
+      });
+    });
+
+    describe('label', () => {
+      it('is the pattern', () => {
+        const rule = new PatternOwnersRule('OWNERS.yaml', [], '*.css');
+
+        expect(rule.label).toEqual('*.css');
       });
     });
 

--- a/owners/test/rules.test.js
+++ b/owners/test/rules.test.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-const {OwnersRule, PatternOwnersRule} = require('../src/rules');
+const {
+  OwnersRule,
+  PatternOwnersRule,
+  SameDirPatternOwnersRule,
+} = require('../src/rules');
 
 describe('owners rules', () => {
   expect.extend({
@@ -110,14 +114,10 @@ describe('owners rules', () => {
         );
       });
 
-      it.each([
-        ['package.json', 'foo/package.json'],
-        ['*.js', 'bar/main.js'],
-        ['*.css', 'foo/bar/baz/style.css'],
-      ])('pattern %p matches nested file %p', (pattern, filePath) => {
-        expect(new PatternOwnersRule('OWNERS.yaml', [], pattern)).toMatchFile(
-          filePath
-        );
+      it('fails for non-matching patterns', () => {
+        const rule = new PatternOwnersRule('OWNERS.yaml', [], '*.js');
+
+        expect(rule).not.toMatchFile('style.css');
       });
     });
 
@@ -138,6 +138,36 @@ describe('owners rules', () => {
         );
 
         expect(rule.toString()).toEqual('*.css: rcebulko, erwinmombay');
+      });
+    });
+
+    describe('in the same directory', () => {
+      const rule = new SameDirPatternOwnersRule('foo/OWNERS.yaml', [], '*.js');
+
+      describe('label', () => {
+        it('is the pattern in the "./" directory', () => {
+          expect(rule.label).toEqual('./*.js');
+        });
+      });
+
+      describe('matchesFile', () => {
+        it('fails if there is no pattern match', () => {
+          expect(rule).not.toMatchFile('style.css');
+        });
+
+        it('fails for files in subdirectories', () => {
+          expect(rule).not.toMatchFile('foo/bar/code.js');
+        });
+
+        it('passes for matching files in the same directory', () => {
+          expect(rule).toMatchFile('foo/main.js');
+        });
+
+        it('works for files and rules in the root directory', () => {
+          expect(
+            new SameDirPatternOwnersRule('OWNERS.yaml', [], '*.js')
+          ).toMatchFile('main.js');
+        });
       });
     });
   });

--- a/owners/test/rules.test.js
+++ b/owners/test/rules.test.js
@@ -125,7 +125,7 @@ describe('owners rules', () => {
       it('is the pattern', () => {
         const rule = new PatternOwnersRule('OWNERS.yaml', [], '*.css');
 
-        expect(rule.label).toEqual('*.css');
+        expect(rule.label).toEqual('**/*.css');
       });
     });
 
@@ -137,7 +137,7 @@ describe('owners rules', () => {
           '*.css'
         );
 
-        expect(rule.toString()).toEqual('*.css: rcebulko, erwinmombay');
+        expect(rule.toString()).toEqual('**/*.css: rcebulko, erwinmombay');
       });
     });
 


### PR DESCRIPTION
Note that this only implements the test itself; parsing the difference between recursive and same-directory rules is a job left to the parser, and is yet to be implemented (just like with the `PatternOwnersRule`)