### PR TITLE
Add support for glob and pattern parsing + improve testing and error handling

### DIFF
--- a/owners/OWNERS.example.yaml
+++ b/owners/OWNERS.example.yaml
@@ -1,0 +1,64 @@
+# OWNERS files support standard YAML syntax, including comments and blank lines.
+# In this file, "this directory" refers to the directory containing the
+# OWNERS.yaml file.
+
+# IMPORTANT NOTE: YAML syntax does not like non-alphanumeric characters to start
+# dictionary keys, so patterns or globs starting with `*` must be wrapped in
+# quotes to ensure it is parsed correctly. For consistency, it is preferred to 
+# wrap all patterns and globs in quotes.
+
+# The top-level structure must be a list. Any usernames in this top-level list
+# will be considered owners of all files and subdirectories of this directory.
+- someuser
+- anotheruser
+
+# Usernames should not be prefixed with '@'. This will raise a parsing error.
+# - @dontdothis
+- dothisinstead
+- "@thiswillworkbutdontdoit"
+
+# Teams are not supported. The following owner declaration will be ignored.
+- teams/arenotsupported
+
+# Individual filenames can be listed, with owners as the value. The value can be
+# a single owner on the same line, or a list of many on the following lines.
+# These users own the file matching that name within this directory. For
+# example, if this file were in the root directory, the first rule below means
+# `fileowner` owns `./package.json` but not `./examples/package.json`.
+- package.json: fileowner
+- .eslintrc:
+  - styleperson
+  - infraperson
+
+# Glob-like patterns may be used in place of literal filenames. In these
+# patterns, a star `*` can represent any sequence of characters. These patterns
+# follow the same directory rules as above, so the pattern `*.js` applies to
+# `./main.js` and `./index.js` but not `./extensions/script.js`.
+- "*.js": scripter
+- "package*.json":
+  - infraperson
+  - developer
+
+# To apply a filename or pattern to all subdirectories as well, prefix the
+# pattern with `**/`. The pattern `**/.eslintrc` applies to
+# `./.eslintrc` as well as `./foo/.eslintrc`. The pattern `**/*.protoascii`
+# applies to `./test.protoascii` as well as `./foo/example.protoascii`.
+- "**/.eslintrc": styleperson
+- "**/*.protoascii":
+  - languageperson
+  - translator
+
+# Any other use of `/` in a pattern is forbidden (ie. no directory traversal).
+# Patterns using `/` will be ignored. If rules are needed in a subdirectory, the
+# appropriate OWNERS file should be created/updated in that subdirectory.
+- this/pattern/will/be/ignored.txt: doesntmatter
+
+# The result of parsing this file would be a tree with these rules:
+#
+# All files:       someuser, anotheruser, dothisinstead, thiswillworkbutdontdoit
+# ./package.json:  fileowner
+# ./.eslintrc:     styleperson, infraperson
+# ./*.js:          scripter
+# ./package*.json: infraperson, developer
+# **/.eslintrc:    styleperson
+# **/*.protoascii: languageperson, translator

--- a/owners/OWNERS.example.yaml
+++ b/owners/OWNERS.example.yaml
@@ -53,6 +53,13 @@
 # appropriate OWNERS file should be created/updated in that subdirectory.
 - this/pattern/will/be/ignored.txt: doesntmatter
 
+# Filename and pattern rules may be combined with commas. They will be treated
+# as separate rules. An error in one sub-pattern will not block the rest from
+# being parsed.
+- "*.js, *.css": frontend
+- "a/bad/pattern, package.json, **/.eslintrc": somebodyelse
+
+
 # The result of parsing this file would be a tree with these rules:
 #
 # All files:       someuser, anotheruser, dothisinstead, thiswillworkbutdontdoit
@@ -62,3 +69,7 @@
 # ./package*.json: infraperson, developer
 # **/.eslintrc:    styleperson
 # **/*.protoascii: languageperson, translator
+# *.js:            frontend
+# *.css:           frontend
+# package.json:    somebodyelse
+# **/.eslintrc:    somebodyelse

--- a/owners/index.js
+++ b/owners/index.js
@@ -62,12 +62,14 @@ module.exports = app => {
     const treeParse = await parser.parseOwnersTree();
     const treeHeader = '<h3>OWNERS tree</h3>';
     const treeDisplay = `<pre>${treeParse.result.toString()}</pre>`;
-    const errorHeader = '<h3>Parser Errors</h3>';
-    const errorDisplay = treeParse.errors.map(error => error.toString());
 
     let output = `${treeHeader}${treeDisplay}`;
     if (treeParse.errors.length) {
-      output += `${errorHeader}${errorDisplay}`;
+      const errorHeader = '<h3>Parser Errors</h3>';
+      const errorDisplay = treeParse.errors
+        .map(error => error.toString())
+        .join('<br>');
+      output += `${errorHeader}<code>${errorDisplay}</code>`;
     }
 
     res.send(output);

--- a/owners/index.js
+++ b/owners/index.js
@@ -59,14 +59,14 @@ module.exports = app => {
 
   adminRouter.get('/tree', async (req, res) => {
     const parser = new OwnersParser(localRepo, req.log);
-    const {tree, errors} = await parser.parseOwnersTree();
+    const treeParse = await parser.parseOwnersTree();
     const treeHeader = '<h3>OWNERS tree</h3>';
-    const treeDisplay = `<pre>${tree.toString()}</pre>`;
+    const treeDisplay = `<pre>${treeParse.result.toString()}</pre>`;
     const errorHeader = '<h3>Parser Errors</h3>';
-    const errorDisplay = errors.map(error => error.toString());
+    const errorDisplay = treeParse.errors.map(error => error.toString());
 
     let output = `${treeHeader}${treeDisplay}`;
-    if (errors.length) {
+    if (treeParse.errors.length) {
       output += `${errorHeader}${errorDisplay}`;
     }
 

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -88,13 +88,13 @@ class OwnersCheck {
    */
   async init() {
     await this.repo.checkout();
-    const {tree, errors} = await this.parser.parseOwnersTree();
+    const treeParse = await this.parser.parseOwnersTree();
 
-    errors.forEach(error => {
+    treeParse.errors.forEach(error => {
       console.warn(error);
     });
 
-    this.tree = tree;
+    this.tree = treeParse.result;
     this.approvers = await this._getApprovers();
     this.changedFiles = await this.github.listFiles(this.pr.number);
     this.initialized = true;

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -152,7 +152,7 @@ class OwnersParser {
         errors.push(
           new OwnersParserError(
             ownersPath,
-            `Failed to parse rule for pattern '${subpattern}';' ` +
+            `Failed to parse rule for pattern '${subpattern}'; ` +
               "directory patterns other than '**/' not supported"
           )
         );

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -22,7 +22,7 @@ const {
 } = require('./rules');
 const {OwnersTree} = require('./owners_tree');
 
-const GLOB_PATTERN = '**/'
+const GLOB_PATTERN = '**/';
 
 /**
  * An error encountered parsing an OWNERS file

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -98,6 +98,27 @@ class OwnersParser {
   }
 
   /**
+   * Parse a list of owners.
+   *
+   * @private
+   * @param {!string} ownersPath OWNERS.yaml file path (for error reporting).
+   * @param {string[]} ownersList list of owners.
+   * @return {OwnersParserResult<string[]>} list of owners' usernames.
+   */
+  _parseOwnersList(ownersPath, ownersList) {
+    const owners = [];
+    const errors = [];
+
+    ownersList.forEach(owner => {
+      const lineResult = this._parseOwnersLine(ownersPath, owner);
+      owners.push(...lineResult.result);
+      errors.push(...lineResult.errors);
+    });
+
+    return {result: owners, errors};
+  }
+
+  /**
    * Parse an OWNERS.yaml file.
    *
    * @param {!string} ownersPath OWNERS.yaml file path (for error reporting).
@@ -112,15 +133,10 @@ class OwnersParser {
     if (lines instanceof Array) {
       const stringLines = lines.filter(line => typeof line === 'string');
 
-      const ownersList = [];
-      stringLines.forEach(line => {
-        const lineResult = this._parseOwnersLine(ownersPath, line);
-        ownersList.push(...lineResult.result);
-        errors.push(...lineResult.errors);
-      });
-
-      if (ownersList.length) {
-        rules.push(new OwnersRule(ownersPath, ownersList));
+      const fileOwners = this._parseOwnersList(ownersPath, stringLines);
+      errors.push(...fileOwners.errors);
+      if (fileOwners.result.length) {
+        rules.push(new OwnersRule(ownersPath, fileOwners.result));
       }
     } else {
       errors.push(

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -22,6 +22,8 @@ const {
 } = require('./rules');
 const {OwnersTree} = require('./owners_tree');
 
+const GLOB_PATTERN = '**/'
+
 /**
  * An error encountered parsing an OWNERS file
  */
@@ -143,9 +145,9 @@ class OwnersParser {
     // Treat each comma-separated subpattern as its own rule definition.
     pattern.split(/\s*,\s*/).forEach(subpattern => {
       const owners = [];
-      const isRecursive = subpattern.indexOf('**/') === 0;
+      const isRecursive = subpattern.startsWith(GLOB_PATTERN);
       if (isRecursive) {
-        subpattern = subpattern.slice(3);
+        subpattern = subpattern.slice(GLOB_PATTERN.length);
       }
 
       if (subpattern.indexOf('/') !== -1) {
@@ -153,7 +155,7 @@ class OwnersParser {
           new OwnersParserError(
             ownersPath,
             `Failed to parse rule for pattern '${subpattern}'; ` +
-              "directory patterns other than '**/' not supported"
+              `directory patterns other than '${GLOB_PATTERN}' not supported`
           )
         );
       } else if (typeof ownersList === 'string') {

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -73,7 +73,7 @@ class OwnersParser {
       );
     }
 
-    return {rules, errors};
+    return {result: rules, errors};
   }
 
   /**
@@ -86,31 +86,32 @@ class OwnersParser {
    */
   async parseAllOwnersRules() {
     const ownersPaths = await this.localRepo.findOwnersFiles();
-    const allRules = [];
-    const allErrors = [];
+    const rules = [];
+    const errors = [];
 
     ownersPaths.forEach(ownersPath => {
-      const {rules, errors} = this.parseOwnersFile(ownersPath);
-      allRules.push(...rules);
-      allErrors.push(...errors);
+      const fileParse = this.parseOwnersFile(ownersPath);
+      rules.push(...fileParse.result);
+      errors.push(...fileParse.errors);
     });
 
     return {
-      rules: allRules,
-      errors: allErrors,
+      result: rules,
+      errors,
     };
   }
 
   /**
    * Parse all OWNERS rules into a tree.
    *
-   * @return {{tree: OwnersTree, errors: OwnersParserError[]}} owners rule hierarchy.
+   * @return {OwnersParserResult<OwnersTree>} owners rule hierarchy.
    */
   async parseOwnersTree() {
     const tree = new OwnersTree(this.localRepo.rootPath);
-    const {rules, errors} = await this.parseAllOwnersRules();
-    rules.forEach(rule => tree.addRule(rule));
-    return {tree, errors};
+    const ruleParse = await this.parseAllOwnersRules();
+    ruleParse.result.forEach(rule => tree.addRule(rule));
+    
+    return {result: tree, errors: ruleParse.errors};
   }
 }
 

--- a/owners/src/types.js
+++ b/owners/src/types.js
@@ -43,11 +43,11 @@ let FileTreeMap;
 let ReviewerFiles;
 
 /**
- * The result of parsing OWNERS rules, along with any errors encountered.
+ * The result of parsing OWNERS files, along with any errors encountered.
  *
  * @template T
  * @typedef {{
- *   rules: T,
+ *   result: T,
  *   errors: OwnersParserError[],
  * }}
  */

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -63,7 +63,7 @@ describe('owners bot', () => {
     sandbox.stub(LocalRepository.prototype, 'checkout');
     sandbox
       .stub(OwnersParser.prototype, 'parseAllOwnersRules')
-      .returns({rules: ownersRules});
+      .returns({result: ownersRules, errors: []});
 
     probot = new Probot({});
     const app = probot.load(owners);

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -134,11 +134,12 @@ describe('owners check', () => {
     beforeEach(() => {
       ownersCheck = new OwnersCheck(repo, github, pr);
       sandbox.stub(ownersCheck.parser, 'parseAllOwnersRules').returns({
-        rules: [
+        result: [
           new OwnersRule('OWNERS.yaml', ['root_owner']),
           new OwnersRule('foo/OWNERS.yaml', ['approver', 'some_user']),
           new OwnersRule('bar/OWNERS.yaml', ['other_approver']),
         ],
+        errors: [],
       });
     });
 
@@ -293,11 +294,12 @@ describe('owners check', () => {
       ownersCheck = new OwnersCheck(repo, github, pr);
 
       sandbox.stub(ownersCheck.parser, 'parseAllOwnersRules').returns({
-        rules: [
+        result: [
           new OwnersRule('OWNERS.yaml', ['root_owner']),
           new OwnersRule('foo/OWNERS.yaml', ['approver', 'some_user']),
           new OwnersRule('bar/OWNERS.yaml', ['other_approver']),
         ],
+        errors: [],
       });
 
       await ownersCheck.init();
@@ -394,12 +396,13 @@ describe('owners check', () => {
         pr
       );
       sandbox.stub(ownersCheck.parser, 'parseAllOwnersRules').returns({
-        rules: [
+        result: [
           new OwnersRule('OWNERS.yaml', ['root_owner']),
           new OwnersRule('foo/OWNERS.yaml', ['approver', 'some_user']),
           new OwnersRule('bar/OWNERS.yaml', ['other_approver']),
           new OwnersRule('buzz/OWNERS.yaml', ['the_author']),
         ],
+        errors: [],
       });
     });
 

--- a/owners/test/parser.test.js
+++ b/owners/test/parser.test.js
@@ -169,6 +169,15 @@ describe('owners parser', () => {
           "Failed to parse rule for pattern 'foo/*.js'; directory patterns other than '**/' not supported"
         );
       });
+
+      it('parses comma-separate patterns as separate rules', () => {
+        sandbox.stub(repo, 'readFile').returns('- *.js, *.css: frontend\n');
+        const fileParse = parser.parseOwnersFile('');
+        const rules = fileParse.result;
+
+        expect(rules[0].pattern).toEqual('*.js');
+        expect(rules[1].pattern).toEqual('*.css');
+      });
     });
 
     describe('files containing top-level dictionaries', () => {

--- a/owners/test/parser.test.js
+++ b/owners/test/parser.test.js
@@ -30,28 +30,32 @@ describe('owners parser', () => {
 
     it('assigns the OWNERS directory path', () => {
       sandbox.stub(repo, 'readFile').returns('- owner');
-      const {rules} = parser.parseOwnersFile('foo/OWNERS.yaml');
+      const fileParse = parser.parseOwnersFile('foo/OWNERS.yaml');
+      const rules = fileParse.result;
 
       expect(rules[0].dirPath).toEqual('foo');
     });
 
     it('parses a YAML list', () => {
       sandbox.stub(repo, 'readFile').returns('- user1\n- user2\n');
-      const {rules} = parser.parseOwnersFile('');
+      const fileParse = parser.parseOwnersFile('');
+      const rules = fileParse.result;
 
       expect(rules[0].owners).toEqual(['user1', 'user2']);
     });
 
     it('parses a YAML list with blank lines and comments', () => {
       sandbox.stub(repo, 'readFile').returns('- user1\n# comment\n\n- user2\n');
-      const {rules} = parser.parseOwnersFile('');
+      const fileParse = parser.parseOwnersFile('');
+      const rules = fileParse.result;
 
       expect(rules[0].owners).toEqual(['user1', 'user2']);
     });
 
     it('returns no rule for team rules', () => {
       sandbox.stub(repo, 'readFile').returns('- ampproject/team\n');
-      const {rules} = parser.parseOwnersFile('');
+      const fileParse = parser.parseOwnersFile('');
+      const rules = fileParse.result;
 
       expect(rules).toEqual([]);
     });
@@ -63,7 +67,8 @@ describe('owners parser', () => {
           .returns('dict:\n  key: "value"\n  key2: "value2"\n');
       });
       it('returns no rule', () => {
-        const {rules} = parser.parseOwnersFile('');
+        const fileParse = parser.parseOwnersFile('');
+        const rules = fileParse.result;
 
         expect(rules).toEqual([]);
       });
@@ -81,7 +86,8 @@ describe('owners parser', () => {
       sandbox
         .stub(repo, 'readFile')
         .returns('- owner\n- dict:\n  key: "value"\n  key2: "value2"\n');
-      const {rules} = parser.parseOwnersFile('');
+      const fileParse = parser.parseOwnersFile('');
+      const rules = fileParse.result;
 
       expect(rules.length).toEqual(1);
     });
@@ -95,7 +101,8 @@ describe('owners parser', () => {
       const readFileStub = sandbox.stub(repo, 'readFile');
       readFileStub.onCall(0).returns('- user1\n- user2\n');
       readFileStub.onCall(1).returns('- user3\n- user4\n');
-      const {rules} = await parser.parseAllOwnersRules();
+      const ruleParse = await parser.parseAllOwnersRules();
+      const rules = ruleParse.result;
 
       expect(rules[0].dirPath).toEqual('.');
       expect(rules[1].dirPath).toEqual('foo');
@@ -106,7 +113,8 @@ describe('owners parser', () => {
     it('does not include invalid rules', async () => {
       sandbox.stub(repo, 'findOwnersFiles').returns(['OWNERS.yaml']);
       sandbox.stub(repo, 'readFile').returns('dict:\n  key: value');
-      const {rules} = await parser.parseAllOwnersRules();
+      const ruleParse = await parser.parseAllOwnersRules();
+      const rules = ruleParse.result;
 
       expect(rules).toEqual([]);
     });
@@ -129,8 +137,9 @@ describe('owners parser', () => {
     it('adds each rule to the tree', async () => {
       sandbox
         .stub(parser, 'parseAllOwnersRules')
-        .returns({rules: [rootRule, childRule], errors: []});
-      const {tree} = await parser.parseOwnersTree();
+        .returns({result: [rootRule, childRule], errors: []});
+      const treeParse = await parser.parseOwnersTree();
+      const tree = treeParse.result;
 
       expect(tree.rules).toContain(rootRule);
       expect(tree.get('foo').rules).toContain(childRule);
@@ -139,7 +148,7 @@ describe('owners parser', () => {
     it('returns parser errors', async () => {
       sandbox
         .stub(parser, 'parseAllOwnersRules')
-        .returns({rules: [], errors: [new Error('Oops!')]});
+        .returns({result: [], errors: [new Error('Oops!')]});
       const {errors} = await parser.parseOwnersTree();
 
       expect(errors[0].message).toEqual('Oops!');

--- a/owners/test/parser.test.js
+++ b/owners/test/parser.test.js
@@ -111,7 +111,6 @@ describe('owners parser', () => {
     describe('rule dictionary', () => {
       it('parses a single owner into a pattern rule', () => {
         sandbox.stub(repo, 'readFile').returns('- *.js: scripty\n');
-
         const fileParse = parser.parseOwnersFile('');
         const rules = fileParse.result;
 
@@ -124,7 +123,6 @@ describe('owners parser', () => {
         sandbox
           .stub(repo, 'readFile')
           .returns('- *.js:\n  - scripty\n  - coder\n');
-
         const fileParse = parser.parseOwnersFile('');
         const rules = fileParse.result;
 
@@ -146,13 +144,30 @@ describe('owners parser', () => {
 
       it('starting with **/ parses into a recursive pattern rule', () => {
         sandbox.stub(repo, 'readFile').returns('- **/*.js: scripty\n');
-
         const fileParse = parser.parseOwnersFile('');
         const rules = fileParse.result;
 
         expect(rules[0]).toBeInstanceOf(PatternOwnersRule);
         expect(rules[0].pattern).toEqual('*.js');
         expect(rules[0].owners).toEqual(['scripty']);
+      });
+
+      it('parses no rule if no valid owners are listed', () => {
+        sandbox.stub(repo, 'readFile').returns('- *.js: bad/team_owner\n');
+        const fileParse = parser.parseOwnersFile('');
+        const rules = fileParse.result;
+
+        expect(rules.length).toEqual(0);
+      });
+
+      it("reports an error for patterns containing illegal '/'", () => {
+        sandbox.stub(repo, 'readFile').returns('- foo/*.js: scripty\n');
+        const fileParse = parser.parseOwnersFile('');
+
+        expect(fileParse.result.length).toEqual(0);
+        expect(fileParse.errors[0].message).toEqual(
+          "Failed to parse rule for pattern 'foo/*.js'; directory patterns other than '**/' not supported"
+        );
       });
     });
 


### PR DESCRIPTION
See the added `OWNERS.example.yaml` for supported syntax.
Closes #278 
Closes #282 

As a summary/guide to understanding and reviewing the parser, here is the Jest test summary for the module:

```
owners parser error
  toString
    ✓ displays the file containing the error
    ✓ displays the error message

owners parser
  parseOwnersFile
    ✓ reads the file from the local repository
    ✓ assigns the OWNERS directory path
    ✓ parses a YAML list
    ✓ parses a YAML list with blank lines and comments
    team rule declarations
      ✓ returns no rule
      ✓ records an error
    owner with a leading @
      ✓ parses ignoring the @ sign
      ✓ records an error
    rule dictionary
      ✓ parses a single owner into a pattern rule
      ✓ parses a list of owners into a pattern rule
      ✓ reports errors for non-string owners
      ✓ starting with **/ parses into a recursive pattern rule
      ✓ parses no rule if no valid owners are listed
      ✓ reports an error for patterns containing illegal '/'
      ✓ parses comma-separate patterns as separate rules
    files containing top-level dictionaries
      ✓ returns no rules
      ✓ returns a parser error
  parseAllOwnersRules
    ✓ reads all owners files in the repo
    ✓ does not include invalid rules
    ✓ collects errors from all parsed files
  parseOwnersTree
    ✓ adds each rule to the tree
    ✓ returns parser errors
```