### PR TITLE
Make failing checks red on PR

### DIFF
--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -110,7 +110,7 @@ class OwnersCheck {
         reviewSuggestions
       );
       return new CheckRun(
-        CheckRunConclusion.NEUTRAL,
+        CheckRunConclusion.FAILURE,
         `Missing required OWNERS approvals! Suggested reviewers: ${reviewers}`,
         `${coverageText}\n\n${suggestionsText}`
       );

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -22,7 +22,7 @@ const CheckRunConclusion = {
   SUCCESS: 'success',
   FAILURE: 'failure',
   NEUTRAL: 'neutral',
-  ACTION_REQUIRED: 'action_required', 
+  ACTION_REQUIRED: 'action_required',
 };
 
 /**

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -22,6 +22,7 @@ const CheckRunConclusion = {
   SUCCESS: 'success',
   FAILURE: 'failure',
   NEUTRAL: 'neutral',
+  ACTION_REQUIRED: 'action_required', 
 };
 
 /**
@@ -110,7 +111,7 @@ class OwnersCheck {
         reviewSuggestions
       );
       return new CheckRun(
-        CheckRunConclusion.FAILURE,
+        CheckRunConclusion.ACTION_REQUIRED,
         `Missing required OWNERS approvals! Suggested reviewers: ${reviewers}`,
         `${coverageText}\n\n${suggestionsText}`
       );

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -106,7 +106,7 @@ describe('owners bot', () => {
           '/repos/erwinmombay/github-owners-bot-test-repo/check-runs/53472315',
           body => {
             expect(body).toMatchObject({
-              conclusion: 'failure',
+              conclusion: 'action_required',
               output: {
                 title:
                   'Missing required OWNERS approvals! Suggested reviewers: erwinmombay',
@@ -167,7 +167,7 @@ describe('owners bot', () => {
               name: 'ampproject/owners-check',
               head_sha: opened35.pull_request.head.sha,
               status: 'completed',
-              conclusion: 'failure',
+              conclusion: 'action_required',
               output: {
                 title:
                   'Missing required OWNERS approvals! Suggested reviewers: erwinmombay',
@@ -224,7 +224,7 @@ describe('owners bot', () => {
           '/repos/erwinmombay/github-owners-bot-test-repo/check-runs/53472313',
           body => {
             expect(body).toMatchObject({
-              conclusion: 'failure',
+              conclusion: 'action_required',
               output: {
                 title:
                   'Missing required OWNERS approvals! Suggested reviewers: erwinmombay',
@@ -279,7 +279,7 @@ describe('owners bot', () => {
           '/repos/erwinmombay/github-owners-bot-test-repo/check-runs/53472313',
           body => {
             expect(body).toMatchObject({
-              conclusion: 'failure',
+              conclusion: 'action_required',
               output: {
                 title:
                   'Missing required OWNERS approvals! Suggested reviewers: erwinmombay',
@@ -347,7 +347,7 @@ describe('owners bot', () => {
               name: 'ampproject/owners-check',
               head_sha: opened35.pull_request.head.sha,
               status: 'completed',
-              conclusion: 'failure',
+              conclusion: 'action_required',
               output: {
                 title:
                   'Missing required OWNERS approvals! Suggested reviewers: erwinmombay',

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -106,7 +106,7 @@ describe('owners bot', () => {
           '/repos/erwinmombay/github-owners-bot-test-repo/check-runs/53472315',
           body => {
             expect(body).toMatchObject({
-              conclusion: 'neutral',
+              conclusion: 'failure',
               output: {
                 title:
                   'Missing required OWNERS approvals! Suggested reviewers: erwinmombay',
@@ -167,7 +167,7 @@ describe('owners bot', () => {
               name: 'ampproject/owners-check',
               head_sha: opened35.pull_request.head.sha,
               status: 'completed',
-              conclusion: 'neutral',
+              conclusion: 'failure',
               output: {
                 title:
                   'Missing required OWNERS approvals! Suggested reviewers: erwinmombay',
@@ -224,7 +224,7 @@ describe('owners bot', () => {
           '/repos/erwinmombay/github-owners-bot-test-repo/check-runs/53472313',
           body => {
             expect(body).toMatchObject({
-              conclusion: 'neutral',
+              conclusion: 'failure',
               output: {
                 title:
                   'Missing required OWNERS approvals! Suggested reviewers: erwinmombay',
@@ -279,7 +279,7 @@ describe('owners bot', () => {
           '/repos/erwinmombay/github-owners-bot-test-repo/check-runs/53472313',
           body => {
             expect(body).toMatchObject({
-              conclusion: 'neutral',
+              conclusion: 'failure',
               output: {
                 title:
                   'Missing required OWNERS approvals! Suggested reviewers: erwinmombay',
@@ -347,7 +347,7 @@ describe('owners bot', () => {
               name: 'ampproject/owners-check',
               head_sha: opened35.pull_request.head.sha,
               status: 'completed',
-              conclusion: 'neutral',
+              conclusion: 'failure',
               output: {
                 title:
                   'Missing required OWNERS approvals! Suggested reviewers: erwinmombay',

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -131,11 +131,10 @@ describe('owners check', () => {
       });
 
       describe('for a PR requiring approvals', () => {
-        // TODO(rcebulko): Update once this is changed to a blocking check.
-        it('has a neutral conclusion', () => {
+        it('has a failure conclusion', () => {
           const checkRun = ownersCheck.run();
 
-          expect(checkRun.json.conclusion).toEqual('neutral');
+          expect(checkRun.json.conclusion).toEqual('failure');
         });
 
         it('has a failing summary', () => {
@@ -170,7 +169,6 @@ describe('owners check', () => {
             .throws(new Error('Something is wrong'));
         });
 
-        // TODO(rcebulko): Update once this is changed to a blocking check.
         it('has a neutral conclusion', () => {
           const checkRun = ownersCheck.run();
 

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -131,10 +131,10 @@ describe('owners check', () => {
       });
 
       describe('for a PR requiring approvals', () => {
-        it('has a failure conclusion', () => {
+        it('has an action-required conclusion', () => {
           const checkRun = ownersCheck.run();
 
-          expect(checkRun.json.conclusion).toEqual('failure');
+          expect(checkRun.json.conclusion).toEqual('action_required');
         });
 
         it('has a failing summary', () => {


### PR DESCRIPTION
With this, a failing check will have status 'failure' while a passing check will have status 'passing'. Currently, if there's an error, the status will remain 'neutral'. Possible statuses also include 'canceled' or 'action_required'. Do the current statuses seem fine, or do y'all have any suggestions on what should be adjusted?