### PR TITLE
Update getCheckRunId to support multiple different checks

### DIFF
--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -21,7 +21,7 @@ class PullRequest {
   /**
    * Constructor.
    *
-   * @param {!number} number pull request number.
+   * @param {number} number pull request number.
    * @param {!string} author username of the pull request author.
    * @param {!string} headSha SHA hash of the PR's HEAD commit.
    */
@@ -67,7 +67,7 @@ class Team {
   /**
    * Constructor.
    *
-   * @param {!number} id team ID.
+   * @param {number} id team ID.
    * @param {!string} org GitHub organization the team belongs to.
    * @param {!string} slug team name slug.
    */
@@ -185,7 +185,7 @@ class GitHub {
   /**
    * Fetch all members of a team.
    *
-   * @param {!number} teamId ID of team to find members for.
+   * @param {number} teamId ID of team to find members for.
    * @return {string[]} list of member usernames.
    */
   async getTeamMembers(teamId) {
@@ -201,7 +201,7 @@ class GitHub {
   /**
    * Fetches a pull request.
    *
-   * @param {!number} number pull request number.
+   * @param {number} number pull request number.
    * @return {PullRequest} pull request instance.
    */
   async getPullRequest(number) {
@@ -212,7 +212,7 @@ class GitHub {
   /**
    * Retrives code reviews for a PR from GitHub.
    *
-   * @param {!number} number PR number.
+   * @param {number} number PR number.
    * @return {Review[]} the list of code reviews.
    */
   async getReviews(number) {
@@ -251,7 +251,7 @@ class GitHub {
   /**
    * Lists all modified files for a PR.
    *
-   * @param {!number} number PR number
+   * @param {number} number PR number
    * @return {FileRef[]} list of relative file paths.
    */
   async listFiles(number) {
@@ -293,7 +293,7 @@ class GitHub {
    * will return `null`.
    *
    * @param {!string} sha SHA hash for head commit to lookup check-runs on.
-   * @return {Object<!string, !number>} map from check names to check-run IDs.
+   * @return {Object<!string, number>} map from check names to check-run IDs.
    */
   async getCheckRunIds(sha) {
     this.logger.info(`Fetching check run ID for commit ${sha.substr(0, 7)}`);
@@ -329,7 +329,7 @@ class GitHub {
   /**
    * Updates the check-run status for a commit.
    *
-   * @param {!number} id ID of check-run data to update.
+   * @param {number} id ID of check-run data to update.
    * @param {!CheckRun} checkRun check-run data to update.
    */
   async updateCheckRun(id, checkRun) {

--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -312,14 +312,16 @@ class GitHub {
     this.logger.debug('[getCheckRunIds]', sha, checkRuns);
 
     const checkRunIds = {};
-    checkRuns.filter(cr => cr.head_sha === sha).forEach(checkRun => {
-      const [owner, checkName] = checkRun.name.split('/');
-      // Always take the first matching result, since the response is in
-      // most-recent-first order.
-      if (!checkRunIds[checkName]) {
-        checkRunIds[checkName] = checkRun.id;
-      }
-    });
+    checkRuns
+      .filter(cr => cr.head_sha === sha)
+      .forEach(checkRun => {
+        const checkName = checkRun.name.split('/')[1];
+        // Always take the first matching result, since the response is in
+        // most-recent-first order.
+        if (!checkRunIds[checkName]) {
+          checkRunIds[checkName] = checkRun.id;
+        }
+      });
 
     return checkRunIds;
   }

--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -309,9 +309,9 @@ class GitHub {
       return {};
     }
 
-    this.logger.debug('[getCheckRunId]', sha, checkRuns);
+    this.logger.debug('[getCheckRunIds]', sha, checkRuns);
 
-    let checkRunIds = {};
+    const checkRunIds = {};
     checkRuns.filter(cr => cr.head_sha === sha).forEach(checkRun => {
       const [owner, checkName] = checkRun.name.split('/');
       // Always take the first matching result, since the response is in

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -21,6 +21,7 @@ const {OwnersParser} = require('./parser');
 
 const GITHUB_CHECKRUN_DELAY = 2000;
 const GITHUB_GET_MEMBERS_DELAY = 3000;
+const OWNERS_CHECKRUN_NAME = 'owners-check';
 
 /**
  * Bot to run the owners check and create/update the GitHub check-run.
@@ -94,7 +95,9 @@ class OwnersBot {
   async runOwnersCheck(github, pr) {
     const {tree, approvers, changedFiles} = await this.initPr(github, pr);
     const ownersCheck = new OwnersCheck(tree, approvers, changedFiles);
-    const checkRunId = await github.getCheckRunId(pr.headSha);
+    const checkRunIdMap = await github.getCheckRunIds(pr.headSha);
+    // TODO(rcebulko): Make this into a loop through multiple check/name pairs.
+    const checkRunId = checkRunIdMap[OWNERS_CHECKRUN_NAME];
     const latestCheckRun = ownersCheck.run();
 
     if (checkRunId) {

--- a/owners/test/fixtures/check-runs/check-runs.get.35.multiple.json
+++ b/owners/test/fixtures/check-runs/check-runs.get.35.multiple.json
@@ -1,5 +1,5 @@
 {
-    "total_count": 1,
+    "total_count": 2,
     "check_runs": [
         {
             "id": 53472315,
@@ -99,7 +99,7 @@
                 "annotations_count": 0,
                 "annotations_url": "https://api.github.com/repos/erwinmombay/github-owners-bot-test-repo/check-runs/53472313/annotations"
             },
-            "name": "some other check from the same bot",
+            "name": "ampproject/another-check",
             "check_suite": {
                 "id": 52508974
             },

--- a/owners/test/github.test.js
+++ b/owners/test/github.test.js
@@ -363,19 +363,20 @@ describe('GitHub API', () => {
     });
   });
 
-  describe('getCheckRunId', () => {
+  describe('getCheckRunIds', () => {
     it('fetches the first matching check-run from the list', async () => {
-      expect.assertions(1);
+      expect.assertions(2);
       const sha = '9272f18514cbd3fa935b3ced62ae1c2bf6efa76d';
       nock('https://api.github.com')
         .get(`/repos/test_owner/test_repo/commits/${sha}/check-runs`)
         .reply(200, checkRunsListResponse);
 
       await withContext(async (context, github) => {
-        const checkRunId = await github.getCheckRunId(sha);
+        const checkRunIds = await github.getCheckRunIds(sha);
 
         // ID pulled from check-runs.get.35.multiple
-        expect(checkRunId).toEqual(53472315);
+        expect(checkRunIds['owners-check']).toEqual(53472315);
+        expect(checkRunIds['another-check']).toEqual(53472313);
       })();
     });
 
@@ -386,9 +387,9 @@ describe('GitHub API', () => {
         .reply(200, checkRunsListResponse);
 
       await withContext(async (context, github) => {
-        const checkRun = await github.getCheckRunId('_missing_hash_');
+        const checkRunIds = await github.getCheckRunIds('_missing_hash_');
 
-        expect(checkRun).toBeNull();
+        expect(checkRunIds['owners-check']).toBeUndefined();
       })();
     });
 
@@ -399,9 +400,9 @@ describe('GitHub API', () => {
         .reply(200, checkRunsEmptyResponse);
 
       await withContext(async (context, github) => {
-        const checkRun = await github.getCheckRunId('_test_hash_');
+        const checkRunIds = await github.getCheckRunIds('_test_hash_');
 
-        expect(checkRun).toBeNull();
+        expect(checkRunIds['owners-check']).toBeUndefined();
       })();
     });
 
@@ -415,9 +416,9 @@ describe('GitHub API', () => {
         });
 
       await withContext(async (context, github) => {
-        const checkRun = await github.getCheckRunId('_test_hash_');
+        const checkRunIds = await github.getCheckRunIds('_test_hash_');
 
-        expect(checkRun).toBeNull();
+        expect(checkRunIds['owners-check']).toBeUndefined();
       })();
     });
   });

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -141,10 +141,10 @@ describe('owners bot', () => {
       'Success!',
       'The owners check passed.'
     );
-    let getCheckRunIdStub;
+    let getCheckRunIdsStub;
 
     beforeEach(() => {
-      getCheckRunIdStub = sandbox.stub(GitHub.prototype, 'getCheckRunId');
+      getCheckRunIdsStub = sandbox.stub(GitHub.prototype, 'getCheckRunIds');
       sandbox.stub(OwnersCheck.prototype, 'run').returns(checkRun);
       sandbox.stub(GitHub.prototype, 'updateCheckRun');
       sandbox.stub(GitHub.prototype, 'createCheckRun');
@@ -154,8 +154,9 @@ describe('owners bot', () => {
 
     it('attempts to fetch the existing check-run ID', async () => {
       expect.assertions(1);
+      getCheckRunIdsStub.returns({});
       await ownersBot.runOwnersCheck(github, pr);
-      sandbox.assert.calledWith(github.getCheckRunId, '_test_hash_');
+      sandbox.assert.calledWith(github.getCheckRunIds, '_test_hash_');
 
       // Ensures the test fails if the assertion is never run.
       expect(true).toBe(true);
@@ -163,6 +164,7 @@ describe('owners bot', () => {
 
     it('checks out the latest master', async () => {
       expect.assertions(1);
+      getCheckRunIdsStub.returns({});
       await ownersBot.runOwnersCheck(github, pr);
       sandbox.assert.calledOnce(localRepo.checkout);
 
@@ -172,6 +174,7 @@ describe('owners bot', () => {
 
     it('runs the owners check', async () => {
       expect.assertions(1);
+      getCheckRunIdsStub.returns({});
       await ownersBot.runOwnersCheck(github, pr);
       sandbox.assert.calledOnce(OwnersCheck.prototype.run);
 
@@ -182,7 +185,7 @@ describe('owners bot', () => {
     describe('when a check-run exists', () => {
       it('updates the existing check-run', async () => {
         expect.assertions(1);
-        getCheckRunIdStub.returns(42);
+        getCheckRunIdsStub.returns({'owners-check': 42});
         await ownersBot.runOwnersCheck(github, pr);
 
         sandbox.assert.calledWith(
@@ -199,7 +202,7 @@ describe('owners bot', () => {
     describe('when no check-run exists yet', () => {
       it('creates a new check-run', async () => {
         expect.assertions(1);
-        getCheckRunIdStub.returns(null);
+        getCheckRunIdsStub.returns({});
         await ownersBot.runOwnersCheck(github, pr);
 
         sandbox.assert.calledWith(


### PR DESCRIPTION
Since the OwnersBot will soon also run other checks (notably an owners-syntax-check and eventually a dependency-owners-check), this refactors the `getCheckRunId` method to return multiple check-run IDs instead of just the owners check-run ID.