### PR TITLE
[bundle-size] Also write bundle size results to a JSON file

### DIFF
--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -602,7 +602,8 @@ module.exports = app => {
         );
         app.log(
           `Stored the new ${compression} bundle size of ${bundleSizeText} in ` +
-            'the artifacts repository on GitHub'
+            `the bundle-size/${bundleSizeFile} file artifacts repository on ` +
+            'GitHub'
         );
       } catch (error) {
         const errorMessage =
@@ -637,8 +638,8 @@ module.exports = app => {
         jsonBundleSizeText
       );
       app.log(
-        'Stored the new bundle size JSON file in the artifacts repository on ' +
-          'GitHub'
+        `Stored the new bundle size file bundle-size/${jsonBundleSizeFile} ` +
+          'the artifacts repository on GitHub'
       );
     } catch (error) {
       const errorMessage =

--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -573,6 +573,8 @@ module.exports = app => {
       }
     }
 
+    // TODO(danielrozenberg): remove this block once we switch entirely to the
+    // JSON format.
     for (const [compression, extension, bundleSizeValue] of [
       ['gzip', '', gzippedBundleSize],
       ['brotli', '.br', brotliBundleSize],
@@ -606,11 +608,47 @@ module.exports = app => {
         const errorMessage =
           `ERROR: Failed to create the bundle-size/${bundleSizeFile} file in ` +
           'the build artifacts repository on GitHub!\n' +
-          `Error message was: ${error.message}`;
+          `Error message was: ${error}`;
         app.log(errorMessage);
         return response.status(500).end(errorMessage);
       }
     }
+
+    const jsonBundleSizeFile = `${headSha}.json`;
+    try {
+      await getBuildArtifactsFile(userBasedGithub, jsonBundleSizeFile);
+      app.log(
+        `The file bundle-size/${jsonBundleSizeFile} already exists in the ` +
+          'build artifacts repository on GitHub. Skipping...'
+      );
+      return response.end();
+    } catch (unusedException) {
+      // The file was not found in the GitHub repository, so continue to
+      // create it...
+    }
+
+    try {
+      const jsonBundleSizeText = JSON.stringify({
+        'dist/v0.js': brotliBundleSize,
+      });
+      await storeBuildArtifactsFile(
+        userBasedGithub,
+        jsonBundleSizeFile,
+        jsonBundleSizeText
+      );
+      app.log(
+        'Stored the new bundle size JSON file in the artifacts repository on ' +
+          'GitHub'
+      );
+    } catch (error) {
+      const errorMessage =
+        `ERROR: Failed to create the bundle-size/${jsonBundleSizeFile} file ` +
+        'in the build artifacts repository on GitHub!\n' +
+        `Error message was: ${error}`;
+      app.log(errorMessage);
+      return response.status(500).end(errorMessage);
+    }
+
     response.end();
   });
 };

--- a/bundle-size/test/app.test.js
+++ b/bundle-size/test/app.test.js
@@ -762,8 +762,8 @@ describe('bundle-size', () => {
         {
           message:
             'bundle-size: 5f27002526a808c5c1ad5d0f1ab1cec471af0a33 ' +
-            '(12.34KB)',
-          content: Buffer.from('12.34KB').toString('base64'),
+            '(23.45KB)',
+          content: Buffer.from('23.45KB').toString('base64'),
         }
       )
       .reply(201)
@@ -782,13 +782,29 @@ describe('bundle-size', () => {
           content: Buffer.from('12.34KB').toString('base64'),
         }
       )
+      .reply(201)
+      .get(
+        '/repos/ampproject/amphtml-build-artifacts/contents/' +
+          'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+      )
+      .reply(404)
+      .put(
+        '/repos/ampproject/amphtml-build-artifacts/contents/' +
+          'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json',
+        {
+          message:
+            'bundle-size: 5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json ' +
+            '({"dist/v0.js":12.34})',
+          content: Buffer.from('{"dist/v0.js":12.34}').toString('base64'),
+        }
+      )
       .reply(201);
 
     await request(probot.server)
       .post('/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store')
       .send({
         token: '0123456789abcdefghijklmnopqrstuvwxyz',
-        gzippedBundleSize: 12.34,
+        gzippedBundleSize: 23.45,
         brotliBundleSize: 12.34,
       })
       .set('Content-Type', 'application/json')
@@ -807,6 +823,11 @@ describe('bundle-size', () => {
       .get(
         '/repos/ampproject/amphtml-build-artifacts/contents/' +
           'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'
+      )
+      .reply(200, getFixture('5f27002526a808c5c1ad5d0f1ab1cec471af0a33'))
+      .get(
+        '/repos/ampproject/amphtml-build-artifacts/contents/' +
+          'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
       )
       .reply(200, getFixture('5f27002526a808c5c1ad5d0f1ab1cec471af0a33'));
 


### PR DESCRIPTION
Workplan:
- [ ] submit and deploy this change
- [ ] after this is deployed, create a PR that migrates all `.br` files to `.json` (with the proper format of course)
- [ ] unrollback #412
- [ ] create a new PR that reads bundle-sizes from the `.json` file instead of the `.br` file, submit and deploy it
- [ ] delete all `.br` and extensionless files from https://github.com/ampproject/amphtml-build-artifacts/tree/master/bundle-size
- [ ] ???
- [ ] #271