### PR TITLE
Use Owner classes instead of username strings

### DIFF
--- a/owners/src/owner.js
+++ b/owners/src/owner.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2019 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * An owner of some set of files.
+ *
+ * TODO(#395): Implement ownership modifiers.
+ * @private
+ */
+class Owner {
+  /**
+   * Tests if this owner matches a username.
+   *
+   * @param {!string} username username to check.
+   * @return {boolean} true if this owner has the username.
+   */
+   includes(username) {
+    throw new Error('Not implemented for abstract class `Owner`');
+   }
+}
+
+class UserOwner extends Owner {
+  /**
+   * Constructor.
+   *
+   * @param {!string} username owner's GitHub username.
+   */
+  constructor(username) {
+    super();
+    Object.assign(this, {username});
+  }
+
+  /**
+   * Tests if this owner matches a username.
+   *
+   * @param {!string} username username to check.
+   * @return {boolean} true if this owner has the username.
+   */
+  includes(username) {
+    return this.username === username;
+  }
+}
+
+/**
+ * A team which owns some set of files.
+ */
+class TeamOwner extends Owner {
+  /**
+   * Constructor.
+   *
+   * @param {!Team} team the GitHub team.
+   */
+  constructor(team) {
+    super();
+    Object.assign(this, {team});
+  }
+
+  /**
+   * Tests if this owner matches a username.
+   *
+   * @param {!string} username username to check.
+   * @return {boolean} true if this team owner has the username.
+   */
+  includes(username) {
+    return this.team.members.includes(username);
+  }
+}
+
+/**
+ * A wildcard owner that includes anyone.
+ */
+class WildcardOwner extends Owner {
+  /**
+   * Tests if this owner matches a username.
+   *
+   * @param {!string} username username to check.
+   * @return {boolean} always true
+   */
+  includes(unusedUsername) {
+    return true;
+  }
+}
+
+module.exports = {Owner, UserOwner, TeamOwner, WildcardOwner};

--- a/owners/src/owner.js
+++ b/owners/src/owner.js
@@ -18,20 +18,22 @@
  * An owner of some set of files.
  *
  * TODO(#395): Implement ownership modifiers.
- * @private
  */
 class Owner {
   /**
    * Tests if this owner matches a username.
    *
+   * @throws {Error} if called on the abstract base `Owner` class.
    * @param {!string} username username to check.
-   * @return {boolean} true if this owner has the username.
    */
   includes(username) {
     throw new Error('Not implemented for abstract class `Owner`');
   }
 }
 
+/**
+ * A user who owns a set of files.
+ */
 class UserOwner extends Owner {
   /**
    * Constructor.
@@ -104,7 +106,7 @@ class WildcardOwner extends Owner {
   /**
    * Tests if this owner matches a username.
    *
-   * @param {!string} username username to check.
+   * @param {!string} unusedUsername username to check.
    * @return {boolean} always true
    */
   includes(unusedUsername) {

--- a/owners/src/owner.js
+++ b/owners/src/owner.js
@@ -29,6 +29,15 @@ class Owner {
   includes(username) {
     throw new Error('Not implemented for abstract class `Owner`');
   }
+
+  /**
+   * Returns a list of all usernames included by the owner.
+   *
+   * @return {string[]} list of GitHub usernames.
+   */
+  get allUsernames() {
+    return [];
+  }
 }
 
 /**
@@ -53,6 +62,15 @@ class UserOwner extends Owner {
    */
   includes(username) {
     return this.username === username;
+  }
+
+  /**
+   * Returns a list of all usernames included by the owner.
+   *
+   * @return {string[]} list containing the user's GitHub username.
+   */
+  get allUsernames() {
+    return [this.username];
   }
 
   /**
@@ -87,6 +105,15 @@ class TeamOwner extends Owner {
    */
   includes(username) {
     return this.team.members.includes(username);
+  }
+
+  /**
+   * Returns a list of all usernames included by the owner.
+   *
+   * @return {string[]} list containing the user's GitHub username.
+   */
+  get allUsernames() {
+    return this.team.members;
   }
 
   /**

--- a/owners/src/owner.js
+++ b/owners/src/owner.js
@@ -27,9 +27,9 @@ class Owner {
    * @param {!string} username username to check.
    * @return {boolean} true if this owner has the username.
    */
-   includes(username) {
+  includes(username) {
     throw new Error('Not implemented for abstract class `Owner`');
-   }
+  }
 }
 
 class UserOwner extends Owner {
@@ -51,6 +51,15 @@ class UserOwner extends Owner {
    */
   includes(username) {
     return this.username === username;
+  }
+
+  /**
+   * Render the owner as a string.
+   *
+   * @return {string} the owner's username.
+   */
+  toString() {
+    return this.username;
   }
 }
 
@@ -77,6 +86,15 @@ class TeamOwner extends Owner {
   includes(username) {
     return this.team.members.includes(username);
   }
+
+  /**
+   * Render the owner as a string.
+   *
+   * @return {string} the team members' usernames as a comma-separated list.
+   */
+  toString() {
+    return this.team.members.join(', ');
+  }
 }
 
 /**
@@ -91,6 +109,15 @@ class WildcardOwner extends Owner {
    */
   includes(unusedUsername) {
     return true;
+  }
+
+  /**
+   * Render the owner as a string.
+   *
+   * @return {string} the `*` wildcard symbol.
+   */
+  toString() {
+    return '*';
   }
 }
 

--- a/owners/src/owners_tree.js
+++ b/owners/src/owners_tree.js
@@ -137,8 +137,8 @@ class OwnersTree {
     const allRules = this.atPath(filename).allRules;
     const fileRules = allRules.filter(rule => rule.matchesFile(filename));
 
-    return fileRules.some(
-      rule => rule.owners.some(owner => owner.includes(username))
+    return fileRules.some(rule =>
+      rule.owners.some(owner => owner.includes(username))
     );
   }
 

--- a/owners/src/owners_tree.js
+++ b/owners/src/owners_tree.js
@@ -136,8 +136,9 @@ class OwnersTree {
   fileHasOwner(filename, username) {
     const allRules = this.atPath(filename).allRules;
     const fileRules = allRules.filter(rule => rule.matchesFile(filename));
+
     return fileRules.some(
-      rule => rule.wildcardOwner || rule.owners.includes(username)
+      rule => rule.owners.some(owner => owner.includes(username))
     );
   }
 

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -21,6 +21,7 @@ const {
   SameDirPatternOwnersRule,
 } = require('./rules');
 const {OwnersTree} = require('./owners_tree');
+const {UserOwner, TeamOwner} = require('./owner');
 
 const GLOB_PATTERN = '**/';
 
@@ -74,7 +75,7 @@ class OwnersParser {
    * @private
    * @param {!string} ownersPath OWNERS.yaml file path (for error reporting).
    * @param {!string} owner owner username.
-   * @return {OwnersParserResult<string[]>} list of owners' usernames.
+   * @return {OwnersParserResult<Owner>} list of owners.
    */
   _parseOwnersLine(ownersPath, owner) {
     const owners = [];
@@ -95,7 +96,7 @@ class OwnersParser {
       const team = this.teamMap[owner];
 
       if (team) {
-        owners.push(...team.members);
+        owners.push(new TeamOwner(team));
       } else {
         errors.push(
           new OwnersParserError(ownersPath, `Unrecognized team: '${owner}'`)

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -21,7 +21,7 @@ const {
   SameDirPatternOwnersRule,
 } = require('./rules');
 const {OwnersTree} = require('./owners_tree');
-const {UserOwner, TeamOwner} = require('./owner');
+const {UserOwner, TeamOwner, WildcardOwner} = require('./owner');
 
 const GLOB_PATTERN = '**/';
 
@@ -75,7 +75,7 @@ class OwnersParser {
    * @private
    * @param {!string} ownersPath OWNERS.yaml file path (for error reporting).
    * @param {!string} owner owner username.
-   * @return {OwnersParserResult<Owner>} list of owners.
+   * @return {OwnersParserResult<Owner[]>} list of owners.
    */
   _parseOwnersLine(ownersPath, owner) {
     const owners = [];
@@ -102,8 +102,10 @@ class OwnersParser {
           new OwnersParserError(ownersPath, `Unrecognized team: '${owner}'`)
         );
       }
+    } else if (owner === '*') {
+      owners.push(new WildcardOwner());
     } else {
-      owners.push(owner);
+      owners.push(new UserOwner(owner));
     }
 
     return {result: owners, errors};
@@ -115,7 +117,7 @@ class OwnersParser {
    * @private
    * @param {!string} ownersPath OWNERS.yaml file path (for error reporting).
    * @param {string[]} ownersList list of owners.
-   * @return {OwnersParserResult<string[]>} list of owners' usernames.
+   * @return {OwnersParserResult<Owner[]>} list of owners' usernames.
    */
   _parseOwnersList(ownersPath, ownersList) {
     const owners = [];

--- a/owners/src/reviewer_selection.js
+++ b/owners/src/reviewer_selection.js
@@ -63,7 +63,9 @@ class ReviewerSelection {
       tree.rules
         .filter(rule => !rule.wildcardOwner)
         .forEach(rule => {
-          rule.owners.forEach(owner => reviewers.add(owner));
+          rule.owners.forEach(owner => {
+            owner.allUsernames.forEach(username => reviewers.add(username));
+          });
         });
     });
     return Array.from(reviewers);
@@ -145,6 +147,10 @@ class ReviewerSelection {
 
   /**
    * Picks a set of reviews to approve the PR.
+   *
+   * Assumption: The file-tree map should only contain files which do not yet
+   * have owners approval. This means that any file under the scope of a
+   * wildcard `*` ownership will not be considered.
    *
    * @throws {Error} if the algorithm fails to select reviewers.
    * @param {!FileTreeMap} fileTreeMap map from filenames to ownership subtrees.

--- a/owners/src/rules.js
+++ b/owners/src/rules.js
@@ -23,8 +23,8 @@ class OwnersRule {
   /**
    * Constructor.
    *
-   * If a rule's owners includes the `*` wildcard, all other owners will be
-   * ignored, and the rule will be satisfied by any reviewer.
+   * If a rule's owners includes the `*` wildcard, the rule will be satisfied by
+   * any reviewer.
    *
    * @param {!string} ownersPath path to OWNERS file.
    * @param {string[]} owners list of GitHub usernames of owners.
@@ -32,8 +32,7 @@ class OwnersRule {
   constructor(ownersPath, owners) {
     this.filePath = ownersPath;
     this.dirPath = path.dirname(ownersPath);
-    this.wildcardOwner = owners.includes('*');
-    this.owners = this.wildcardOwner ? ['*'] : owners;
+    this.owners = owners;
   }
 
   /**

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -21,6 +21,7 @@ const {Probot} = require('probot');
 const sinon = require('sinon');
 const {LocalRepository} = require('../src/local_repo');
 const {OwnersParser} = require('../src/parser');
+const {UserOwner} = require('../src/owner');
 const {OwnersRule} = require('../src/rules');
 const {OwnersBot} = require('../src/owners_bot');
 
@@ -47,10 +48,10 @@ jest.setTimeout(30000);
 
 const GITHUB_REPO_DIR = '/Users/erwinm/dev/github-owners-bot-test-repo';
 const ownersRules = [
-  new OwnersRule('OWNERS.yaml', ['donttrustthisbot']),
-  new OwnersRule('dir1/OWNERS.yaml', ['donttrustthisbot']),
-  new OwnersRule('dir2/OWNERS.yaml', ['erwinmombay']),
-  new OwnersRule('dir2/dir1/dir1/OWNERS.yaml', ['erwinmombay']),
+  new OwnersRule('OWNERS.yaml', [new UserOwner('donttrustthisbot')]),
+  new OwnersRule('dir1/OWNERS.yaml', [new UserOwner('donttrustthisbot')]),
+  new OwnersRule('dir2/OWNERS.yaml', [new UserOwner('erwinmombay')]),
+  new OwnersRule('dir2/dir1/dir1/OWNERS.yaml', [new UserOwner('erwinmombay')]),
 ];
 
 describe('owners bot', () => {

--- a/owners/test/owner.test.js
+++ b/owners/test/owner.test.js
@@ -54,7 +54,7 @@ describe('owner teams', () => {
   });
 
   describe('toString', () => {
-    it('returns the team members\' usernames as a comma-separated list', () => {
+    it("returns the team members' usernames as a comma-separated list", () => {
       expect(owner.toString()).toEqual('auser, anothermember');
     });
   });

--- a/owners/test/owner.test.js
+++ b/owners/test/owner.test.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-const sinon = require('sinon');
 const {UserOwner, TeamOwner, WildcardOwner} = require('../src/owner');
 const {Team} = require('../src/github');
 
@@ -30,20 +29,33 @@ describe('owner users', () => {
       expect(owner.includes('someoneelse')).toBe(false);
     });
   });
+
+  describe('toString', () => {
+    it('returns the owner username', () => {
+      expect(owner.toString()).toEqual('auser');
+    });
+  });
 });
 
 describe('owner teams', () => {
   const myTeam = new Team(42, 'ampproject', 'my_team');
-  myTeam.members = ['auser'];
+  myTeam.members = ['auser', 'anothermember'];
   const owner = new TeamOwner(myTeam);
 
   describe('includes', () => {
     it('returns true for a username in the team', () => {
       expect(owner.includes('auser')).toBe(true);
+      expect(owner.includes('anothermember')).toBe(true);
     });
 
     it('returns true for a username in the team', () => {
       expect(owner.includes('someoneelse')).toBe(false);
+    });
+  });
+
+  describe('toString', () => {
+    it('returns the team members\' usernames as a comma-separated list', () => {
+      expect(owner.toString()).toEqual('auser, anothermember');
     });
   });
 });
@@ -54,6 +66,12 @@ describe('owner wildcard', () => {
   describe('includes', () => {
     it('returns true for any username', () => {
       expect(owner.includes('auser')).toBe(true);
+    });
+  });
+
+  describe('toString', () => {
+    it('returns the `*` wildcard symbol ', () => {
+      expect(owner.toString()).toEqual('*');
     });
   });
 });

--- a/owners/test/owner.test.js
+++ b/owners/test/owner.test.js
@@ -30,6 +30,12 @@ describe('owner users', () => {
     });
   });
 
+  describe('allUsernames', () => {
+    it("returns the user owner's username", () => {
+      expect(owner.allUsernames).toEqual(['auser']);
+    });
+  });
+
   describe('toString', () => {
     it('returns the owner username', () => {
       expect(owner.toString()).toEqual('auser');
@@ -53,6 +59,12 @@ describe('owner teams', () => {
     });
   });
 
+  describe('allUsernames', () => {
+    it("returns the team members' username", () => {
+      expect(owner.allUsernames).toEqual(['auser', 'anothermember']);
+    });
+  });
+
   describe('toString', () => {
     it("returns the team members' usernames as a comma-separated list", () => {
       expect(owner.toString()).toEqual('auser, anothermember');
@@ -66,6 +78,12 @@ describe('owner wildcard', () => {
   describe('includes', () => {
     it('returns true for any username', () => {
       expect(owner.includes('auser')).toBe(true);
+    });
+  });
+
+  describe('allUsernames', () => {
+    it('returns an empty list', () => {
+      expect(owner.allUsernames).toEqual([]);
     });
   });
 

--- a/owners/test/owner.test.js
+++ b/owners/test/owner.test.js
@@ -14,8 +14,20 @@
  * limitations under the License.
  */
 
-const {UserOwner, TeamOwner, WildcardOwner} = require('../src/owner');
+const {Owner, UserOwner, TeamOwner, WildcardOwner} = require('../src/owner');
 const {Team} = require('../src/github');
+
+describe('owner base class', () => {
+  const owner = new Owner();
+
+  describe('includes', () => {
+    it('throws an error', () => {
+      expect(() => {
+        owner.includes('');
+      }).toThrow('Not implemented for abstract class `Owner`');
+    });
+  });
+});
 
 describe('owner users', () => {
   const owner = new UserOwner('auser');

--- a/owners/test/owner.test.js
+++ b/owners/test/owner.test.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2019 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const sinon = require('sinon');
+const {UserOwner, TeamOwner, WildcardOwner} = require('../src/owner');
+const {Team} = require('../src/github');
+
+describe('owner users', () => {
+  const owner = new UserOwner('auser');
+
+  describe('includes', () => {
+    it('returns true for a matching username', () => {
+      expect(owner.includes('auser')).toBe(true);
+    });
+
+    it('returns true for non-matching usernames', () => {
+      expect(owner.includes('someoneelse')).toBe(false);
+    });
+  });
+});
+
+describe('owner teams', () => {
+  const myTeam = new Team(42, 'ampproject', 'my_team');
+  myTeam.members = ['auser'];
+  const owner = new TeamOwner(myTeam);
+
+  describe('includes', () => {
+    it('returns true for a username in the team', () => {
+      expect(owner.includes('auser')).toBe(true);
+    });
+
+    it('returns true for a username in the team', () => {
+      expect(owner.includes('someoneelse')).toBe(false);
+    });
+  });
+});
+
+describe('owner wildcard', () => {
+  const owner = new WildcardOwner();
+
+  describe('includes', () => {
+    it('returns true for any username', () => {
+      expect(owner.includes('auser')).toBe(true);
+    });
+  });
+});

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -20,6 +20,7 @@ const {
   CheckRunConclusion,
   OwnersCheck,
 } = require('../src/owners_check');
+const {UserOwner} = require('../src/owner');
 const {OwnersTree} = require('../src/owners_tree');
 const {OwnersRule} = require('../src/rules');
 const {ReviewerSelection} = require('../src/reviewer_selection');
@@ -51,10 +52,13 @@ describe('owners check', () => {
   beforeEach(() => {
     const ownersTree = new OwnersTree();
     [
-      new OwnersRule('OWNERS.yaml', ['root_owner']),
-      new OwnersRule('foo/OWNERS.yaml', ['approver', 'some_user']),
-      new OwnersRule('bar/OWNERS.yaml', ['other_approver']),
-      new OwnersRule('buzz/OWNERS.yaml', ['the_author']),
+      new OwnersRule('OWNERS.yaml', [new UserOwner('root_owner')]),
+      new OwnersRule('foo/OWNERS.yaml', [
+        new UserOwner('approver'),
+        new UserOwner('some_user'),
+      ]),
+      new OwnersRule('bar/OWNERS.yaml', [new UserOwner('other_approver')]),
+      new OwnersRule('buzz/OWNERS.yaml', [new UserOwner('the_author')]),
     ].forEach(rule => ownersTree.addRule(rule));
 
     ownersCheck = new OwnersCheck(

--- a/owners/test/owners_tree.test.js
+++ b/owners/test/owners_tree.test.js
@@ -15,6 +15,8 @@
  */
 
 const {OwnersTree} = require('../src/owners_tree');
+const {Team} = require('../src/github');
+const {UserOwner, TeamOwner, WildcardOwner} = require('../src/owner');
 const {
   OwnersRule,
   PatternOwnersRule,
@@ -23,21 +25,31 @@ const {
 
 describe('owners tree', () => {
   let tree;
-  const rootDirRule = new OwnersRule('OWNERS.yaml', ['root']);
-  const childDirRule = new OwnersRule('foo/OWNERS.yaml', ['child']);
-  const otherChildDirRule = new OwnersRule('biz/OWNERS.yaml', ['child']);
-  const descendantDirRule = new OwnersRule('foo/bar/baz/OWNERS.yaml', [
-    'descendant',
+  const rootDirRule = new OwnersRule('OWNERS.yaml', [new UserOwner('root')]);
+  const childDirRule = new OwnersRule('foo/OWNERS.yaml', [
+    new UserOwner('child'),
   ]);
-  const wildcardDirRule = new OwnersRule('shared/OWNERS.yaml', ['*']);
+  const otherChildDirRule = new OwnersRule('biz/OWNERS.yaml', [
+    new UserOwner('child'),
+  ]);
+  const descendantDirRule = new OwnersRule('foo/bar/baz/OWNERS.yaml', [
+    new UserOwner('descendant'),
+  ]);
+  const wildcardDirRule = new OwnersRule('shared/OWNERS.yaml', [
+    new WildcardOwner(),
+  ]);
+
+  const testerTeam = new Team(42, 'ampproject', 'testers');
+  testerTeam.members.push('tester');
   const testFileRule = new PatternOwnersRule(
     'OWNERS.yaml',
-    ['testers'],
+    [new TeamOwner(testerTeam)],
     '*.test.js'
   );
+
   const packageJsonRule = new SameDirPatternOwnersRule(
     'OWNERS.yaml',
-    ['anyone'],
+    [new UserOwner('anyone')],
     'package.json'
   );
 
@@ -204,8 +216,8 @@ describe('owners tree', () => {
     });
 
     it('should respect pattern-based rules', () => {
-      expect(tree.fileHasOwner('foo/bar/thing.test.js', 'testers')).toBe(true);
-      expect(tree.fileHasOwner('foo/bar/thing.js', 'testers')).toBe(false);
+      expect(tree.fileHasOwner('foo/bar/thing.test.js', 'tester')).toBe(true);
+      expect(tree.fileHasOwner('foo/bar/thing.js', 'tester')).toBe(false);
     });
 
     it('should respect same-directory rules', () => {

--- a/owners/test/owners_tree.test.js
+++ b/owners/test/owners_tree.test.js
@@ -261,6 +261,7 @@ describe('owners tree', () => {
       tree.addRule(childDirRule);
       tree.addRule(otherChildDirRule);
       tree.addRule(descendantDirRule);
+      tree.addRule(wildcardDirRule);
       tree.addRule(testFileRule);
       tree.addRule(packageJsonRule);
 
@@ -268,7 +269,7 @@ describe('owners tree', () => {
         [
           'ROOT',
           ' • All files: root',
-          ' • **/*.test.js: testers',
+          ' • **/*.test.js: tester',
           ' • ./package.json: anyone',
           '└───foo',
           ' • All files: child',
@@ -277,6 +278,8 @@ describe('owners tree', () => {
           '         • All files: descendant',
           '└───biz',
           ' • All files: child',
+          '└───shared',
+          ' • All files: *',
         ].join('\n')
       );
     });

--- a/owners/test/parser.test.js
+++ b/owners/test/parser.test.js
@@ -2,7 +2,7 @@ const sinon = require('sinon');
 const {Team} = require('../src/github');
 const {LocalRepository} = require('../src/local_repo');
 const {OwnersParser, OwnersParserError} = require('../src/parser');
-const {UserOwner, WildcardOwner, TeamOwner} = require('../src/owner');
+const {UserOwner, TeamOwner} = require('../src/owner');
 const {
   OwnersRule,
   PatternOwnersRule,

--- a/owners/test/parser.test.js
+++ b/owners/test/parser.test.js
@@ -2,6 +2,7 @@ const sinon = require('sinon');
 const {Team} = require('../src/github');
 const {LocalRepository} = require('../src/local_repo');
 const {OwnersParser, OwnersParserError} = require('../src/parser');
+const {UserOwner, WildcardOwner, TeamOwner} = require('../src/owner');
 const {
   OwnersRule,
   PatternOwnersRule,
@@ -65,7 +66,10 @@ describe('owners parser', () => {
       const fileParse = parser.parseOwnersFile('');
       const rules = fileParse.result;
 
-      expect(rules[0].owners).toEqual(['user1', 'user2']);
+      expect(rules[0].owners).toEqual([
+        new UserOwner('user1'),
+        new UserOwner('user2'),
+      ]);
     });
 
     it('parses a YAML list with blank lines and comments', () => {
@@ -73,7 +77,10 @@ describe('owners parser', () => {
       const fileParse = parser.parseOwnersFile('');
       const rules = fileParse.result;
 
-      expect(rules[0].owners).toEqual(['user1', 'user2']);
+      expect(rules[0].owners).toEqual([
+        new UserOwner('user1'),
+        new UserOwner('user2'),
+      ]);
     });
 
     describe('team rule declarations', () => {
@@ -82,7 +89,7 @@ describe('owners parser', () => {
         const fileParse = parser.parseOwnersFile('');
         const rules = fileParse.result;
 
-        expect(rules[0].owners).toEqual(['team_member', 'other_member']);
+        expect(rules[0].owners).toEqual([new TeamOwner(myTeam)]);
       });
 
       it('records an error for unknown teams', () => {
@@ -105,7 +112,7 @@ describe('owners parser', () => {
 
       it('parses ignoring the @ sign', () => {
         const [rule] = fileParse.result;
-        expect(rule.owners).toEqual(['owner']);
+        expect(rule.owners).toEqual([new UserOwner('owner')]);
       });
 
       it('records an error', () => {
@@ -122,7 +129,7 @@ describe('owners parser', () => {
 
         expect(rules[0]).toBeInstanceOf(SameDirPatternOwnersRule);
         expect(rules[0].pattern).toEqual('*.js');
-        expect(rules[0].owners).toEqual(['scripty']);
+        expect(rules[0].owners).toEqual([new UserOwner('scripty')]);
       });
 
       it('parses a list of owners into a pattern rule', () => {
@@ -134,7 +141,10 @@ describe('owners parser', () => {
 
         expect(rules[0]).toBeInstanceOf(SameDirPatternOwnersRule);
         expect(rules[0].pattern).toEqual('*.js');
-        expect(rules[0].owners).toEqual(['scripty', 'coder']);
+        expect(rules[0].owners).toEqual([
+          new UserOwner('scripty'),
+          new UserOwner('coder'),
+        ]);
       });
 
       it('reports errors for non-string owners', () => {
@@ -155,7 +165,7 @@ describe('owners parser', () => {
 
         expect(rules[0]).toBeInstanceOf(PatternOwnersRule);
         expect(rules[0].pattern).toEqual('*.js');
-        expect(rules[0].owners).toEqual(['scripty']);
+        expect(rules[0].owners).toEqual([new UserOwner('scripty')]);
       });
 
       it('parses no rule if no valid owners are listed', () => {
@@ -224,8 +234,14 @@ describe('owners parser', () => {
 
       expect(rules[0].dirPath).toEqual('.');
       expect(rules[1].dirPath).toEqual('foo');
-      expect(rules[0].owners).toEqual(['user1', 'user2']);
-      expect(rules[1].owners).toEqual(['user3', 'user4']);
+      expect(rules[0].owners).toEqual([
+        new UserOwner('user1'),
+        new UserOwner('user2'),
+      ]);
+      expect(rules[1].owners).toEqual([
+        new UserOwner('user3'),
+        new UserOwner('user4'),
+      ]);
     });
 
     it('does not include invalid rules', async () => {

--- a/owners/test/parser.test.js
+++ b/owners/test/parser.test.js
@@ -2,7 +2,7 @@ const sinon = require('sinon');
 const {Team} = require('../src/github');
 const {LocalRepository} = require('../src/local_repo');
 const {OwnersParser, OwnersParserError} = require('../src/parser');
-const {UserOwner, TeamOwner} = require('../src/owner');
+const {UserOwner, TeamOwner, WildcardOwner} = require('../src/owner');
 const {
   OwnersRule,
   PatternOwnersRule,
@@ -81,6 +81,14 @@ describe('owners parser', () => {
         new UserOwner('user1'),
         new UserOwner('user2'),
       ]);
+    });
+
+    it('parses a wildcard owner', () => {
+      sandbox.stub(repo, 'readFile').returns('- "*"');
+      const fileParse = parser.parseOwnersFile('hat');
+      const rules = fileParse.result;
+
+      expect(rules[0].owners).toEqual([new WildcardOwner()]);
     });
 
     describe('team rule declarations', () => {

--- a/owners/test/reviewer_selection.test.js
+++ b/owners/test/reviewer_selection.test.js
@@ -16,24 +16,32 @@
 
 const sinon = require('sinon');
 const {ReviewerSelection} = require('../src/reviewer_selection');
+const {Team} = require('../src/github');
+const {UserOwner, TeamOwner} = require('../src/owner');
 const {OwnersTree} = require('../src/owners_tree');
 const {OwnersRule} = require('../src/rules');
 
 describe('reviewer selection', () => {
   const sandbox = sinon.createSandbox();
   const ownersTree = new OwnersTree();
+  const myTeam = new Team(42, 'ampproject', 'my_team');
+  myTeam.members = ['child', 'kid'];
 
   const dirTrees = {
-    '/': ownersTree.addRule(new OwnersRule('OWNERS.yaml', ['rootOwner'])),
-    '/foo': ownersTree.addRule(new OwnersRule('foo/OWNERS.yaml', ['child'])),
+    '/': ownersTree.addRule(
+      new OwnersRule('OWNERS.yaml', [new UserOwner('rootOwner')])
+    ),
+    '/foo': ownersTree.addRule(
+      new OwnersRule('foo/OWNERS.yaml', [new UserOwner('child')])
+    ),
     '/biz': ownersTree.addRule(
-      new OwnersRule('biz/OWNERS.yaml', ['child', 'kid'])
+      new OwnersRule('biz/OWNERS.yaml', [new TeamOwner(myTeam)])
     ),
     '/buzz': ownersTree.addRule(
-      new OwnersRule('buzz/OWNERS.yaml', ['thirdChild'])
+      new OwnersRule('buzz/OWNERS.yaml', [new UserOwner('thirdChild')])
     ),
     '/foo/bar/baz': ownersTree.addRule(
-      new OwnersRule('foo/bar/baz/OWNERS.yaml', ['descendant'])
+      new OwnersRule('foo/bar/baz/OWNERS.yaml', [new UserOwner('descendant')])
     ),
   };
 


### PR DESCRIPTION
Paves the way for allowing modifiers of owners (see #395 ) like no-notify, always-notify, and require-review.