### PR TITLE
[owners] Handle requested and non-approving reviewers

### DIFF
--- a/owners/index.js
+++ b/owners/index.js
@@ -87,12 +87,7 @@ module.exports = app => {
 
   adminRouter.get('/check/:prNumber', async (req, res) => {
     const pr = await github.getPullRequest(req.params.prNumber);
-    const {tree, changedFiles, approvers} = await ownersBot.initPr(github, pr);
-
-    const reviewers = {};
-    approvers.forEach(username => {
-      reviewers[username] = true;
-    });
+    const {tree, changedFiles, reviewers} = await ownersBot.initPr(github, pr);
     const ownersCheck = new OwnersCheck(tree, changedFiles, reviewers);
 
     const checkRun = ownersCheck.run();

--- a/owners/index.js
+++ b/owners/index.js
@@ -88,7 +88,13 @@ module.exports = app => {
   adminRouter.get('/check/:prNumber', async (req, res) => {
     const pr = await github.getPullRequest(req.params.prNumber);
     const {tree, changedFiles, approvers} = await ownersBot.initPr(github, pr);
-    const ownersCheck = new OwnersCheck(tree, changedFiles, approvers);
+
+    const reviewers = {};
+    approvers.forEach(username => {
+      reviewers[username] = true;
+    });
+    const ownersCheck = new OwnersCheck(tree, changedFiles, reviewers);
+
     const checkRun = ownersCheck.run();
 
     res.send(checkRun.json);

--- a/owners/index.js
+++ b/owners/index.js
@@ -87,8 +87,8 @@ module.exports = app => {
 
   adminRouter.get('/check/:prNumber', async (req, res) => {
     const pr = await github.getPullRequest(req.params.prNumber);
-    const {tree, approvers, changedFiles} = await ownersBot.initPr(github, pr);
-    const ownersCheck = new OwnersCheck(tree, approvers, changedFiles);
+    const {tree, changedFiles, approvers} = await ownersBot.initPr(github, pr);
+    const ownersCheck = new OwnersCheck(tree, changedFiles, approvers);
     const checkRun = ownersCheck.run();
 
     res.send(checkRun.json);

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -80,10 +80,10 @@ class OwnersBot {
     });
     const tree = treeParse.result;
 
-    const approvers = await this._getApprovers(github, pr);
     const changedFiles = await github.listFiles(pr.number);
+    const approvers = await this._getApprovers(github, pr);
 
-    return {tree, approvers, changedFiles};
+    return {tree, changedFiles, approvers};
   }
 
   /**
@@ -94,8 +94,8 @@ class OwnersBot {
    * @param {!PullRequest} pr pull request to run owners check on.
    */
   async runOwnersCheck(github, pr) {
-    const {tree, approvers, changedFiles} = await this.initPr(github, pr);
-    const ownersCheck = new OwnersCheck(tree, approvers, changedFiles);
+    const {tree, changedFiles, approvers} = await this.initPr(github, pr);
+    const ownersCheck = new OwnersCheck(tree, changedFiles, approvers);
     const checkRunIdMap = await github.getCheckRunIds(pr.headSha);
     // TODO(rcebulko): Make this into a loop through multiple check/name pairs.
     const checkRunId = checkRunIdMap[OWNERS_CHECKRUN_NAME];

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -95,7 +95,13 @@ class OwnersBot {
    */
   async runOwnersCheck(github, pr) {
     const {tree, changedFiles, approvers} = await this.initPr(github, pr);
-    const ownersCheck = new OwnersCheck(tree, changedFiles, approvers);
+
+    const reviewers = {};
+    approvers.forEach(username => {
+      reviewers[username] = true;
+    });
+    const ownersCheck = new OwnersCheck(tree, changedFiles, reviewers);
+
     const checkRunIdMap = await github.getCheckRunIds(pr.headSha);
     // TODO(rcebulko): Make this into a loop through multiple check/name pairs.
     const checkRunId = checkRunIdMap[OWNERS_CHECKRUN_NAME];

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -66,7 +66,7 @@ class OwnersBot {
    * @param {!PullRequest} pr pull request to initialize data for.
    * @return {{
    *     tree: !OwnersTree,
-   *     approvers: !ReviewerApprovalMap,
+   *     reviewers: !ReviewerApprovalMap,
    *     changedFiles: string[],
    * }} key structures needed to check PR ownership.
    */

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -110,7 +110,7 @@ class OwnersCheck {
         };
       }
 
-      Object.entries(fileTreeMap).forEach(([filename, subtree])=> {
+      Object.entries(fileTreeMap).forEach(([filename, subtree]) => {
         if (this._hasOwnersPendingReview(filename, subtree)) {
           delete fileTreeMap[filename];
         }

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -68,14 +68,14 @@ class OwnersCheck {
    * Constructor.
    *
    * @param {!OwnersTree} tree file ownership tree.
-   * @param {string[]} approvers list of usernames of approving reviewers.
    * @param {FileRef[]} changedFiles list of change files.
+   * @param {string[]} approvers list of usernames of approving reviewers.
    */
-  constructor(tree, approvers, changedFiles) {
+  constructor(tree, changedFiles, approvers) {
     Object.assign(this, {
       tree,
-      approvers,
       changedFilenames: changedFiles.map(({filename}) => filename),
+      approvers,
     });
   }
 

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -144,13 +144,40 @@ class OwnersCheck {
    *
    * @param {!string} filename file to check.
    * @param {!OwnersTree} subtree nearest ownership tree to file.
-   * @return {boolean} if the file is approved
+   * @param {boolean} isApproved approval status to filter by.
+   * @return {boolean} if the file is approved.
    */
-  _hasOwnersApproval(filename, subtree) {
+  _hasOwnersReview(filename, subtree, isApproved) {
     return Object.entries(this.reviewers)
-      .filter(([username, approved]) => approved)
+      .filter(([username, approved]) => approved === isApproved)
       .map(([username, approved]) => username)
       .some(approver => this.tree.fileHasOwner(filename, approver));
+  }
+
+  /**
+   * Tests whether a file has been approved by an owner.
+   *
+   * Must be called after `init`.
+   *
+   * @param {!string} filename file to check.
+   * @param {!OwnersTree} subtree nearest ownership tree to file.
+   * @return {boolean} if the file is approved.
+   */
+  _hasOwnersApproval(filename, subtree) {
+    return this._hasOwnersReview(filename, subtree, true);
+  }
+
+  /**
+   * Tests whether a file has been approved by an owner.
+   *
+   * Must be called after `init`.
+   *
+   * @param {!string} filename file to check.
+   * @param {!OwnersTree} subtree nearest ownership tree to file.
+   * @return {boolean} if the file is approved.
+   */
+  _hasOwnersPendingReview(filename, subtree) {
+    return this._hasOwnersReview(filename, subtree, false);
   }
 
   /**

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -110,6 +110,11 @@ class OwnersCheck {
         };
       }
 
+      Object.entries(fileTreeMap).forEach(([filename, subtree])=> {
+        if (this._hasOwnersPendingReview(filename, subtree)) {
+          delete fileTreeMap[filename];
+        }
+      });
       const reviewSuggestions = ReviewerSelection.pickReviews(fileTreeMap);
       const reviewers = reviewSuggestions.map(([reviewer, files]) => reviewer);
       const suggestionsText = this.buildReviewSuggestionsText(

--- a/owners/src/types.js
+++ b/owners/src/types.js
@@ -73,6 +73,13 @@ let FileRef;
  */
 let OwnersCheckResult;
 
+/**
+ * A map from reviewer usernames to their approval status.
+ *
+ * @typedef {!Object<!string, boolean>}
+ */
+let ReviewerApprovalMap;
+
 module.exports = {
   FileTreeMap,
   Logger,
@@ -80,4 +87,5 @@ module.exports = {
   OwnersParserResult,
   FileRef,
   OwnersCheckResult,
+  ReviewerApprovalMap,
 };

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -36,7 +36,6 @@ describe('owners bot', () => {
 
   const timestamp = '2019-01-01T00:00:00Z';
   const approval = new Review('approver', 'approved', timestamp);
-  const authorApproval = new Review('the_author', 'approved', timestamp);
   const otherApproval = new Review('other_approver', 'approved', timestamp);
   const rejection = new Review('rejector', 'changes_requested', timestamp);
 

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -119,9 +119,11 @@ describe('owners bot', () => {
     });
 
     it('finds the reviewers that approved', async () => {
-      expect.assertions(1);
-      const {approvers} = await ownersBot.initPr(github, pr);
-      expect(approvers).toContain('approver', 'other_approver');
+      expect.assertions(2);
+      const {reviewers} = await ownersBot.initPr(github, pr);
+
+      expect(reviewers['approver']).toBe(true);
+      expect(reviewers['other_approver']).toBe(true);
     });
 
     it('fetches the files changed in the PR', async () => {
@@ -246,43 +248,34 @@ describe('owners bot', () => {
     });
   });
 
-  describe('getApprovers', () => {
-    it("returns the reviewers' usernames", async () => {
-      expect.assertions(1);
+  describe('getCurrentReviewers', () => {
+    it("includes true for approvers' usernames", async () => {
+      expect.assertions(2);
       sandbox
         .stub(GitHub.prototype, 'getReviews')
         .returns([approval, otherApproval]);
-      const approvers = await ownersBot._getApprovers(github, pr);
+      const reviewers = await ownersBot._getCurrentReviewers(github, pr);
 
-      expect(approvers).toContain('approver', 'other_approver');
+      expect(reviewers['approver']).toBe(true);
+      expect(reviewers['other_approver']).toBe(true);
     });
 
-    it('includes the author', async () => {
+    it('includes true for the author', async () => {
       expect.assertions(1);
       sandbox.stub(GitHub.prototype, 'getReviews').returns([]);
-      const approvers = await ownersBot._getApprovers(github, pr);
+      const reviewers = await ownersBot._getCurrentReviewers(github, pr);
 
-      expect(approvers).toContain('the_author');
+      expect(reviewers['the_author']).toBe(true);
     });
 
-    it('produces unique usernames', async () => {
-      expect.assertions(1);
-      sandbox
-        .stub(GitHub.prototype, 'getReviews')
-        .returns([approval, approval, authorApproval]);
-      const approvers = await ownersBot._getApprovers(github, pr);
-
-      expect(approvers).toEqual(['approver', 'the_author']);
-    });
-
-    it('includes only reviewers who approved the review', async () => {
+    it('includes false for reviewers who rejected the review', async () => {
       expect.assertions(1);
       sandbox
         .stub(GitHub.prototype, 'getReviews')
         .returns([approval, rejection]);
-      const approvers = await ownersBot._getApprovers(github, pr);
+      const reviewers = await ownersBot._getCurrentReviewers(github, pr);
 
-      expect(approvers).not.toContain('rejector');
+      expect(reviewers['rejector']).toBe(false);
     });
   });
 

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -63,7 +63,6 @@ describe('owners check', () => {
 
     ownersCheck = new OwnersCheck(
       ownersTree,
-      ['the_author', 'approver', 'other_approver'],
       [
         {
           // root_owner
@@ -85,7 +84,8 @@ describe('owners check', () => {
           filename: 'buzz/README.md',
           sha: '_sha3_',
         },
-      ]
+      ],
+      ['the_author', 'approver', 'other_approver'],
     );
   });
 

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -297,6 +297,17 @@ describe('owners check', () => {
     });
   });
 
+  describe('hasOwnersPendingReview', () => {
+    it('returns true if there are reviewers that have not yet approved', () => {
+      expect(
+        ownersCheck._hasOwnersPendingReview(
+          'extra/script.js',
+          ownersCheck.tree.atPath('extra/script.js')
+        )
+      ).toBe(true);
+    });
+  });
+
   describe('buildCurrentCoverageText', () => {
     let coverageText;
 

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -200,7 +200,7 @@ describe('owners check', () => {
           const {checkRun} = ownersCheck.run();
 
           expect(checkRun.summary).toEqual(
-            'Missing required OWNERS approvals! Suggested reviewers: extra_reviewer, root_owner'
+            'Missing required OWNERS approvals! Suggested reviewers: root_owner'
           );
         });
 
@@ -216,7 +216,7 @@ describe('owners check', () => {
         it('returns reviewers to add', () => {
           const {reviewers} = ownersCheck.run();
 
-          expect(reviewers).toEqual(['extra_reviewer', 'root_owner']);
+          expect(reviewers).toEqual(['root_owner']);
         });
       });
 

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -118,6 +118,27 @@ describe('owners check', () => {
       ]);
     });
 
+    it('picks reviewers', () => {
+      sandbox.stub(ReviewerSelection, 'pickReviews').callThrough();
+      ownersCheck.run();
+
+      sandbox.assert.calledOnce(ReviewerSelection.pickReviews);
+    });
+
+    it("doesn't pick reviewers for a file with owner review requested", () => {
+      let fileTreeMap;
+      // Note: A spy cannot be used here because the assertion takes place after
+      // reviewer selection, which empties out the file-tree map object.
+      sandbox.stub(ReviewerSelection, 'pickReviews').callsFake(ftm => {
+        fileTreeMap = ftm;
+        return [];
+      });
+      ownersCheck.run();
+
+      expect(fileTreeMap['extra/script.js']).toBeUndefined();
+      sandbox.assert.calledOnce(ReviewerSelection.pickReviews);
+    });
+
     describe('created check-run', () => {
       it('contains coverage information in the output', () => {
         sandbox
@@ -181,13 +202,6 @@ describe('owners check', () => {
           expect(checkRun.summary).toEqual(
             'Missing required OWNERS approvals! Suggested reviewers: extra_reviewer, root_owner'
           );
-        });
-
-        it('runs reviewer selection', () => {
-          sandbox.stub(ReviewerSelection, 'pickReviews').callThrough();
-          ownersCheck.run();
-
-          sandbox.assert.calledOnce(ReviewerSelection.pickReviews);
         });
 
         it('contains review suggestions in the output', () => {


### PR DESCRIPTION
For the purposes of selecting reviewers, assume that anyone already added to the PR will eventually approve it. Especially relevant in subsequent runs of the check, such as after new commits or reviewers adding approval.