### PR TITLE
Use `minimatch` to support brace expansion

### DIFF
--- a/owners/OWNERS.example.yaml
+++ b/owners/OWNERS.example.yaml
@@ -10,15 +10,16 @@
 # The top-level structure must be a list. Any usernames in this top-level list
 # will be considered owners of all files and subdirectories of this directory.
 - someuser
-- anotheruser
 
 # Usernames should not be prefixed with '@'. This will raise a parsing error.
 # - @dontdothis
 - dothisinstead
 - "@thiswillworkbutdontdoit"
 
-# Teams are not supported. The following owner declaration will be ignored.
-- teams/arenotsupported
+# GitHub teams are also supported as owners. When a team is declared as an
+# owner, it is treated the same as if all members of the team were listed as
+# owners individually
+- ampproject/wg-cool-team
 
 # Individual filenames can be listed, with owners as the value. The value can be
 # a single owner on the same line, or a list of many on the following lines.
@@ -53,23 +54,21 @@
 # appropriate OWNERS file should be created/updated in that subdirectory.
 - this/pattern/will/be/ignored.txt: doesntmatter
 
-# Filename and pattern rules may be combined with commas. They will be treated
-# as separate rules. An error in one sub-pattern will not block the rest from
-# being parsed.
-- "*.js, *.css": frontend
-- "a/bad/pattern, package.json, **/.eslintrc": somebodyelse
+# Filename and pattern rules may be combined with brace expansion.
+- "*.{js,css}": frontend
+- "package.{,lock.}json": somebodyelse
 
 
 # The result of parsing this file would be a tree with these rules:
 #
-# All files:       someuser, anotheruser, dothisinstead, thiswillworkbutdontdoit
-# ./package.json:  fileowner
-# ./.eslintrc:     styleperson, infraperson
-# ./*.js:          scripter
-# ./package*.json: infraperson, developer
-# **/.eslintrc:    styleperson
-# **/*.protoascii: languageperson, translator
-# *.js:            frontend
-# *.css:           frontend
-# package.json:    somebodyelse
-# **/.eslintrc:    somebodyelse
+# */**:                  someuser, dothisinstead, thiswillworkbutdontdoit
+#                        ampproject/wg-cool-team [member, othermember, etc]
+# ./package.json:        fileowner
+# ./.eslintrc:           styleperson, infraperson
+# ./*.js:                scripter
+# ./package*.json:       infraperson, developer
+# **/.eslintrc:          styleperson
+# **/*.protoascii:       languageperson, translator
+# *.{js,css}:            frontend
+# package.{,lock.}json:  somebodyelse
+# **/.eslintrc:          somebodyelse

--- a/owners/package.json
+++ b/owners/package.json
@@ -17,6 +17,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "lodash": "4.17.15",
+    "minimatch": "3.0.4",
     "probot": "7.5.0",
     "sleep-promise": "8.0.1",
     "yamljs": "0.3.0"

--- a/owners/src/rules.js
+++ b/owners/src/rules.js
@@ -15,6 +15,7 @@
  */
 
 const path = require('path');
+const minimatch = require('minimatch');
 
 /**
  * A rule describing ownership for a directory.
@@ -88,12 +89,14 @@ class PatternOwnersRule extends OwnersRule {
   constructor(ownersPath, owners, pattern) {
     super(ownersPath, owners);
     this.pattern = pattern;
-    this.regex = new RegExp(
-      pattern
-        .split('*')
-        .map(PatternOwnersRule.escapeRegexChars)
-        .join('.*?')
-    );
+    this.regex = minimatch.makeRe(pattern, {
+      matchBase: true,
+      noglobstar: true,
+      noext: true,
+      nocase: true,
+      nocomment: true,
+      nonegate: true,
+    });
   }
 
   /**
@@ -103,16 +106,6 @@ class PatternOwnersRule extends OwnersRule {
    */
   get label() {
     return `**/${this.pattern}`;
-  }
-
-  /**
-   * Escapes all regex characters in a string.
-   *
-   * @param {!string} str string to escape.
-   * @return {string} copy of the string that can be used in a regex.
-   */
-  static escapeRegexChars(str) {
-    return str.replace(/[[\]{}()*+?.\\^$|]/g, '\\$&');
   }
 
   /**

--- a/owners/test/parser.test.js
+++ b/owners/test/parser.test.js
@@ -198,15 +198,6 @@ describe('owners parser', () => {
           "Failed to parse rule for pattern 'foo/*.js'; directory patterns other than '**/' not supported"
         );
       });
-
-      it('parses comma-separate patterns as separate rules', () => {
-        sandbox.stub(repo, 'readFile').returns('- *.js, *.css: frontend\n');
-        const fileParse = parser.parseOwnersFile('');
-        const rules = fileParse.result;
-
-        expect(rules[0].pattern).toEqual('*.js');
-        expect(rules[1].pattern).toEqual('*.css');
-      });
     });
 
     describe('files containing top-level dictionaries', () => {

--- a/owners/test/rules.test.js
+++ b/owners/test/rules.test.js
@@ -64,22 +64,6 @@ describe('owners rules', () => {
   });
 
   describe('with glob patterns', () => {
-    describe('constructor', () => {
-      it.each([
-        ['file.txt', /file\.txt/],
-        ['package*.json', /package.*?\.json/],
-      ])('converts the pattern %p into regex %p', (pattern, expectedRegex) => {
-        const rule = new PatternOwnersRule('OWNERS.yaml', [], pattern);
-        expect(rule.regex).toEqual(expectedRegex);
-      });
-    });
-
-    describe('regexEscape', () => {
-      it.each([])('escapes %p as %p', (text, expected) => {
-        expect(PatternOwnersRule.escapeRegexChars(text)).toEqual(expected);
-      });
-    });
-
     describe('matchesFile', () => {
       it('matches literal filenames', () => {
         const rule = new PatternOwnersRule('OWNERS.yaml', [], 'package.json');
@@ -118,6 +102,17 @@ describe('owners rules', () => {
         const rule = new PatternOwnersRule('OWNERS.yaml', [], '*.js');
 
         expect(rule).not.toMatchFile('style.css');
+      });
+
+      it.each([
+        ['*.{js,css}', 'file.js'],
+        ['*.{js,css}', 'style.css'],
+        ['package{,-lock}.json', 'package.json'],
+        ['package{,.lock}.json', 'package.lock.json'],
+      ])('brace-set pattern %p matches file %p', (pattern, filePath) => {
+        expect(new PatternOwnersRule('OWNERS.yaml', [], pattern)).toMatchFile(
+          filePath
+        );
       });
     });
 


### PR DESCRIPTION
Recent updates to owners files highlighted that brace expansion would be useful, at which point it became worth it to use `minimatch`.