### PR TITLE
[owners] Create a comment tagging owners with the always-notify modifier

### DIFF
--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -137,6 +137,27 @@ class OwnersBot {
     await this.runOwnersCheck(github, pr);
   }
 
+  async createNotifications(github, prNumber, fileTreeMap) {
+    const botComments = await github.getBotComments(prNumber);
+    if (botComments.length) {
+      // Avoid adding duplicate notification comment.
+      return;
+    }
+
+    const notifies = this._getNotifies(fileTreeMap);
+
+    const tag = name => `@${name}`;
+    const header = 'Some owners are notified of changes to files in this PR:'
+    const fileNotifyComments = Object.entries(notifies).map(
+      ([filename, names]) => `- ${filename}: ${names.map(tag).join(', ')}`
+    );
+
+    if (fileNotifyComments.length) {
+      const comment = [header, ...fileNotifyComments].join('\n');
+      await github.createBotComment(prNumber, comment);
+    }
+  }
+
   /**
    * Identifies all reviewers and whether their latest reviews are approvals.
    *

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -150,6 +150,8 @@ class OwnersBot {
     const botComments = await github.getBotComments(prNumber);
     if (botComments.length) {
       // Avoid adding duplicate notification comment.
+      // TODO(rcebulko): Handle cases where the fileset changes after PR
+      // creation.
       return;
     }
 

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -123,6 +123,8 @@ class OwnersBot {
 
       await github.createReviewRequests(pr.number, reviewRequests);
     }
+
+    await this.createNotifications(github, pr.number, fileTreeMap);
   }
 
   /**

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -139,6 +139,13 @@ class OwnersBot {
     await this.runOwnersCheck(github, pr);
   }
 
+  /**
+   * Adds a comment tagging always-notify owners of changed files.
+   *
+   * @param {!GitHub} github GitHub API interface.
+   * @param {!number} prNumber pull request number.
+   * @param {!FileTreeMap} fileTreeMap map from filenames to ownership subtrees.
+   */
   async createNotifications(github, prNumber, fileTreeMap) {
     const botComments = await github.getBotComments(prNumber);
     if (botComments.length) {
@@ -149,7 +156,7 @@ class OwnersBot {
     const notifies = this._getNotifies(fileTreeMap);
 
     const tag = name => `@${name}`;
-    const header = 'Some owners are notified of changes to files in this PR:'
+    const header = 'Some owners are notified of changes to files in this PR:';
     const fileNotifyComments = Object.entries(notifies).map(
       ([filename, names]) => `- ${filename}: ${names.map(tag).join(', ')}`
     );

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -20,6 +20,7 @@ const owners = require('..');
 const {Probot} = require('probot');
 const sinon = require('sinon');
 const {LocalRepository} = require('../src/local_repo');
+const {GitHub} = require('../src/github');
 const {OwnersParser} = require('../src/parser');
 const {UserOwner} = require('../src/owner');
 const {OwnersRule} = require('../src/rules');
@@ -65,6 +66,7 @@ describe('owners bot', () => {
     // Disabled execution of `git pull` for testing.
     sandbox.stub(LocalRepository.prototype, 'checkout');
     sandbox.stub(OwnersBot.prototype, 'initTeams');
+    sandbox.stub(GitHub.prototype, 'getBotComments').returns([]);
     sandbox.stub(CheckRun.prototype, 'helpText').value('HELP TEXT');
     sandbox
       .stub(OwnersParser.prototype, 'parseAllOwnersRules')

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -157,6 +157,8 @@ describe('owners bot', () => {
       sandbox.stub(GitHub.prototype, 'getReviews').returns([]);
       sandbox.stub(GitHub.prototype, 'listFiles').returns([]);
       sandbox.stub(GitHub.prototype, 'createReviewRequests');
+      sandbox.stub(GitHub.prototype, 'getBotComments').returns([]);
+      sandbox.stub(GitHub.prototype, 'createBotComment');
     });
 
     it('attempts to fetch the existing check-run ID', async () => {
@@ -241,6 +243,16 @@ describe('owners bot', () => {
         ]);
         done();
       });
+
+    it('creates a notification comment', async () => {
+      expect.assertions(1);
+      getCheckRunIdsStub.returns({});
+      sandbox.stub(OwnersBot.prototype, 'createNotifications');
+      await ownersBot.runOwnersCheck(github, pr);
+
+      sandbox.assert.calledOnce(ownersBot.createNotifications);
+      // Ensures the test fails if the assertion is never run.
+      expect(true).toBe(true);
     });
   });
 

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -251,15 +251,12 @@ describe('owners bot', () => {
         done();
       });
 
-    it('creates a notification comment', async () => {
-      expect.assertions(1);
-      getCheckRunIdsStub.returns({});
+    it('creates a notification comment', async done => {
       sandbox.stub(OwnersBot.prototype, 'createNotifications');
       await ownersBot.runOwnersCheck(github, pr);
 
       sandbox.assert.calledOnce(ownersBot.createNotifications);
-      // Ensures the test fails if the assertion is never run.
-      expect(true).toBe(true);
+      done();
     });
   });
 
@@ -300,13 +297,11 @@ describe('owners bot', () => {
         sandbox.stub(GitHub.prototype, 'getBotComments').returns(['a comment']);
       });
 
-      it('does not create a comment', async () => {
-        expect.assertions(1);
+      it('does not create a comment', async done => {
         await ownersBot.createNotifications(github, 1337, fileTreeMap);
 
         sandbox.assert.notCalled(github.createBotComment);
-        // Ensures the test fails if the assertion is never run.
-        expect(true).toBe(true);
+        done();
       });
     });
 
@@ -315,14 +310,12 @@ describe('owners bot', () => {
         sandbox.stub(GitHub.prototype, 'getBotComments').returns([]);
       });
 
-      it('gets users and teams to notify', async () => {
-        expect.assertions(1);
+      it('gets users and teams to notify', async done => {
         sandbox.stub(OwnersBot.prototype, '_getNotifies').returns([]);
         await ownersBot.createNotifications(github, 1337, fileTreeMap);
 
         sandbox.assert.calledWith(ownersBot._getNotifies, fileTreeMap);
-        // Ensures the test fails if the assertion is never run.
-        expect(true).toBe(true);
+        done();
       });
 
       describe('when there are users or teams to notify', () => {
@@ -346,13 +339,11 @@ describe('owners bot', () => {
       });
 
       describe('when there are no users or teams to notify', () => {
-        it('does not create a comment', async () => {
-          expect.assertions(1);
+        it('does not create a comment', async done => {
           await ownersBot.createNotifications(github, 1337, fileTreeMap);
 
           sandbox.assert.notCalled(github.createBotComment);
-          // Ensures the test fails if the assertion is never run.
-          expect(true).toBe(true);
+          done();
         });
       });
     });

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -321,7 +321,8 @@ describe('owners bot', () => {
       describe('when there are users or teams to notify', () => {
         beforeEach(() => {
           sandbox.stub(OwnersBot.prototype, '_getNotifies').returns({
-            'foo/main.js': ['a_subscriber', 'ampproject/some_team'],
+            'a_subscriber': ['foo/main.js'],
+            'ampproject/some_team': ['foo/main.js'],
           });
         });
 
@@ -333,7 +334,8 @@ describe('owners bot', () => {
           const [prNumber, comment] = github.createBotComment.getCall(0).args;
           expect(prNumber).toEqual(1337);
           expect(comment).toContain(
-            '- foo/main.js: @a_subscriber, @ampproject/some_team'
+            'Hey @a_subscriber, these files were changed:\n- foo/main.js',
+            'Hey @ampproject/some_team, these files were changed:\n- foo/main.js'
           );
         });
       });
@@ -445,26 +447,27 @@ describe('owners bot', () => {
         new TeamOwner(relevantTeam, OWNER_MODIFIER.NOTIFY),
       ])
     );
+    tree.addRule(new OwnersRule('baz/OWNERS.yaml', [new UserOwner('rando')]));
 
     it('includes user owners with the always-notify modifier', () => {
       const fileTreeMap = tree.buildFileTreeMap(['foo/main.js']);
       const notifies = ownersBot._getNotifies(fileTreeMap);
 
-      expect(notifies['foo/main.js']).toContain('relevant_user');
+      expect(notifies['relevant_user']).toContain('foo/main.js');
     });
 
     it('includes team owners with the always-notify modifier', () => {
       const fileTreeMap = tree.buildFileTreeMap(['bar/script.js']);
       const notifies = ownersBot._getNotifies(fileTreeMap);
 
-      expect(notifies['bar/script.js']).toContain('ampproject/relevant_team');
+      expect(notifies['ampproject/relevant_team']).toContain('bar/script.js');
     });
 
     it('excludes files with no always-notify owners', () => {
       const fileTreeMap = tree.buildFileTreeMap(['baz/test.js']);
       const notifies = ownersBot._getNotifies(fileTreeMap);
 
-      expect(notifies['baz/test.js']).toBeUndefined();
+      expect(notifies['rando']).toBeUndefined();
     });
   });
 });

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -29,8 +29,15 @@ const {
 } = require('../src/owners_check');
 
 describe('owners bot', () => {
+  const silentLogger = {
+    debug: () => {},
+    log: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+
   let sandbox;
-  const github = new GitHub({}, 'ampproject', 'amphtml', console);
+  const github = new GitHub({}, 'ampproject', 'amphtml', silentLogger);
   const pr = new PullRequest(1337, 'the_author', '_test_hash_', 'descrption');
   const localRepo = new LocalRepository('path/to/repo');
   const ownersBot = new OwnersBot(localRepo);
@@ -105,14 +112,14 @@ describe('owners bot', () => {
     it('warns about parsing errors', async () => {
       expect.assertions(1);
       const error = new Error('Oops!');
-      sandbox.stub(console, 'warn');
+      sandbox.stub(silentLogger, 'warn');
       sandbox.stub(OwnersParser.prototype, 'parseOwnersTree').returns({
         tree: new OwnersTree(),
         errors: [error],
       });
       await ownersBot.initPr(github, pr);
 
-      sandbox.assert.calledWith(console.warn, error);
+      sandbox.assert.calledWith(silentLogger.warn, error);
       // Ensures the test fails if the assertion is never run.
       expect(true).toBe(true);
     });

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -317,7 +317,7 @@ describe('owners bot', () => {
 
       it('gets users and teams to notify', async () => {
         expect.assertions(1);
-        sandbox.stub(OwnersBot.prototype, '_getNotifies').returns([])
+        sandbox.stub(OwnersBot.prototype, '_getNotifies').returns([]);
         await ownersBot.createNotifications(github, 1337, fileTreeMap);
 
         sandbox.assert.calledWith(ownersBot._getNotifies, fileTreeMap);
@@ -328,7 +328,7 @@ describe('owners bot', () => {
       describe('when there are users or teams to notify', () => {
         beforeEach(() => {
           sandbox.stub(OwnersBot.prototype, '_getNotifies').returns({
-            'foo/main.js': ['a_subscriber', 'ampproject/some_team']
+            'foo/main.js': ['a_subscriber', 'ampproject/some_team'],
           });
         });
 
@@ -344,7 +344,7 @@ describe('owners bot', () => {
           );
         });
       });
-        
+
       describe('when there are no users or teams to notify', () => {
         it('does not create a comment', async () => {
           expect.assertions(1);

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -250,6 +250,7 @@ describe('owners bot', () => {
         ]);
         done();
       });
+    });
 
     it('creates a notification comment', async done => {
       sandbox.stub(OwnersBot.prototype, 'createNotifications');


### PR DESCRIPTION
Owners specified as always-notify, ie. `!rcebulko`, should be tagged on a PR even if they are not a reviewer. This PR uses existing API interfaces to verify that such a comment does not yet exist, determine which users/teams should be notified for which files, and creates a PR comment tagging those users/teams.