### PR TITLE
[owners] Add backwards compatibility for comma-separated rules without braces

### DIFF
--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -180,7 +180,7 @@ class GitHub {
         `/orgs/${this.owner}/teams?page=${pageNum}`
       );
       const nextLink = response.headers.link || '';
-      isNextLink = nextLink.indexOf('rel="next"') !== -1;
+      isNextLink = nextLink.includes('rel="next"');
 
       const teamPage = response.data;
       teamsList.push(...teamPage);

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -108,7 +108,7 @@ class OwnersParser {
       owner = owner.slice(1);
     }
 
-    if (owner.indexOf('/') !== -1) {
+    if (owner.includes('/')) {
       const team = this.teamMap[owner];
 
       if (team) {
@@ -187,7 +187,7 @@ class OwnersParser {
         pattern = pattern.slice(GLOB_PATTERN.length);
       }
 
-      if (pattern.indexOf('/') !== -1) {
+      if (pattern.includes('/')) {
         errors.push(
           new OwnersParserError(
             ownersPath,

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -167,53 +167,64 @@ class OwnersParser {
    *     rule.
    */
   _parseOwnersDict(ownersPath, ownersDict) {
-    let [[pattern, ownersList]] = Object.entries(ownersDict);
+    const [[fullPattern, ownersList]] = Object.entries(ownersDict);
     const rules = [];
     const errors = [];
+    let patternList = [];
 
-    const owners = [];
-    const isRecursive = pattern.startsWith(GLOB_PATTERN);
-    if (isRecursive) {
-      pattern = pattern.slice(GLOB_PATTERN.length);
-    }
-
-    if (pattern.indexOf('/') !== -1) {
-      errors.push(
-        new OwnersParserError(
-          ownersPath,
-          `Failed to parse rule for pattern '${pattern}'; ` +
-            `directory patterns other than '${GLOB_PATTERN}' not supported`
-        )
-      );
-    } else if (typeof ownersList === 'string') {
-      const lineResult = this._parseOwnersLine(ownersPath, ownersList);
-      owners.push(...lineResult.result);
-      errors.push(...lineResult.errors);
+    // TODO(rcebulko): Remove backwards-compatibility once all owners files have
+    // been updated to use brace syntax.
+    if (fullPattern.indexOf('{') === -1) {
+      patternList = fullPattern.split(/\s*,\s*/);
     } else {
-      ownersList.forEach(owner => {
-        if (typeof owner === 'string') {
-          const lineResult = this._parseOwnersLine(ownersPath, owner);
-          owners.push(...lineResult.result);
-          errors.push(...lineResult.errors);
-        } else {
-          errors.push(
-            new OwnersParserError(
-              ownersPath,
-              `Failed to parse owner of type ${typeof owner} for pattern ` +
-                `rule '${pattern}'`
-            )
-          );
-        }
-      });
+      patternList = [fullPattern];
     }
 
-    if (owners.length) {
+    patternList.forEach(pattern => {
+      const owners = [];
+      const isRecursive = pattern.startsWith(GLOB_PATTERN);
       if (isRecursive) {
-        rules.push(new PatternOwnersRule(ownersPath, owners, pattern));
-      } else {
-        rules.push(new SameDirPatternOwnersRule(ownersPath, owners, pattern));
+        pattern = pattern.slice(GLOB_PATTERN.length);
       }
-    }
+
+      if (pattern.indexOf('/') !== -1) {
+        errors.push(
+          new OwnersParserError(
+            ownersPath,
+            `Failed to parse rule for pattern '${pattern}'; ` +
+              `directory patterns other than '${GLOB_PATTERN}' not supported`
+          )
+        );
+      } else if (typeof ownersList === 'string') {
+        const lineResult = this._parseOwnersLine(ownersPath, ownersList);
+        owners.push(...lineResult.result);
+        errors.push(...lineResult.errors);
+      } else {
+        ownersList.forEach(owner => {
+          if (typeof owner === 'string') {
+            const lineResult = this._parseOwnersLine(ownersPath, owner);
+            owners.push(...lineResult.result);
+            errors.push(...lineResult.errors);
+          } else {
+            errors.push(
+              new OwnersParserError(
+                ownersPath,
+                `Failed to parse owner of type ${typeof owner} for pattern ` +
+                  `rule '${pattern}'`
+              )
+            );
+          }
+        });
+      }
+
+      if (owners.length) {
+        if (isRecursive) {
+          rules.push(new PatternOwnersRule(ownersPath, owners, pattern));
+        } else {
+          rules.push(new SameDirPatternOwnersRule(ownersPath, owners, pattern));
+        }
+      }
+    });
 
     return {result: rules, errors};
   }

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -174,7 +174,7 @@ class OwnersParser {
 
     // TODO(rcebulko): Remove backwards-compatibility once all owners files have
     // been updated to use brace syntax.
-    if (fullPattern.indexOf('{') === -1) {
+    if (!fullPattern.includes('{')) {
       patternList = fullPattern.split(/\s*,\s*/);
     } else {
       patternList = [fullPattern];

--- a/owners/test/parser.test.js
+++ b/owners/test/parser.test.js
@@ -199,13 +199,13 @@ describe('owners parser', () => {
         );
       });
 
-      it('parses comma-separate patterns as separate rules', () => {  
-        sandbox.stub(repo, 'readFile').returns('- *.js, *.css: frontend\n');  
-        const fileParse = parser.parseOwnersFile(''); 
-        const rules = fileParse.result; 
+      it('parses comma-separate patterns as separate rules', () => {
+        sandbox.stub(repo, 'readFile').returns('- *.js, *.css: frontend\n');
+        const fileParse = parser.parseOwnersFile('');
+        const rules = fileParse.result;
 
-        expect(rules[0].pattern).toEqual('*.js'); 
-        expect(rules[1].pattern).toEqual('*.css');  
+        expect(rules[0].pattern).toEqual('*.js');
+        expect(rules[1].pattern).toEqual('*.css');
       });
     });
 

--- a/owners/test/parser.test.js
+++ b/owners/test/parser.test.js
@@ -198,6 +198,15 @@ describe('owners parser', () => {
           "Failed to parse rule for pattern 'foo/*.js'; directory patterns other than '**/' not supported"
         );
       });
+
+      it('parses comma-separate patterns as separate rules', () => {  
+        sandbox.stub(repo, 'readFile').returns('- *.js, *.css: frontend\n');  
+        const fileParse = parser.parseOwnersFile(''); 
+        const rules = fileParse.result; 
+
+        expect(rules[0].pattern).toEqual('*.js'); 
+        expect(rules[1].pattern).toEqual('*.css');  
+      });
     });
 
     describe('files containing top-level dictionaries', () => {


### PR DESCRIPTION
Pull #437 added support for brace-set expansion, but that broke backwards-compatibility with comma-delimited rules since they could no longer be split by commas. Since the comma-separated form is already in use in the repo, this PR reverts to the original comma-separated functionality for rules which do not contain a brace `{}`, allowing existing comma-delimited rules to remain. Once this is submitted and deployed, I will update existing rules to use the brace-set syntax and remove this backwards compatibility (it is not documented in the [example file](https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example.yaml))