### PR TITLE
[owners] Add a "require review" modifier

### DIFF
--- a/owners/src/owner.js
+++ b/owners/src/owner.js
@@ -18,6 +18,7 @@ const OWNER_MODIFIER = {
   NONE: '',
   NOTIFY: 'always notify',
   SILENT: 'never notify',
+  REQUIRE: 'require review',
 };
 
 /**

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -93,6 +93,9 @@ class OwnersParser {
     } else if (owner.startsWith('#')) {
       modifier = OWNER_MODIFIER.NOTIFY;
       owner = owner.slice(1);
+    } else if (owner.startsWith('!')) {
+      modifier = OWNER_MODIFIER.REQUIRE;
+      owner = owner.slice(1);
     }
 
     if (owner.startsWith('@')) {

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -90,7 +90,7 @@ class OwnersParser {
     if (owner.startsWith('?')) {
       modifier = OWNER_MODIFIER.SILENT;
       owner = owner.slice(1);
-    } else if (owner.startsWith('!')) {
+    } else if (owner.startsWith('#')) {
       modifier = OWNER_MODIFIER.NOTIFY;
       owner = owner.slice(1);
     }

--- a/owners/test/parser.test.js
+++ b/owners/test/parser.test.js
@@ -244,6 +244,16 @@ describe('owners parser', () => {
             new UserOwner('auser', OWNER_MODIFIER.SILENT)
           );
         });
+
+        it('parses a require-review `!` modifier', () => {
+          sandbox.stub(repo, 'readFile').returns('- "!auser"');
+          const fileParse = parser.parseOwnersFile('');
+          const rules = fileParse.result;
+
+          expect(rules[0].owners).toContainEqual(
+            new UserOwner('auser', OWNER_MODIFIER.REQUIRE)
+          );
+        });
       });
 
       describe('team owner', () => {
@@ -264,6 +274,15 @@ describe('owners parser', () => {
           expect(teamOwner.name).toEqual('ampproject/my_team');
           expect(teamOwner.modifier).toEqual(OWNER_MODIFIER.SILENT);
         });
+
+        it('parses a require-review `!` team modifier', () => {
+          sandbox.stub(repo, 'readFile').returns('- "!ampproject/my_team"');
+          const fileParse = parser.parseOwnersFile('');
+          const teamOwner = fileParse.result[0].owners[0];
+
+          expect(teamOwner.name).toEqual('ampproject/my_team');
+          expect(teamOwner.modifier).toEqual(OWNER_MODIFIER.REQUIRE);
+        });
       });
 
       describe('wildcard owner', () => {
@@ -281,6 +300,18 @@ describe('owners parser', () => {
 
         it('reports an error for a never-notify `?` modifier', () => {
           sandbox.stub(repo, 'readFile').returns('- "?*"');
+          const {result, errors} = parser.parseOwnersFile('');
+
+          expect(result[0].owners[0]).toEqual(
+            new WildcardOwner(OWNER_MODIFIER.NONE)
+          );
+          expect(errors[0].message).toEqual(
+            'Modifiers not supported on wildcard `*` owner'
+          );
+        });
+
+        it('reports an error for a require-review `!` modifier', () => {
+          sandbox.stub(repo, 'readFile').returns('- "!*"');
           const {result, errors} = parser.parseOwnersFile('');
 
           expect(result[0].owners[0]).toEqual(

--- a/owners/test/parser.test.js
+++ b/owners/test/parser.test.js
@@ -225,8 +225,8 @@ describe('owners parser', () => {
 
     describe('owner modifiers', () => {
       describe('user owner', () => {
-        it('parses an always-notify `!` modifier', () => {
-          sandbox.stub(repo, 'readFile').returns('- "!auser"');
+        it('parses an always-notify `#` modifier', () => {
+          sandbox.stub(repo, 'readFile').returns('- "#auser"');
           const fileParse = parser.parseOwnersFile('');
           const rules = fileParse.result;
 
@@ -247,8 +247,8 @@ describe('owners parser', () => {
       });
 
       describe('team owner', () => {
-        it('parses an always-notify `!` team modifier', () => {
-          sandbox.stub(repo, 'readFile').returns('- "!ampproject/my_team"');
+        it('parses an always-notify `#` team modifier', () => {
+          sandbox.stub(repo, 'readFile').returns('- "#ampproject/my_team"');
           const fileParse = parser.parseOwnersFile('');
           const teamOwner = fileParse.result[0].owners[0];
 
@@ -267,8 +267,8 @@ describe('owners parser', () => {
       });
 
       describe('wildcard owner', () => {
-        it('reports an error for an always-notify `!` modifier', () => {
-          sandbox.stub(repo, 'readFile').returns('- "!*"');
+        it('reports an error for an always-notify `#` modifier', () => {
+          sandbox.stub(repo, 'readFile').returns('- "#*"');
           const {result, errors} = parser.parseOwnersFile('');
 
           expect(result[0].owners[0]).toEqual(


### PR DESCRIPTION
In some instances (such as validator files), certain types of files or directories should require reviews even when they have an owner's approval. In the case of validator files, even though they may live within individual extensions and could be approved by low-level owners, they should require approval from a member of wg-caching before submission. This PR adds that "gatekeeper" modifier.