### PR TITLE
[owners] Request reviewers if PR description contains #addowners

### DIFF
--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -24,9 +24,10 @@ class PullRequest {
    * @param {number} number pull request number.
    * @param {!string} author username of the pull request author.
    * @param {!string} headSha SHA hash of the PR's HEAD commit.
+   * @param {!string} description pull request description.
    */
-  constructor(number, author, headSha) {
-    Object.assign(this, {number, author, headSha});
+  constructor(number, author, headSha, description) {
+    Object.assign(this, {number, author, headSha, description});
   }
 
   /**
@@ -36,7 +37,12 @@ class PullRequest {
    * @return {PullRequest} a pull request instance.
    */
   static fromGitHubResponse(res) {
-    return new PullRequest(res.number, res.user.login, res.head.sha);
+    return new PullRequest(
+      res.number,
+      res.user.login,
+      res.head.sha,
+      res.body,
+    );
   }
 }
 

--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -37,12 +37,7 @@ class PullRequest {
    * @return {PullRequest} a pull request instance.
    */
   static fromGitHubResponse(res) {
-    return new PullRequest(
-      res.number,
-      res.user.login,
-      res.head.sha,
-      res.body,
-    );
+    return new PullRequest(res.number, res.user.login, res.head.sha, res.body);
   }
 }
 

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -156,19 +156,21 @@ class OwnersBot {
   /**
    * Determine the set of users to request reviews from.
    *
-   * @param {Set<!OwnersTree>} trees set of ownership trees touched by the PR.
+   * @param {!FileTreeMap} fileTreeMap map from filenames to ownership subtrees.
    * @param {string[]} suggestedReviewers list of suggested reviewer usernames.
    * @return {Set<string>} set of usernames.
    */
-  _getReviewRequests(trees, suggestedReviewers) {
+  _getReviewRequests(fileTreeMap, suggestedReviewers) {
     const reviewers = new Set(suggestedReviewers);
-    trees.forEach(tree =>
-      tree
+    Object.entries(fileTreeMap).forEach(([filename, subtree]) => {
+      // TODO(rcebulko): Update to pass filename once PR #452 is submitted and
+      // this branch is rebased.
+      subtree
         .getModifiedOwners(OWNER_MODIFIER.SILENT)
         .map(owner => owner.allUsernames)
         .reduce((left, right) => left.concat(right), [])
         .forEach(reviewers.delete, reviewers)
-    );
+    });
 
     return reviewers;
   }

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -182,7 +182,7 @@ class OwnersBot {
         .getModifiedOwners(OWNER_MODIFIER.SILENT)
         .map(owner => owner.allUsernames)
         .reduce((left, right) => left.concat(right), [])
-        .forEach(reviewers.delete, reviewers)
+        .forEach(reviewers.delete, reviewers);
     });
 
     return reviewers;

--- a/owners/test/fixtures/pulls/pull_request.35.json
+++ b/owners/test/fixtures/pulls/pull_request.35.json
@@ -30,7 +30,7 @@
         "type": "User",
         "site_admin": false
     },
-    "body": "",
+    "body": "Pull request description",
     "created_at": "2019-01-22T17:22:51Z",
     "updated_at": "2019-02-26T20:53:31Z",
     "closed_at": null,

--- a/owners/test/github.test.js
+++ b/owners/test/github.test.js
@@ -42,6 +42,7 @@ describe('pull request', () => {
       expect(pr.number).toEqual(35);
       expect(pr.author).toEqual('ampprojectbot');
       expect(pr.headSha).toEqual('9272f18514cbd3fa935b3ced62ae1c2bf6efa76d');
+      expect(pr.description).toEqual('Pull request description');
     });
   });
 });

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -220,7 +220,7 @@ describe('owners bot', () => {
       });
     });
 
-    it('does not create review requests', async (done) => {
+    it('does not create review requests', async done => {
       await ownersBot.runOwnersCheck(github, pr);
 
       sandbox.assert.notCalled(github.createReviewRequests);
@@ -232,18 +232,16 @@ describe('owners bot', () => {
         pr.description = 'Assign reviewers please #addowners';
       });
 
-      it('requests reviewers', async (done) => {
-        sandbox.stub(OwnersBot.prototype, '_getReviewRequests').returns([
+      it('requests reviewers', async done => {
+        sandbox
+          .stub(OwnersBot.prototype, '_getReviewRequests')
+          .returns(['auser', 'anotheruser']);
+        await ownersBot.runOwnersCheck(github, pr);
+
+        sandbox.assert.calledWith(github.createReviewRequests, 1337, [
           'auser',
           'anotheruser',
         ]);
-        await ownersBot.runOwnersCheck(github, pr);
-
-        sandbox.assert.calledWith(
-          github.createReviewRequests,
-          1337,
-          ['auser', 'anotheruser']
-        );
         done();
       });
     });
@@ -319,12 +317,12 @@ describe('owners bot', () => {
 
       tree.addRule(
         new OwnersRule('foo/OWNERS.yaml', [
-          new UserOwner('busy_user', OWNER_MODIFIER.SILENT)
+          new UserOwner('busy_user', OWNER_MODIFIER.SILENT),
         ])
       );
       tree.addRule(
         new OwnersRule('foo/OWNERS.yaml', [
-          new TeamOwner(busyTeam, OWNER_MODIFIER.SILENT)
+          new TeamOwner(busyTeam, OWNER_MODIFIER.SILENT),
         ])
       );
 
@@ -332,25 +330,25 @@ describe('owners bot', () => {
     });
 
     it('includes suggested reviewers', () => {
-      const reviewRequests = ownersBot._getReviewRequests(fileTreeMap, ['auser']);
+      const reviewRequests = ownersBot._getReviewRequests(fileTreeMap, [
+        'auser',
+      ]);
 
       expect(Array.from(reviewRequests)).toContain('auser');
     });
 
     it('excludes user owners with the no-notify modifier', () => {
-      const reviewRequests = ownersBot._getReviewRequests(
-        fileTreeMap,
-        ['busy_user']
-      );
+      const reviewRequests = ownersBot._getReviewRequests(fileTreeMap, [
+        'busy_user',
+      ]);
 
       expect(Array.from(reviewRequests)).not.toContain('busy_user');
     });
 
     it('excludes members of team owners with the no-notify modifier', () => {
-      const reviewRequests = ownersBot._getReviewRequests(
-        fileTreeMap,
-        ['busy_member']
-      );
+      const reviewRequests = ownersBot._getReviewRequests(fileTreeMap, [
+        'busy_member',
+      ]);
 
       expect(Array.from(reviewRequests)).not.toContain('busy_member');
     });

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -31,7 +31,7 @@ const {
 describe('owners bot', () => {
   let sandbox;
   const github = new GitHub({}, 'ampproject', 'amphtml', console);
-  const pr = new PullRequest(1337, 'the_author', '_test_hash_');
+  const pr = new PullRequest(1337, 'the_author', '_test_hash_', 'descrption');
   const localRepo = new LocalRepository('path/to/repo');
   const ownersBot = new OwnersBot(localRepo);
 


### PR DESCRIPTION
In order to start testing out reviewer assignment without fully enabling it everywhere, this PR makes the Owners Bot use the PR description as a gatekeeper. If and only if the description contains `#addowners`, it will assign reviewers to the PR.