### PR TITLE
[owners] Disable stdout logging stream during test

### DIFF
--- a/owners/index.js
+++ b/owners/index.js
@@ -47,11 +47,13 @@ module.exports = app => {
 
   // Probot does not stream properly to GCE logs so we need to hook into
   // bunyan explicitly and stream it to process.stdout.
-  app.log.target.addStream({
-    name: 'app-custom-stream',
-    stream: process.stdout,
-    level: process.env.LOG_LEVEL || 'info',
-  });
+  if (process.env.NODE_ENV !== 'test') {
+    app.log.target.addStream({
+      name: 'app-custom-stream',
+      stream: process.stdout,
+      level: process.env.LOG_LEVEL || 'info',
+    });
+  }
 
   /** Health check server endpoints **/
   // TODO(rcebulko): Implement GitHub authentication to prevent spamming any of

--- a/owners/test/github.test.js
+++ b/owners/test/github.test.js
@@ -180,7 +180,10 @@ describe('GitHub API', () => {
 
   describe('customRequest', () => {
     beforeEach(() => {
-      sandbox.stub(process, 'env').value({GITHUB_ACCESS_TOKEN: '_TOKEN_'});
+      sandbox.stub(process, 'env').value({
+        ...process.env,
+        GITHUB_ACCESS_TOKEN: '_TOKEN_',
+      });
     });
 
     it('returns the response', async () => {

--- a/owners/test/github.test.js
+++ b/owners/test/github.test.js
@@ -181,8 +181,8 @@ describe('GitHub API', () => {
   describe('customRequest', () => {
     beforeEach(() => {
       sandbox.stub(process, 'env').value({
-        ...process.env,
         GITHUB_ACCESS_TOKEN: '_TOKEN_',
+        NODE_ENV: 'test',
       });
     });
 

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -62,7 +62,7 @@ describe('owners bot', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    sandbox.stub(process, 'env').value({...process.env, GITHUB_REPO_DIR});
+    sandbox.stub(process, 'env').value({GITHUB_REPO_DIR, NODE_ENV: 'test'});
     // Disabled execution of `git pull` for testing.
     sandbox.stub(LocalRepository.prototype, 'checkout');
     sandbox.stub(OwnersBot.prototype, 'initTeams');

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -62,7 +62,7 @@ describe('owners bot', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    sandbox.stub(process, 'env').value({GITHUB_REPO_DIR});
+    sandbox.stub(process, 'env').value({...process.env, GITHUB_REPO_DIR});
     // Disabled execution of `git pull` for testing.
     sandbox.stub(LocalRepository.prototype, 'checkout');
     sandbox.stub(OwnersBot.prototype, 'initTeams');


### PR DESCRIPTION
Bunyan logging evidently needs special treatment in order to properly log to GCE, but the code implementing this was still running during tests and made test output excessively verbose. This PR gates the `app.log.target.addStream` call, skipping if the node environment is `'test'`