### PR TITLE
[owners] Prioritize more specific rules during reviewer selection.

### DIFF
--- a/owners/index.js
+++ b/owners/index.js
@@ -92,7 +92,7 @@ module.exports = app => {
     const {tree, changedFiles, reviewers} = await ownersBot.initPr(github, pr);
     const ownersCheck = new OwnersCheck(tree, changedFiles, reviewers);
 
-    const checkRun = ownersCheck.run();
+    const {checkRun} = ownersCheck.run();
 
     res.send(checkRun.json);
   });

--- a/owners/src/reviewer_selection.js
+++ b/owners/src/reviewer_selection.js
@@ -39,35 +39,45 @@ class ReviewerSelection {
   /** Part 1 **/
 
   /**
-   * Produce a set of all ownership subtrees directly owning a changed file.
+   * Produce a set of rules at the deepest layer of ownership.
    *
    * @private
    * @param {!FileTreeMap} fileTreeMap map from filenames to ownership subtrees.
-   * @return {Set<OwnersTree>} a set of the nearest ownership subtrees.
+   * @return {Set<OwnersRule>} a set of the most specific ownership rules.
    */
-  static _nearestOwnersTrees(fileTreeMap) {
-    const trees = new Set(Object.values(fileTreeMap));
-    return Array.from(trees);
+  static _deepestOwnersRules(fileTreeMap) {
+    const maxDepth = Math.max(
+      ...Object.values(fileTreeMap).map(tree => tree.depth)
+    );
+
+    const deepRules = Object.entries(fileTreeMap)
+      .filter(([filename, subtree]) => subtree.depth === maxDepth)
+      .map(([filename, subtree]) => 
+        subtree.rules.filter(rule => rule.matchesFile(filename))
+      )
+      .reduce((left, right) => left.concat(right), []);
+
+    return Array.from(new Set(deepRules));
   }
 
   /**
-   * Produce the set of all owners for a set of ownership trees.
+   * Produce the set of all owners for a set of ownership rules.
    *
    * @private
-   * @param {OwnersTree[]} trees list of ownership trees.
-   * @return {string[]} union of reviewers lists for all trees.
+   * @param {OwnersRule[]} rules list of ownership rules.
+   * @return {string[]} union of reviewers lists for highest priority rules.
    */
-  static _reviewersForTrees(trees) {
+  static _reviewersForRules(rules) {
     const reviewers = new Set();
-    trees.forEach(tree => {
-      tree.rules
-        .filter(rule => !rule.wildcardOwner)
-        .forEach(rule => {
-          rule.owners.forEach(owner => {
-            owner.allUsernames.forEach(username => reviewers.add(username));
-          });
-        });
-    });
+    const maxPriority = Math.max(...rules.map(rule => rule.priority));
+
+    rules.filter(rule => rule.priority === maxPriority)
+        .map(rule => rule.owners)
+        .reduce((left, right) => left.concat(right), [])
+        .map(owner => owner.allUsernames)
+        .reduce((left, right) => left.concat(right), [])
+        .forEach(username => reviewers.add(username));
+
     return Array.from(reviewers);
   }
 
@@ -80,10 +90,8 @@ class ReviewerSelection {
    * @return {string[]} list of reviewer usernames.
    */
   static _findPotentialReviewers(fileTreeMap) {
-    const nearestTrees = this._nearestOwnersTrees(fileTreeMap);
-    const maxDepth = Math.max(...nearestTrees.map(tree => tree.depth));
-    const deepestTrees = nearestTrees.filter(tree => tree.depth === maxDepth);
-    return this._reviewersForTrees(deepestTrees);
+    const deepestRules = this._deepestOwnersRules(fileTreeMap);
+    return this._reviewersForRules(deepestRules);
   }
 
   /** Part 2 **/

--- a/owners/src/reviewer_selection.js
+++ b/owners/src/reviewer_selection.js
@@ -52,7 +52,7 @@ class ReviewerSelection {
 
     const deepRules = Object.entries(fileTreeMap)
       .filter(([filename, subtree]) => subtree.depth === maxDepth)
-      .map(([filename, subtree]) => 
+      .map(([filename, subtree]) =>
         subtree.rules.filter(rule => rule.matchesFile(filename))
       )
       .reduce((left, right) => left.concat(right), []);
@@ -71,12 +71,13 @@ class ReviewerSelection {
     const reviewers = new Set();
     const maxPriority = Math.max(...rules.map(rule => rule.priority));
 
-    rules.filter(rule => rule.priority === maxPriority)
-        .map(rule => rule.owners)
-        .reduce((left, right) => left.concat(right), [])
-        .map(owner => owner.allUsernames)
-        .reduce((left, right) => left.concat(right), [])
-        .forEach(username => reviewers.add(username));
+    rules
+      .filter(rule => rule.priority === maxPriority)
+      .map(rule => rule.owners)
+      .reduce((left, right) => left.concat(right), [])
+      .map(owner => owner.allUsernames)
+      .reduce((left, right) => left.concat(right), [])
+      .forEach(username => reviewers.add(username));
 
     return Array.from(reviewers);
   }

--- a/owners/src/rules.js
+++ b/owners/src/rules.js
@@ -34,6 +34,7 @@ class OwnersRule {
     this.filePath = ownersPath;
     this.dirPath = path.dirname(ownersPath);
     this.owners = owners;
+    this.priority = 1;
   }
 
   /**
@@ -97,6 +98,7 @@ class PatternOwnersRule extends OwnersRule {
       nocomment: true,
       nonegate: true,
     });
+    this.priority = 2;
   }
 
   /**
@@ -123,6 +125,18 @@ class PatternOwnersRule extends OwnersRule {
  * A pattern-based ownership rule applying only to files in the same directory.
  */
 class SameDirPatternOwnersRule extends PatternOwnersRule {
+  /**
+   * Constructor.
+   *
+   * @param {!string} ownersPath path to OWNERS file.
+   * @param {string[]} owners list of GitHub usernames of owners.
+   * @param {!string} pattern filename/type pattern.
+   */
+  constructor(ownersPath, owners, pattern) {
+    super(ownersPath, owners, pattern);
+    this.priority = 3;
+  }
+
   /**
    * The label to use when describing the rule.
    *

--- a/owners/src/rules.js
+++ b/owners/src/rules.js
@@ -21,7 +21,7 @@ const RULE_PRIORITY = {
   DIRECTORY: 1,
   RECURSIVE_PATTERN: 2,
   SAME_DIRECTORY_PATTERN: 3,
-}
+};
 
 /**
  * A rule describing ownership for a directory.

--- a/owners/src/rules.js
+++ b/owners/src/rules.js
@@ -17,6 +17,12 @@
 const path = require('path');
 const minimatch = require('minimatch');
 
+const RULE_PRIORITY = {
+  DIRECTORY: 1,
+  RECURSIVE_PATTERN: 2,
+  SAME_DIRECTORY_PATTERN: 3,
+}
+
 /**
  * A rule describing ownership for a directory.
  */
@@ -34,7 +40,7 @@ class OwnersRule {
     this.filePath = ownersPath;
     this.dirPath = path.dirname(ownersPath);
     this.owners = owners;
-    this.priority = 1;
+    this.priority = RULE_PRIORITY.DIRECTORY;
   }
 
   /**
@@ -98,7 +104,7 @@ class PatternOwnersRule extends OwnersRule {
       nocomment: true,
       nonegate: true,
     });
-    this.priority = 2;
+    this.priority = RULE_PRIORITY.RECURSIVE_PATTERN;
   }
 
   /**
@@ -134,7 +140,7 @@ class SameDirPatternOwnersRule extends PatternOwnersRule {
    */
   constructor(ownersPath, owners, pattern) {
     super(ownersPath, owners, pattern);
-    this.priority = 3;
+    this.priority = RULE_PRIORITY.SAME_DIRECTORY_PATTERN;
   }
 
   /**
@@ -159,4 +165,9 @@ class SameDirPatternOwnersRule extends PatternOwnersRule {
   }
 }
 
-module.exports = {OwnersRule, PatternOwnersRule, SameDirPatternOwnersRule};
+module.exports = {
+  OwnersRule,
+  PatternOwnersRule,
+  SameDirPatternOwnersRule,
+  RULE_PRIORITY,
+};

--- a/owners/src/rules.js
+++ b/owners/src/rules.js
@@ -17,6 +17,14 @@
 const path = require('path');
 const minimatch = require('minimatch');
 
+/**
+ * The priority level for a rule.
+ *
+ * Since reviewer selection targets the most-specific rules, it should consider
+ * patterns to be more specific than directory owners. These priorities are used
+ * to determine which set of rules are the most specific so they can be targeted
+ * first.
+ */
 const RULE_PRIORITY = {
   DIRECTORY: 1,
   RECURSIVE_PATTERN: 2,

--- a/owners/test/reviewer_selection.test.js
+++ b/owners/test/reviewer_selection.test.js
@@ -17,54 +17,88 @@
 const sinon = require('sinon');
 const {ReviewerSelection} = require('../src/reviewer_selection');
 const {Team} = require('../src/github');
-const {UserOwner, TeamOwner} = require('../src/owner');
+const {UserOwner, TeamOwner, WildcardOwner} = require('../src/owner');
 const {OwnersTree} = require('../src/owners_tree');
-const {OwnersRule} = require('../src/rules');
+const {
+  OwnersRule,
+  PatternOwnersRule,
+  SameDirPatternOwnersRule
+} = require('../src/rules');
 
 describe('reviewer selection', () => {
   const sandbox = sinon.createSandbox();
-  const ownersTree = new OwnersTree();
+  let ownersTree;
+  let dirTrees;
+
   const myTeam = new Team(42, 'ampproject', 'my_team');
   myTeam.members = ['child', 'kid'];
 
-  const dirTrees = {
-    '/': ownersTree.addRule(
-      new OwnersRule('OWNERS.yaml', [new UserOwner('rootOwner')])
-    ),
-    '/foo': ownersTree.addRule(
-      new OwnersRule('foo/OWNERS.yaml', [new UserOwner('child')])
-    ),
-    '/biz': ownersTree.addRule(
-      new OwnersRule('biz/OWNERS.yaml', [new TeamOwner(myTeam)])
-    ),
-    '/buzz': ownersTree.addRule(
-      new OwnersRule('buzz/OWNERS.yaml', [new UserOwner('thirdChild')])
-    ),
-    '/foo/bar/baz': ownersTree.addRule(
-      new OwnersRule('foo/bar/baz/OWNERS.yaml', [new UserOwner('descendant')])
+
+  dirRules = {
+    '/': new OwnersRule('OWNERS.yaml', [new UserOwner('rootOwner')]),
+    '/foo': new OwnersRule('foo/OWNERS.yaml', [new UserOwner('child')]),
+    '/biz': new OwnersRule('biz/OWNERS.yaml', [new TeamOwner(myTeam)]),
+    '/buzz': new OwnersRule('buzz/OWNERS.yaml', [new UserOwner('thirdChild')]),
+    '/foo/bar/baz': new OwnersRule(
+      'foo/bar/baz/OWNERS.yaml',
+      [new UserOwner('descendant')],
     ),
   };
+  const wildcardRule = new OwnersRule(
+    'foo/bar/baz/OWNERS.yaml',
+    [new WildcardOwner()],
+  );
+
+  beforeEach(() => {
+    ownersTree = new OwnersTree();
+    dirTrees = {
+      '/': ownersTree.addRule(dirRules['/']),
+      '/foo': ownersTree.addRule(dirRules['/foo']),
+      '/biz': ownersTree.addRule(dirRules['/biz']),
+      '/buzz': ownersTree.addRule(dirRules['/buzz']),
+      '/foo/bar/baz': ownersTree.addRule(dirRules['/foo/bar/baz']),
+    };
+  });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  describe('nearestOwnersTrees', () => {
-    it('returns the nearest trees', () => {
+  describe('deepestOwnersRules', () => {
+    it('returns rules from the deepest trees', () => {
       const fileTreeMap = ownersTree.buildFileTreeMap([
         './main.js',
         'biz/style.css',
         'foo/bar/other_file.js',
       ]);
-      const nearestTrees = ReviewerSelection._nearestOwnersTrees(fileTreeMap);
+      const deepestRules = ReviewerSelection._deepestOwnersRules(fileTreeMap);
 
-      expect(nearestTrees).toEqual(
-        expect.arrayContaining([
-          dirTrees['/'],
-          dirTrees['/biz'],
-          dirTrees['/foo'],
-        ])
-      );
+      expect(deepestRules).toContain(dirRules['/biz'], dirRules['/foo']);
+    });
+
+    it('excludes rules from higher-level trees', () => {
+      const fileTreeMap = ownersTree.buildFileTreeMap([
+        './main.js',
+        'biz/style.css',
+        'foo/bar/other_file.js',
+      ]);
+      const deepestRules = ReviewerSelection._deepestOwnersRules(fileTreeMap);
+
+      expect(deepestRules).toContain(dirRules['/foo']);
+      expect(deepestRules).not.toContain(dirRules['.']);
+    });
+
+    it('excludes rules with wildcard owners', () => {
+      ownersTree.addRule(wildcardRule);
+      const fileTreeMap = ownersTree.buildFileTreeMap([
+        './main.js',
+        'biz/style.css',
+        'foo/bar/other_file.js',
+      ]);
+      const deepestRules = ReviewerSelection._deepestOwnersRules(fileTreeMap);
+
+      expect(deepestRules).toContain(dirRules['/foo']);
+      expect(deepestRules).not.toContain(dirRules['.']);
     });
 
     it('does not return duplicates', () => {
@@ -72,17 +106,17 @@ describe('reviewer selection', () => {
         'foo/file.js',
         'foo/bar/other_file.js',
       ]);
-      const nearestTrees = ReviewerSelection._nearestOwnersTrees(fileTreeMap);
+      const deepestRules = ReviewerSelection._deepestOwnersRules(fileTreeMap);
 
-      expect(nearestTrees).toEqual([dirTrees['/foo']]);
+      expect(deepestRules).toEqual([dirRules['/foo']]);
     });
   });
 
-  describe('reviewersForTrees', () => {
+  describe('reviewersForRules', () => {
     it('unions the owners for all subtrees', () => {
-      const reviewers = ReviewerSelection._reviewersForTrees([
-        dirTrees['/biz'],
-        dirTrees['/foo/bar/baz'],
+      const reviewers = ReviewerSelection._reviewersForRules([
+        dirRules['/biz'],
+        dirRules['/foo/bar/baz'],
       ]);
 
       expect(reviewers).toEqual(
@@ -91,11 +125,72 @@ describe('reviewer selection', () => {
     });
 
     it('does not include inherited owners', () => {
-      const reviewers = ReviewerSelection._reviewersForTrees([
-        dirTrees['/foo'],
+      const reviewers = ReviewerSelection._reviewersForRules([
+        dirRules['/foo'],
       ]);
 
       expect(reviewers).not.toContain('rootOwner');
+    });
+
+    describe('rule priority', () => {
+      const sameDirPatternRule = new SameDirPatternOwnersRule(
+        'priority/OWNERS.yaml',
+        [new UserOwner('same_dir_pattern_owner')],
+        '*.css',
+      );
+      const recursivePatternRule = new PatternOwnersRule(
+        'priority/OWNERS.yaml',
+        [new UserOwner('recursive_pattern_owner')],
+        '*.js',
+      );
+      const directoryRule = new OwnersRule(
+        'priority/OWNERS.yaml',
+        [new UserOwner('directory_owner')],
+      );
+
+      describe('when a same-directory pattern rule is present', () => {
+        const reviewers = ReviewerSelection._reviewersForRules([
+          directoryRule,
+          recursivePatternRule,
+          sameDirPatternRule
+        ]);
+
+        it('returns same-directory pattern rule owners', () => {
+          expect(reviewers).toContain('same_dir_pattern_owner')
+        });
+
+        it('does not return recursive pattern rule owners', () => {
+          expect(reviewers).not.toContain('recursive_pattern_owner');
+        });
+
+        it('does not return directory owners', () => {
+          expect(reviewers).not.toContain('directory_owner');
+        });
+      });
+
+      describe('when no same-directory pattern rule is present', () => {
+        describe('when a recursive pattern rule is present', () => {
+          const reviewers = ReviewerSelection._reviewersForRules([
+            directoryRule,
+            recursivePatternRule
+          ]);
+
+          it('returns recursive pattern rule owners', () => {
+            expect(reviewers).toContain('recursive_pattern_owner');
+          });
+            
+          it('does not return directory owners', () => {
+            expect(reviewers).not.toContain('directory_owner');
+          });
+        });
+
+        describe('when no recursive pattern rule is present', () => {
+          it('returns directory owners', () => {
+            reviewers = ReviewerSelection._reviewersForRules([directoryRule]);
+            expect(reviewers).toContain('directory_owner');
+          });
+        });
+      });
     });
   });
 
@@ -106,25 +201,18 @@ describe('reviewer selection', () => {
         'biz/style.css',
         'foo/bar/other_file.js',
       ]);
-      sandbox.stub(ReviewerSelection, '_reviewersForTrees').callThrough();
+      sandbox.stub(ReviewerSelection, '_reviewersForRules').callThrough();
       const reviewers = ReviewerSelection._findPotentialReviewers(fileTreeMap);
 
       sandbox.assert.calledWith(
-        ReviewerSelection._reviewersForTrees,
-        sinon.match.array.contains([dirTrees['/foo'], dirTrees['/biz']])
+        ReviewerSelection._reviewersForRules,
+        sinon.match.array.contains([dirRules['/foo'], dirRules['/biz']])
       );
       expect(reviewers).toEqual(expect.arrayContaining(['child', 'kid']));
     });
   });
 
   describe('filesOwnedByReviewer', () => {
-    const fileTreeMap = ownersTree.buildFileTreeMap([
-      './main.js', // root
-      'biz/style.css', // child, kid, root
-      'foo/bar/other_file.js', // child, root
-      'foo/bar/baz/README.md', // descendant, child, root
-    ]);
-
     const filesOwnedMap = {
       'rootOwner': [
         './main.js',
@@ -140,6 +228,16 @@ describe('reviewer selection', () => {
       'kid': ['biz/style.css'],
       'descendant': ['foo/bar/baz/README.md'],
     };
+    let fileTreeMap;
+
+    beforeAll(() => {
+      fileTreeMap = ownersTree.buildFileTreeMap([
+        './main.js', // root
+        'biz/style.css', // child, kid, root
+        'foo/bar/other_file.js', // child, root
+        'foo/bar/baz/README.md', // descendant, child, root
+      ]);
+    });
 
     it.each(Object.entries(filesOwnedMap))(
       'lists files for %p',
@@ -172,13 +270,17 @@ describe('reviewer selection', () => {
   });
 
   describe('pickBestReview', () => {
-    const fileTreeMap = ownersTree.buildFileTreeMap([
-      './main.js', // root
-      'biz/style.css', // child, kid, root
-      'foo/bar/other_file.js', // child, root
-      'buzz/info.txt', // thirdChild, root
-      'buzz/code.js', // thirdChild, root
-    ]);
+    let fileTreeMap;
+
+    beforeAll(() => {
+      fileTreeMap = ownersTree.buildFileTreeMap([
+        './main.js', // root
+        'biz/style.css', // child, kid, root
+        'foo/bar/other_file.js', // child, root
+        'buzz/info.txt', // thirdChild, root
+        'buzz/code.js', // thirdChild, root
+      ]);
+    });
 
     it('builds a map from deepest reviewers to files they own', () => {
       sandbox.stub(ReviewerSelection, '_reviewersWithMostFiles').callThrough();

--- a/owners/test/reviewer_selection.test.js
+++ b/owners/test/reviewer_selection.test.js
@@ -22,42 +22,36 @@ const {OwnersTree} = require('../src/owners_tree');
 const {
   OwnersRule,
   PatternOwnersRule,
-  SameDirPatternOwnersRule
+  SameDirPatternOwnersRule,
 } = require('../src/rules');
 
 describe('reviewer selection', () => {
   const sandbox = sinon.createSandbox();
   let ownersTree;
-  let dirTrees;
 
   const myTeam = new Team(42, 'ampproject', 'my_team');
   myTeam.members = ['child', 'kid'];
 
-
-  dirRules = {
+  const dirRules = {
     '/': new OwnersRule('OWNERS.yaml', [new UserOwner('rootOwner')]),
     '/foo': new OwnersRule('foo/OWNERS.yaml', [new UserOwner('child')]),
     '/biz': new OwnersRule('biz/OWNERS.yaml', [new TeamOwner(myTeam)]),
     '/buzz': new OwnersRule('buzz/OWNERS.yaml', [new UserOwner('thirdChild')]),
-    '/foo/bar/baz': new OwnersRule(
-      'foo/bar/baz/OWNERS.yaml',
-      [new UserOwner('descendant')],
-    ),
+    '/foo/bar/baz': new OwnersRule('foo/bar/baz/OWNERS.yaml', [
+      new UserOwner('descendant'),
+    ]),
   };
-  const wildcardRule = new OwnersRule(
-    'foo/bar/baz/OWNERS.yaml',
-    [new WildcardOwner()],
-  );
+  const wildcardRule = new OwnersRule('foo/bar/baz/OWNERS.yaml', [
+    new WildcardOwner(),
+  ]);
 
   beforeEach(() => {
     ownersTree = new OwnersTree();
-    dirTrees = {
-      '/': ownersTree.addRule(dirRules['/']),
-      '/foo': ownersTree.addRule(dirRules['/foo']),
-      '/biz': ownersTree.addRule(dirRules['/biz']),
-      '/buzz': ownersTree.addRule(dirRules['/buzz']),
-      '/foo/bar/baz': ownersTree.addRule(dirRules['/foo/bar/baz']),
-    };
+    ownersTree.addRule(dirRules['/']);
+    ownersTree.addRule(dirRules['/foo']);
+    ownersTree.addRule(dirRules['/biz']);
+    ownersTree.addRule(dirRules['/buzz']);
+    ownersTree.addRule(dirRules['/foo/bar/baz']);
   });
 
   afterEach(() => {
@@ -136,27 +130,26 @@ describe('reviewer selection', () => {
       const sameDirPatternRule = new SameDirPatternOwnersRule(
         'priority/OWNERS.yaml',
         [new UserOwner('same_dir_pattern_owner')],
-        '*.css',
+        '*.css'
       );
       const recursivePatternRule = new PatternOwnersRule(
         'priority/OWNERS.yaml',
         [new UserOwner('recursive_pattern_owner')],
-        '*.js',
+        '*.js'
       );
-      const directoryRule = new OwnersRule(
-        'priority/OWNERS.yaml',
-        [new UserOwner('directory_owner')],
-      );
+      const directoryRule = new OwnersRule('priority/OWNERS.yaml', [
+        new UserOwner('directory_owner'),
+      ]);
 
       describe('when a same-directory pattern rule is present', () => {
         const reviewers = ReviewerSelection._reviewersForRules([
           directoryRule,
           recursivePatternRule,
-          sameDirPatternRule
+          sameDirPatternRule,
         ]);
 
         it('returns same-directory pattern rule owners', () => {
-          expect(reviewers).toContain('same_dir_pattern_owner')
+          expect(reviewers).toContain('same_dir_pattern_owner');
         });
 
         it('does not return recursive pattern rule owners', () => {
@@ -172,13 +165,13 @@ describe('reviewer selection', () => {
         describe('when a recursive pattern rule is present', () => {
           const reviewers = ReviewerSelection._reviewersForRules([
             directoryRule,
-            recursivePatternRule
+            recursivePatternRule,
           ]);
 
           it('returns recursive pattern rule owners', () => {
             expect(reviewers).toContain('recursive_pattern_owner');
           });
-            
+
           it('does not return directory owners', () => {
             expect(reviewers).not.toContain('directory_owner');
           });
@@ -186,7 +179,9 @@ describe('reviewer selection', () => {
 
         describe('when no recursive pattern rule is present', () => {
           it('returns directory owners', () => {
-            reviewers = ReviewerSelection._reviewersForRules([directoryRule]);
+            const reviewers = ReviewerSelection._reviewersForRules([
+              directoryRule,
+            ]);
             expect(reviewers).toContain('directory_owner');
           });
         });

--- a/owners/test/rules.test.js
+++ b/owners/test/rules.test.js
@@ -54,6 +54,14 @@ describe('owners rules', () => {
       });
     });
 
+    describe('priority', () => {
+      it('is 1', () => {
+        const rule = new OwnersRule('OWNERS.yaml', []);
+
+        expect(rule.priority).toBe(1);
+      });
+    });
+
     describe('toString', () => {
       it('lists all owners', () => {
         const rule = new OwnersRule('OWNERS.yaml', ['rcebulko', 'erwinmombay']);
@@ -124,6 +132,14 @@ describe('owners rules', () => {
       });
     });
 
+    describe('priority', () => {
+      it('is 2', () => {
+        const rule = new PatternOwnersRule('OWNERS.yaml', [], '*.css');
+
+        expect(rule.priority).toBe(2);
+      });
+    });
+
     describe('toString', () => {
       it('lists all owners for the pattern', () => {
         const rule = new PatternOwnersRule(
@@ -142,6 +158,12 @@ describe('owners rules', () => {
       describe('label', () => {
         it('is the pattern in the "./" directory', () => {
           expect(rule.label).toEqual('./*.js');
+        });
+      });
+
+      describe('priority', () => {
+        it('is 3', () => {
+          expect(rule.priority).toBe(3);
         });
       });
 

--- a/owners/test/rules.test.js
+++ b/owners/test/rules.test.js
@@ -18,6 +18,7 @@ const {
   OwnersRule,
   PatternOwnersRule,
   SameDirPatternOwnersRule,
+  RULE_PRIORITY,
 } = require('../src/rules');
 
 describe('owners rules', () => {
@@ -55,10 +56,10 @@ describe('owners rules', () => {
     });
 
     describe('priority', () => {
-      it('is 1', () => {
+      it('is DIRECTORY', () => {
         const rule = new OwnersRule('OWNERS.yaml', []);
 
-        expect(rule.priority).toBe(1);
+        expect(rule.priority).toBe(RULE_PRIORITY.DIRECTORY);
       });
     });
 
@@ -133,10 +134,10 @@ describe('owners rules', () => {
     });
 
     describe('priority', () => {
-      it('is 2', () => {
+      it('is RECURSIVE_PATTERN', () => {
         const rule = new PatternOwnersRule('OWNERS.yaml', [], '*.css');
 
-        expect(rule.priority).toBe(2);
+        expect(rule.priority).toBe(RULE_PRIORITY.RECURSIVE_PATTERN);
       });
     });
 
@@ -162,8 +163,8 @@ describe('owners rules', () => {
       });
 
       describe('priority', () => {
-        it('is 3', () => {
-          expect(rule.priority).toBe(3);
+        it('is SAME_DIRECTORY_PATTERN', () => {
+          expect(rule.priority).toBe(RULE_PRIORITY.SAME_DIRECTORY_PATTERN);
         });
       });
 


### PR DESCRIPTION
In cases where pattern rules apply to files, owners of those patterns should be suggested before owners of the whole directory. This is especially relevant in cases of top-level pattern rules, which are currently being treated as equal with top level owners. This PR updates reviewer selection so that when multiple types of rules are present at the same depth, the most specific rules are the ones used to choose the next reviewer.