### PR TITLE
[owners] Add pending reviewers to the current reviewer set

### DIFF
--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -83,6 +83,10 @@ class OwnersBot {
 
     const changedFiles = await github.listFiles(pr.number);
     const reviewers = await this._getCurrentReviewers(github, pr);
+    const pendingReviewers = await github.getReviewRequests(pr.number);
+    pendingReviewers.forEach(reviewer => {
+      reviewers[reviewer] = false;
+    });
 
     return {tree, changedFiles, reviewers};
   }

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -203,7 +203,7 @@ class OwnersBot {
    *
    * @param {!FileTreeMap} fileTreeMap map from filenames to ownership subtrees.
    * @param {string[]} suggestedReviewers list of suggested reviewer usernames.
-   * @return {Set<string>} set of usernames.
+   * @return {string[]} set of usernames.
    */
   _getReviewRequests(fileTreeMap, suggestedReviewers) {
     const reviewers = new Set(suggestedReviewers);
@@ -215,7 +215,7 @@ class OwnersBot {
         .forEach(reviewers.delete, reviewers);
     });
 
-    return reviewers;
+    return Array.from(reviewers);
   }
 
   /**

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -67,6 +67,7 @@ describe('owners bot', () => {
     sandbox.stub(LocalRepository.prototype, 'checkout');
     sandbox.stub(OwnersBot.prototype, 'initTeams');
     sandbox.stub(GitHub.prototype, 'getBotComments').returns([]);
+    sandbox.stub(GitHub.prototype, 'getReviewRequests').returns([]);
     sandbox.stub(CheckRun.prototype, 'helpText').value('HELP TEXT');
     sandbox
       .stub(OwnersParser.prototype, 'parseAllOwnersRules')

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -100,6 +100,9 @@ describe('owners bot', () => {
           {filename: 'changed_file1.js', sha: '_sha1_'},
           {filename: 'foo/changed_file2.js', sha: '_sha2_'},
         ]);
+      sandbox.stub(GitHub.prototype, 'getReviewRequests').returns([
+        'requested'
+      ]);
     });
 
     it('parses the owners tree', async () => {
@@ -127,6 +130,13 @@ describe('owners bot', () => {
 
       expect(reviewers['approver']).toBe(true);
       expect(reviewers['other_approver']).toBe(true);
+    });
+
+    it('finds the requested reviewers', async () => {
+      expect.assertions(1);
+      const {reviewers} = await ownersBot.initPr(github, pr);
+
+      expect(reviewers['requested']).toBe(false);
     });
 
     it('fetches the files changed in the PR', async () => {
@@ -160,6 +170,7 @@ describe('owners bot', () => {
       sandbox.stub(GitHub.prototype, 'createCheckRun');
       sandbox.stub(GitHub.prototype, 'getReviews').returns([]);
       sandbox.stub(GitHub.prototype, 'listFiles').returns([]);
+      sandbox.stub(GitHub.prototype, 'getReviewRequests').returns([]);
       sandbox.stub(GitHub.prototype, 'createReviewRequests');
       sandbox.stub(GitHub.prototype, 'getBotComments').returns([]);
       sandbox.stub(GitHub.prototype, 'createBotComment');

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -100,9 +100,9 @@ describe('owners bot', () => {
           {filename: 'changed_file1.js', sha: '_sha1_'},
           {filename: 'foo/changed_file2.js', sha: '_sha2_'},
         ]);
-      sandbox.stub(GitHub.prototype, 'getReviewRequests').returns([
-        'requested'
-      ]);
+      sandbox
+        .stub(GitHub.prototype, 'getReviewRequests')
+        .returns(['requested']);
     });
 
     it('parses the owners tree', async () => {


### PR DESCRIPTION
Ensures that the bot does not suggest new reviewers when the pending reviewers could provide owners coverage. The logic for this had been written already, it was just never wired together.