### PR TITLE
Lowercase all usernames coming in via GitHub or parser

### DIFF
--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -246,7 +246,7 @@ class GitHub {
           json.user.login.toLowerCase(),
           json.state,
           new Date(json.submitted_at)
-      )
+        )
     );
   }
 

--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -37,7 +37,12 @@ class PullRequest {
    * @return {PullRequest} a pull request instance.
    */
   static fromGitHubResponse(res) {
-    return new PullRequest(res.number, res.user.login, res.head.sha, res.body);
+    return new PullRequest(
+      res.number,
+      res.user.login.toLowerCase(),
+      res.head.sha,
+      res.body
+    );
   }
 }
 
@@ -207,7 +212,7 @@ class GitHub {
     const memberList = response.data;
     this.logger.debug('[getTeamMembers]', teamId, memberList);
 
-    return memberList.map(({login}) => login);
+    return memberList.map(({login}) => login.toLowerCase());
   }
 
   /**
@@ -237,7 +242,11 @@ class GitHub {
 
     return response.data.map(
       json =>
-        new Review(json.user.login, json.state, new Date(json.submitted_at))
+        new Review(
+          json.user.login.toLowerCase(),
+          json.state,
+          new Date(json.submitted_at)
+      )
     );
   }
 
@@ -278,7 +287,7 @@ class GitHub {
     );
     this.logger.debug('[getReviewRequests]', number, response.data);
 
-    return response.data.users.map(({login}) => login);
+    return response.data.users.map(({login}) => login.toLowerCase());
   }
 
   /**

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -87,6 +87,8 @@ class OwnersParser {
     const errors = [];
     let modifier = OWNER_MODIFIER.NONE;
 
+    owner = owner.toLowerCase();
+
     if (owner.startsWith('?')) {
       modifier = OWNER_MODIFIER.SILENT;
       owner = owner.slice(1);


### PR DESCRIPTION
@Enriqe raised the point that case-sensitivity could cause silent bugs in ownership. This PR sanitizes usernames by lowercasing them all at any points they enter the app--notably, either when parsing the owners files or through the few GitHub APIs which return usernames.

Ideally, we could overload the equality operator for owners to be case-insensitive; however, that's not supported in ES6, and much of the owners bot logic is written with maps, sets, `Array.includes(...)`, etc. which are all case-sensitive string comparison operations.