### PR TITLE
Don't @mention the author in a notification comment

### DIFF
--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -239,7 +239,6 @@ class OwnersBot {
         });
     });
 
-
     return notifies;
   }
 }

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -124,7 +124,7 @@ class OwnersBot {
       await github.createReviewRequests(pr.number, reviewRequests);
     }
 
-    await this.createNotifications(github, pr.number, fileTreeMap);
+    await this.createNotifications(github, pr, fileTreeMap);
   }
 
   /**
@@ -143,12 +143,13 @@ class OwnersBot {
    * Adds a comment tagging always-notify owners of changed files.
    *
    * @param {!GitHub} github GitHub API interface.
-   * @param {!number} prNumber pull request number.
+   * @param {!PullRequest} pr pull request to create notifications on.
    * @param {!FileTreeMap} fileTreeMap map from filenames to ownership subtrees.
    */
-  async createNotifications(github, prNumber, fileTreeMap) {
-    const [botComment] = await github.getBotComments(prNumber);
+  async createNotifications(github, pr, fileTreeMap) {
+    const [botComment] = await github.getBotComments(pr.number);
     const notifies = this._getNotifies(fileTreeMap);
+    delete notifies[pr.author];
 
     const fileNotifyComments = Object.entries(notifies).map(
       ([name, filenames]) => {
@@ -166,7 +167,7 @@ class OwnersBot {
     if (botComment) {
       await github.updateComment(botComment.id, comment);
     } else {
-      await github.createBotComment(prNumber, comment);
+      await github.createBotComment(pr.number, comment);
     }
   }
 
@@ -237,6 +238,7 @@ class OwnersBot {
           notifies[name].push(filename);
         });
     });
+
 
     return notifies;
   }

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -282,7 +282,7 @@ describe('owners bot', () => {
 
     it('gets users and teams to notify', async done => {
       sandbox.stub(OwnersBot.prototype, '_getNotifies').returns([]);
-      await ownersBot.createNotifications(github, 1337, fileTreeMap);
+      await ownersBot.createNotifications(github, pr, fileTreeMap);
 
       sandbox.assert.calledWith(ownersBot._getNotifies, fileTreeMap);
       done();
@@ -302,7 +302,7 @@ describe('owners bot', () => {
         });
 
         it('does not create a comment', async done => {
-          await ownersBot.createNotifications(github, 1337, fileTreeMap);
+          await ownersBot.createNotifications(github, pr, fileTreeMap);
 
           sandbox.assert.notCalled(github.createBotComment);
           done();
@@ -310,7 +310,7 @@ describe('owners bot', () => {
 
         it('updates the existing comment', async () => {
           expect.assertions(2);
-          await ownersBot.createNotifications(github, 1337, fileTreeMap);
+          await ownersBot.createNotifications(github, pr, fileTreeMap);
 
           sandbox.assert.calledOnce(github.updateComment);
           const [commentId, comment] = github.updateComment.getCall(0).args;
@@ -325,7 +325,7 @@ describe('owners bot', () => {
       describe('when no comment by the bot exists yet', () => {
         it('creates a comment tagging users and teams', async () => {
           expect.assertions(2);
-          await ownersBot.createNotifications(github, 1337, fileTreeMap);
+          await ownersBot.createNotifications(github, pr, fileTreeMap);
 
           sandbox.assert.calledOnce(github.createBotComment);
           const [prNumber, comment] = github.createBotComment.getCall(0).args;
@@ -340,7 +340,7 @@ describe('owners bot', () => {
 
     describe('when there are no users or teams to notify', () => {
       it('does not create or update a comment', async done => {
-        await ownersBot.createNotifications(github, 1337, fileTreeMap);
+        await ownersBot.createNotifications(github, pr, fileTreeMap);
 
         sandbox.assert.notCalled(github.createBotComment);
         sandbox.assert.notCalled(github.updateComment);
@@ -356,7 +356,7 @@ describe('owners bot', () => {
       });
 
       it('does not notify the author', async done => {
-        await ownersBot.createNotifications(github, 1337, fileTreeMap);
+        await ownersBot.createNotifications(github, pr, fileTreeMap);
 
         sandbox.assert.notCalled(github.createBotComment);
         sandbox.assert.notCalled(github.updateComment);

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -347,6 +347,22 @@ describe('owners bot', () => {
         done();
       });
     });
+
+    describe('when the author is on the notify list', () => {
+      beforeEach(() => {
+        sandbox.stub(OwnersBot.prototype, '_getNotifies').returns({
+          'the_author': ['foo/main.js'],
+        });
+      });
+
+      it('does not notify the author', async done => {
+        await ownersBot.createNotifications(github, 1337, fileTreeMap);
+
+        sandbox.assert.notCalled(github.createBotComment);
+        sandbox.assert.notCalled(github.updateComment);
+        done();
+      });
+    });
   });
 
   describe('getCurrentReviewers', () => {


### PR DESCRIPTION
Currently, if the author is on the notify list, they'll get tagged in the notification comment. This PR removes them from the notification set for their own PR.