### PR TITLE
[owners] Handle undocumented bot username suffix

### DIFF
--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -296,8 +296,14 @@ class GitHub {
     const response = await this.client.issues.listComments(this.repo({number}));
     this.logger.debug('[getBotComments]', number, response.data);
 
+    // GitHub appears to respond with the bot's username suffixed by `[bot]`,
+    // though this doesn't appear to be documented anywhere. Since it's not
+    // documented, rather than testing for that suffix explicitly, we just test
+    // for the presence of the username and ignore whatever extras GitHub tacks
+    // on.
+    const regex = new RegExp(`\\b${process.env.GITHUB_BOT_USERNAME}\\b`);
     return response.data
-      .filter(({user}) => user.login === process.env.GITHUB_BOT_USERNAME)
+      .filter(({user}) => regex.test(user.login))
       .map(({id, body}) => {
         return {id, body};
       });

--- a/owners/test/fixtures/comments/issue_comments.438.json
+++ b/owners/test/fixtures/comments/issue_comments.438.json
@@ -6,7 +6,7 @@
     "id": 532484354,
     "node_id": "MDEyOklzc3VlQ29tbWVudDUzMjQ4NDM1NA==",
     "user": {
-      "login": "ampprojectbot",
+      "login": "amp-owners-bot[bot]",
       "id": 23269078,
       "node_id": "MDQ6VXNlcjIzMjY5MDc4",
       "avatar_url": "https://avatars3.githubusercontent.com/u/23269078?v=4",

--- a/owners/test/github.test.js
+++ b/owners/test/github.test.js
@@ -365,7 +365,7 @@ describe('GitHub API', () => {
     it('fetches a list of comments by the bot user', async () => {
       expect.assertions(1);
       sandbox.stub(process, 'env').value({
-        GITHUB_BOT_USERNAME: 'ampprojectbot',
+        GITHUB_BOT_USERNAME: 'amp-owners-bot',
       });
       nock('https://api.github.com')
         .get('/repos/test_owner/test_repo/issues/24574/comments')


### PR DESCRIPTION
When GitHub responds with the list of comments, it appends `[bot]` to the bot's comment `login` field. As far as I can tell, this isn't documented anywhere, but it messes with the logic around identifying if a bot comment exists or not. This PR replaces checking for an exactly-equal username to just testing if the username is present in the `login` field, ignoring any (undocumented) suffixes.