### PR TITLE
[owners] Migrate  review request and notif comment logic into new notifier class

### DIFF
--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -23,22 +23,22 @@ class OwnersNotifier {
   /**
    * Constructor.
    *
+   * @param {!PullRequest} pr pull request to add notifications to.
    * @param {!FileTreeMap} fileTreeMap map from filenames to ownership subtrees.
    */
-  constructor(fileTreeMap) {
-    Object.assign(this, {fileTreeMap});
+  constructor(pr, fileTreeMap) {
+    Object.assign(this, {pr, fileTreeMap});
   }
 
   /**
    * Adds a comment tagging always-notify owners of changed files.
    *
    * @param {!GitHub} github GitHub API interface.
-   * @param {!PullRequest} pr pull request to create notifications on.
    */
-  async createNotificationComment(github, pr) {
-    const [botComment] = await github.getBotComments(pr.number);
+  async createNotificationComment(github) {
+    const [botComment] = await github.getBotComments(this.pr.number);
     const notifies = this.getOwnersToNotify();
-    delete notifies[pr.author];
+    delete notifies[this.pr.author];
 
     const fileNotifyComments = Object.entries(notifies).map(
       ([name, filenames]) => {
@@ -56,7 +56,7 @@ class OwnersNotifier {
     if (botComment) {
       await github.updateComment(botComment.id, comment);
     } else {
-      await github.createBotComment(pr.number, comment);
+      await github.createBotComment(this.pr.number, comment);
     }
   }
 

--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -24,10 +24,14 @@ class OwnersNotifier {
    * Constructor.
    *
    * @param {!PullRequest} pr pull request to add notifications to.
-   * @param {!FileTreeMap} fileTreeMap map from filenames to ownership subtrees.
+   * @param {!OwnersTree} tree file ownership tree.
+   * @param {FileRef[]} changedFiles list of change files.
    */
-  constructor(pr, fileTreeMap) {
-    Object.assign(this, {pr, fileTreeMap});
+  constructor(pr, tree, changedFiles) {
+    Object.assign(this, {pr});
+    this.fileTreeMap = tree.buildFileTreeMap(
+      changedFiles.map(({filename}) => filename)
+    );
   }
 
   /**

--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -35,7 +35,7 @@ class OwnersNotifier {
    * @param {!GitHub} github GitHub API interface.
    * @param {!PullRequest} pr pull request to create notifications on.
    */
-  async createNotificationComments(github, pr) {
+  async createNotificationComment(github, pr) {
     const [botComment] = await github.getBotComments(pr.number);
     const notifies = this.getOwnersToNotify();
     delete notifies[pr.author];

--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
- const {OWNER_MODIFIER} = require('./owner')
+const {OWNER_MODIFIER} = require('./owner')
+const ADD_REVIEWERS_TAG = /#add-?owners/i;
 
 /**
  * Notifier for to tagging and requesting reviewers for a PR.
@@ -32,6 +33,21 @@ class OwnersNotifier {
     this.fileTreeMap = tree.buildFileTreeMap(
       changedFiles.map(({filename}) => filename)
     );
+  }
+
+  /**
+   * Requests reviews from owners.
+   *
+   * Only requests reviews if the PR description contains the #addowners tag.
+   *
+   * @param {!GitHub} github GitHub API interface.
+   * @param {string[]} suggestedReviewers suggested reviewers to add.
+   */
+  async requestReviews(github, suggestedReviewers) {
+    if (ADD_REVIEWERS_TAG.test(this.pr.description)) {
+      const reviewRequests = this.getReviewersToRequest(suggestedReviewers);
+      await github.createReviewRequests(this.pr.number, reviewRequests);
+    }
   }
 
   /**

--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -25,11 +25,12 @@ class OwnersNotifier {
    * Constructor.
    *
    * @param {!PullRequest} pr pull request to add notifications to.
+   * @param {!ReviewerApprovalMap} currentReviewers current reviewer approvals.
    * @param {!OwnersTree} tree file ownership tree.
    * @param {FileRef[]} changedFiles list of change files.
    */
-  constructor(pr, tree, changedFiles) {
-    Object.assign(this, {pr});
+  constructor(pr, currentReviewers, tree, changedFiles) {
+    Object.assign(this, {pr, currentReviewers});
     this.fileTreeMap = tree.buildFileTreeMap(
       changedFiles.map(({filename}) => filename)
     );
@@ -101,6 +102,8 @@ class OwnersNotifier {
 
   /**
    * Determine the set of owners to notify/tag for each file.
+   *
+   * TODO(#473): Exclude existing & suggested reviewers from the notify set.
    *
    * @return {Object<string, string[]>} map from user/team names to filenames.
    */

--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const {OWNER_MODIFIER} = require('./owner')
+const {OWNER_MODIFIER} = require('./owner');
 const ADD_REVIEWERS_TAG = /#add-?owners/i;
 
 /**
@@ -39,11 +39,11 @@ class OwnersNotifier {
   /**
    * Notify reviewers and owners about the PR.
    *
-   * @param {!ReviewerApprovalMap} currentReviewers existing reviewers.
+   * @param {!GitHub} github GitHub API interface.
    * @param {string[]} suggestedReviewers suggested reviewers to add.
    */
   async notify(github, suggestedReviewers) {
-    const requested = await this.requestReviews(github, suggestedReviewers);
+    await this.requestReviews(github, suggestedReviewers);
     // TODO(#473): Add requested reviews to current reviewer set.
     await this.createNotificationComment(github);
   }

--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2019 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ const {OWNER_MODIFIER} = require('./owner')
+
+/**
+ * Notifier for to tagging and requesting reviewers for a PR.
+ */
+class OwnersNotifier {
+  /**
+   * Constructor.
+   *
+   * @param {!FileTreeMap} fileTreeMap map from filenames to ownership subtrees.
+   */
+  constructor(fileTreeMap) {
+    Object.assign(this, {fileTreeMap});
+  }
+
+  /**
+   * Determine the set of users to request reviews from.
+   *
+   * @param {string[]} suggestedReviewers list of suggested reviewer usernames.
+   * @return {string[]} list of usernames.
+   */
+  getReviewersToRequest(suggestedReviewers) {
+    const reviewers = new Set(suggestedReviewers);
+    Object.entries(this.fileTreeMap).forEach(([filename, subtree]) => {
+      subtree
+        .getModifiedFileOwners(filename, OWNER_MODIFIER.SILENT)
+        .map(owner => owner.allUsernames)
+        .reduce((left, right) => left.concat(right), [])
+        .forEach(reviewers.delete, reviewers);
+    });
+
+    return Array.from(reviewers);
+  }
+
+  /**
+   * Determine the set of owners to notify/tag for each file.
+   *
+   * @return {Object<string, string[]>} map from user/team names to filenames.
+   */
+  getOwnersToNotify() {
+    const notifies = {};
+    Object.entries(this.fileTreeMap).forEach(([filename, subtree]) => {
+      subtree
+        .getModifiedFileOwners(filename, OWNER_MODIFIER.NOTIFY)
+        .map(owner => owner.name)
+        .forEach(name => {
+          if (!notifies[name]) {
+            notifies[name] = [];
+          }
+          notifies[name].push(filename);
+        });
+    });
+
+    return notifies;
+  }
+}
+
+module.exports = {OwnersNotifier};

--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -43,7 +43,8 @@ class OwnersNotifier {
    * @param {string[]} suggestedReviewers suggested reviewers to add.
    */
   async notify(github, suggestedReviewers) {
-    await this.requestReviews(github, suggestedReviewers);
+    const requested = await this.requestReviews(github, suggestedReviewers);
+    // TODO(#473): Add requested reviews to current reviewer set.
     await this.createNotificationComment(github);
   }
 
@@ -54,12 +55,16 @@ class OwnersNotifier {
    *
    * @param {!GitHub} github GitHub API interface.
    * @param {string[]} suggestedReviewers suggested reviewers to add.
+   * @return {string[]} list of reviewers requested.
    */
   async requestReviews(github, suggestedReviewers) {
     if (ADD_REVIEWERS_TAG.test(this.pr.description)) {
       const reviewRequests = this.getReviewersToRequest(suggestedReviewers);
       await github.createReviewRequests(this.pr.number, reviewRequests);
+      return reviewRequests;
     }
+
+    return [];
   }
 
   /**

--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -37,6 +37,17 @@ class OwnersNotifier {
   }
 
   /**
+   * Notify reviewers and owners about the PR.
+   *
+   * @param {!ReviewerApprovalMap} currentReviewers existing reviewers.
+   * @param {string[]} suggestedReviewers suggested reviewers to add.
+   */
+  async notify(github, suggestedReviewers) {
+    await this.requestReviews(github, suggestedReviewers);
+    await this.createNotificationComment(github);
+  }
+
+  /**
    * Requests reviews from owners.
    *
    * Only requests reviews if the PR description contains the #addowners tag.

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -100,10 +100,10 @@ class OwnersBot {
    */
   async runOwnersCheck(github, pr) {
     const {tree, changedFiles, reviewers} = await this.initPr(github, pr);
-    const ownersCheck = new OwnersCheck(tree, changedFiles, reviewers);
 
     const checkRunIdMap = await github.getCheckRunIds(pr.headSha);
     const checkRunId = checkRunIdMap[OWNERS_CHECKRUN_NAME];
+    const ownersCheck = new OwnersCheck(tree, changedFiles, reviewers);
     const ownersCheckResult = ownersCheck.run();
 
     if (checkRunId) {

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -117,8 +117,7 @@ class OwnersBot {
     }
 
     const notifier = new OwnersNotifier(pr, reviewers, tree, changedFiles);
-    await notifier.requestReviews(github, ownersCheckResult.reviewers)
-    await notifier.createNotificationComment(github);
+    await notifier.notify(github, ownersCheckResult.reviewers);
   }
 
   /**

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -117,10 +117,7 @@ class OwnersBot {
       await github.createCheckRun(pr.headSha, ownersCheckResult.checkRun);
     }
 
-    const fileTreeMap = tree.buildFileTreeMap(
-      changedFiles.map(({filename}) => filename)
-    );
-    const notifier = new OwnersNotifier(pr, fileTreeMap);
+    const notifier = new OwnersNotifier(pr, tree, changedFiles);
     if (ADD_REVIEWERS_TAG.test(pr.description)) {
       const reviewRequests = notifier.getReviewersToRequest(
         ownersCheckResult.reviewers

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -121,8 +121,8 @@ class OwnersBot {
       changedFiles.map(({filename}) => filename)
     );
     if (ADD_REVIEWERS_TAG.test(pr.description)) {
-      const reviewRequests = this._getReviewRequests(
-        fileTreeMap,
+      const notifier = new OwnersNotifier(fileTreeMap);
+      const reviewRequests = notifier.getReviewersToRequest(
         ownersCheckResult.reviewers
       );
 
@@ -202,18 +202,6 @@ class OwnersBot {
     approvals[pr.author] = true;
 
     return approvals;
-  }
-
-  /**
-   * Determine the set of users to request reviews from.
-   *
-   * @param {!FileTreeMap} fileTreeMap map from filenames to ownership subtrees.
-   * @param {string[]} suggestedReviewers list of suggested reviewer usernames.
-   * @return {string[]} list of usernames.
-   */
-  _getReviewRequests(fileTreeMap, suggestedReviewers) {
-    const notifier = new OwnersNotifier(fileTreeMap);
-    return notifier.getReviewersToRequest(suggestedReviewers);
   }
 
   /**

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -116,7 +116,7 @@ class OwnersBot {
       await github.createCheckRun(pr.headSha, ownersCheckResult.checkRun);
     }
 
-    const notifier = new OwnersNotifier(pr, tree, changedFiles);
+    const notifier = new OwnersNotifier(pr, reviewers, tree, changedFiles);
     await notifier.requestReviews(github, ownersCheckResult.reviewers)
     await notifier.createNotificationComment(github);
   }

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -120,7 +120,7 @@ class OwnersBot {
     const fileTreeMap = tree.buildFileTreeMap(
       changedFiles.map(({filename}) => filename)
     );
-    const notifier = new OwnersNotifier(fileTreeMap);
+    const notifier = new OwnersNotifier(pr, fileTreeMap);
     if (ADD_REVIEWERS_TAG.test(pr.description)) {
       const reviewRequests = notifier.getReviewersToRequest(
         ownersCheckResult.reviewers
@@ -129,7 +129,7 @@ class OwnersBot {
       await github.createReviewRequests(pr.number, reviewRequests);
     }
 
-    await notifier.createNotificationComment(github, pr);
+    await notifier.createNotificationComment(github);
   }
 
   /**

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -24,7 +24,6 @@ const {OwnersNotifier} = require('./notifier');
 const GITHUB_CHECKRUN_DELAY = 2000;
 const GITHUB_GET_MEMBERS_DELAY = 3000;
 const OWNERS_CHECKRUN_NAME = 'owners-check';
-const ADD_REVIEWERS_TAG = /#add-?owners/i;
 
 /**
  * Bot to run the owners check and create/update the GitHub check-run.
@@ -118,14 +117,7 @@ class OwnersBot {
     }
 
     const notifier = new OwnersNotifier(pr, tree, changedFiles);
-    if (ADD_REVIEWERS_TAG.test(pr.description)) {
-      const reviewRequests = notifier.getReviewersToRequest(
-        ownersCheckResult.reviewers
-      );
-
-      await github.createReviewRequests(pr.number, reviewRequests);
-    }
-
+    await notifier.requestReviews(github, ownersCheckResult.reviewers)
     await notifier.createNotificationComment(github);
   }
 

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -153,7 +153,8 @@ class OwnersBot {
    */
   async createNotifications(github, pr, fileTreeMap) {
     const [botComment] = await github.getBotComments(pr.number);
-    const notifies = this._getNotifies(fileTreeMap);
+    const notifier = new OwnersNotifier(fileTreeMap);
+    const notifies = notifier.getOwnersToNotify();
     delete notifies[pr.author];
 
     const fileNotifyComments = Object.entries(notifies).map(
@@ -202,17 +203,6 @@ class OwnersBot {
     approvals[pr.author] = true;
 
     return approvals;
-  }
-
-  /**
-   * Determine the set of owners to notify/tag for each file.
-   *
-   * @param {!FileTreeMap} fileTreeMap map from filenames to ownership subtrees.
-   * @return {Object<string, string[]>} map from user/team names to filenames.
-   */
-  _getNotifies(fileTreeMap) {
-    const notifier = new OwnersNotifier(fileTreeMap);
-    return notifier.getOwnersToNotify();
   }
 }
 

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -120,8 +120,8 @@ class OwnersBot {
     const fileTreeMap = tree.buildFileTreeMap(
       changedFiles.map(({filename}) => filename)
     );
+    const notifier = new OwnersNotifier(fileTreeMap);
     if (ADD_REVIEWERS_TAG.test(pr.description)) {
-      const notifier = new OwnersNotifier(fileTreeMap);
       const reviewRequests = notifier.getReviewersToRequest(
         ownersCheckResult.reviewers
       );
@@ -129,7 +129,7 @@ class OwnersBot {
       await github.createReviewRequests(pr.number, reviewRequests);
     }
 
-    await this.createNotifications(github, pr, fileTreeMap);
+    await notifier.createNotificationComment(github, pr);
   }
 
   /**
@@ -142,18 +142,6 @@ class OwnersBot {
   async runOwnersCheckOnPrNumber(github, prNumber) {
     const pr = await github.getPullRequest(prNumber);
     await this.runOwnersCheck(github, pr);
-  }
-
-  /**
-   * Adds a comment tagging always-notify owners of changed files.
-   *
-   * @param {!GitHub} github GitHub API interface.
-   * @param {!PullRequest} pr pull request to create notifications on.
-   * @param {!FileTreeMap} fileTreeMap map from filenames to ownership subtrees.
-   */
-  async createNotifications(github, pr, fileTreeMap) {
-    const notifier = new OwnersNotifier(fileTreeMap);
-    await notifier.createNotificationComments(github, pr)
   }
 
   /**

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -152,29 +152,8 @@ class OwnersBot {
    * @param {!FileTreeMap} fileTreeMap map from filenames to ownership subtrees.
    */
   async createNotifications(github, pr, fileTreeMap) {
-    const [botComment] = await github.getBotComments(pr.number);
     const notifier = new OwnersNotifier(fileTreeMap);
-    const notifies = notifier.getOwnersToNotify();
-    delete notifies[pr.author];
-
-    const fileNotifyComments = Object.entries(notifies).map(
-      ([name, filenames]) => {
-        const header = `Hey @${name}, these files were changed:`;
-        const files = filenames.map(filename => `- ${filename}`);
-        return [header, ...files].join('\n');
-      }
-    );
-
-    if (!fileNotifyComments.length) {
-      return;
-    }
-
-    const comment = fileNotifyComments.join('\n\n');
-    if (botComment) {
-      await github.updateComment(botComment.id, comment);
-    } else {
-      await github.createBotComment(pr.number, comment);
-    }
+    await notifier.createNotificationComments(github, pr)
   }
 
   /**

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -16,7 +16,6 @@
 
 const _ = require('lodash');
 const sleep = require('sleep-promise');
-const {OWNER_MODIFIER} = require('./owner');
 const {OwnersCheck} = require('./owners_check');
 const {OwnersParser} = require('./parser');
 const {OwnersNotifier} = require('./notifier');

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -37,7 +37,6 @@ describe('notifier', () => {
   });
 
   describe('createNotificationComment', () => {
-    const fileTreeMap = {'main.js': new OwnersTree()};
     let getCommentsStub;
     let notifier;
 
@@ -47,7 +46,10 @@ describe('notifier', () => {
       getCommentsStub = sandbox.stub(GitHub.prototype, 'getBotComments');
       getCommentsStub.returns([]);
 
-      notifier = new OwnersNotifier(pr, fileTreeMap);
+      notifier = new OwnersNotifier(pr, new OwnersTree(), [{
+        filename: 'main.js',
+        sha: '_sha_',
+      }]);
     });
 
     it('gets users and teams to notify', async done => {
@@ -123,7 +125,6 @@ describe('notifier', () => {
     let tree;
     const busyTeam = new Team(42, 'ampproject', 'busy_team');
     busyTeam.members = ['busy_member'];
-    let fileTreeMap;
     let notifier;
 
     beforeEach(() => {
@@ -144,8 +145,10 @@ describe('notifier', () => {
         ])
       );
 
-      fileTreeMap = tree.buildFileTreeMap(['foo/script.js']);
-      notifier = new OwnersNotifier(pr, fileTreeMap);
+      notifier = new OwnersNotifier(pr, tree, [{
+        filename: 'foo/script.js',
+        sha: '_sha_',
+      }]);
     });
 
     it('includes suggested reviewers', () => {
@@ -181,24 +184,30 @@ describe('notifier', () => {
     tree.addRule(new OwnersRule('baz/OWNERS.yaml', [new UserOwner('rando')]));
 
     it('includes user owners with the always-notify modifier', () => {
-      const fileTreeMap = tree.buildFileTreeMap(['foo/main.js', 'foo/bar.js']);
-      const notifier = new OwnersNotifier(pr, fileTreeMap);
+      const notifier = new OwnersNotifier(pr, tree, [
+        {filename: 'foo/main.js', sha: '_sha_'},
+        {filename: 'foo/bar.js', sha: '_sha_'},
+      ]);
       const notifies = notifier.getOwnersToNotify();
 
       expect(notifies['relevant_user']).toContain('foo/main.js');
     });
 
     it('includes team owners with the always-notify modifier', () => {
-      const fileTreeMap = tree.buildFileTreeMap(['bar/script.js']);
-      const notifier = new OwnersNotifier(pr, fileTreeMap);
+      const notifier = new OwnersNotifier(pr, tree, [{
+        filename: 'bar/script.js',
+        sha: '_sha_',
+      }]);
       const notifies = notifier.getOwnersToNotify();
 
       expect(notifies['ampproject/relevant_team']).toContain('bar/script.js');
     });
 
     it('excludes files with no always-notify owners', () => {
-      const fileTreeMap = tree.buildFileTreeMap(['baz/test.js']);
-      const notifier = new OwnersNotifier(pr, fileTreeMap);
+      const notifier = new OwnersNotifier(pr, tree, [{
+        filename: 'baz/test.js',
+        sha: '_sha_',
+      }]);
       const notifies = notifier.getOwnersToNotify();
 
       expect(notifies['rando']).toBeUndefined();

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -58,17 +58,17 @@ describe('notifier', () => {
 
     it('includes suggested reviewers', () => {
       const reviewRequests = notifier.getReviewersToRequest(['auser']);
-      expect(Array.from(reviewRequests)).toContain('auser');
+      expect(reviewRequests).toContain('auser');
     });
 
     it('excludes user owners with the no-notify modifier', () => {
       const reviewRequests = notifier.getReviewersToRequest(['busy_user']);
-      expect(Array.from(reviewRequests)).not.toContain('busy_user');
+      expect(reviewRequests).not.toContain('busy_user');
     });
 
     it('excludes members of team owners with the no-notify modifier', () => {
       const reviewRequests = notifier.getReviewersToRequest(['busy_member']);
-      expect(Array.from(reviewRequests)).not.toContain('busy_member');
+      expect(reviewRequests).not.toContain('busy_member');
     });
   });
 
@@ -91,7 +91,7 @@ describe('notifier', () => {
     it('includes user owners with the always-notify modifier', () => {
       const fileTreeMap = tree.buildFileTreeMap(['foo/main.js', 'foo/bar.js']);
       const notifier = new OwnersNotifier(fileTreeMap);
-      const notifies = notifier.getOwnersToNotify(fileTree);
+      const notifies = notifier.getOwnersToNotify();
 
       expect(notifies['relevant_user']).toContain('foo/main.js');
     });
@@ -99,7 +99,7 @@ describe('notifier', () => {
     it('includes team owners with the always-notify modifier', () => {
       const fileTreeMap = tree.buildFileTreeMap(['bar/script.js']);
       const notifier = new OwnersNotifier(fileTreeMap);
-      const notifies = notifier.getOwnersToNotify(fileTree);
+      const notifies = notifier.getOwnersToNotify();
 
       expect(notifies['ampproject/relevant_team']).toContain('bar/script.js');
     });
@@ -107,7 +107,7 @@ describe('notifier', () => {
     it('excludes files with no always-notify owners', () => {
       const fileTreeMap = tree.buildFileTreeMap(['baz/test.js']);
       const notifier = new OwnersNotifier(fileTreeMap);
-      const notifies = notifier.getOwnersToNotify(fileTree);
+      const notifies = notifier.getOwnersToNotify();
 
       expect(notifies['rando']).toBeUndefined();
     });

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -24,12 +24,7 @@ const {OwnersNotifier} = require('../src/notifier');
 describe('notifier', () => {
   const sandbox = sinon.createSandbox();
   const loggerStub = sinon.stub();
-  const github = new GitHub(
-    sinon.stub(),
-    'ampproject',
-    'amphtml',
-    loggerStub,
-  );
+  const github = new GitHub(sinon.stub(), 'ampproject', 'amphtml', loggerStub);
   const pr = new PullRequest(1337, 'the_author', '_test_hash_', 'description');
 
   afterEach(() => {
@@ -67,14 +62,14 @@ describe('notifier', () => {
       notifier = new OwnersNotifier(pr, {}, new OwnersTree(), []);
       sandbox.stub(GitHub.prototype, 'createReviewRequests');
     });
-  
+
     it('does not create review requests', async done => {
       await notifier.requestReviews(github, ['auser']);
 
       sandbox.assert.notCalled(github.createReviewRequests);
       done();
     });
-  
+
     it('returns an empty list', async () => {
       expect.assertions(1);
       const requested = await notifier.requestReviews(github, ['auser']);
@@ -95,7 +90,7 @@ describe('notifier', () => {
 
         sandbox.assert.calledWith(notifier.getReviewersToRequest, [
           'auser',
-          'anotheruser'
+          'anotheruser',
         ]);
         sandbox.assert.calledWith(github.createReviewRequests, 1337, ['auser']);
         done();
@@ -103,10 +98,10 @@ describe('notifier', () => {
 
       it('returns the requested reviewers', async () => {
         expect.assertions(1);
-        const requested = await notifier.requestReviews(
-          github,
-          ['auser', 'anotheruser']
-        );
+        const requested = await notifier.requestReviews(github, [
+          'auser',
+          'anotheruser',
+        ]);
 
         expect(requested).toEqual(['auser']);
       });
@@ -123,10 +118,12 @@ describe('notifier', () => {
       getCommentsStub = sandbox.stub(GitHub.prototype, 'getBotComments');
       getCommentsStub.returns([]);
 
-      notifier = new OwnersNotifier(pr, {}, new OwnersTree(), [{
-        filename: 'main.js',
-        sha: '_sha_',
-      }]);
+      notifier = new OwnersNotifier(pr, {}, new OwnersTree(), [
+        {
+          filename: 'main.js',
+          sha: '_sha_',
+        },
+      ]);
     });
 
     it('gets users and teams to notify', async done => {
@@ -210,7 +207,7 @@ describe('notifier', () => {
         .withArgs(sinon.match.string, OWNER_MODIFIER.SILENT)
         .returns([new UserOwner('busy_user'), new TeamOwner(busyTeam)]);
 
-      tree = new OwnersTree()
+      tree = new OwnersTree();
       tree.addRule(
         new OwnersRule('foo/OWNERS.yaml', [
           new UserOwner('busy_user', OWNER_MODIFIER.SILENT),
@@ -222,10 +219,12 @@ describe('notifier', () => {
         ])
       );
 
-      notifier = new OwnersNotifier(pr, {}, tree, [{
-        filename: 'foo/script.js',
-        sha: '_sha_',
-      }]);
+      notifier = new OwnersNotifier(pr, {}, tree, [
+        {
+          filename: 'foo/script.js',
+          sha: '_sha_',
+        },
+      ]);
     });
 
     it('includes suggested reviewers', () => {
@@ -271,20 +270,24 @@ describe('notifier', () => {
     });
 
     it('includes team owners with the always-notify modifier', () => {
-      const notifier = new OwnersNotifier(pr, {}, tree, [{
-        filename: 'bar/script.js',
-        sha: '_sha_',
-      }]);
+      const notifier = new OwnersNotifier(pr, {}, tree, [
+        {
+          filename: 'bar/script.js',
+          sha: '_sha_',
+        },
+      ]);
       const notifies = notifier.getOwnersToNotify();
 
       expect(notifies['ampproject/relevant_team']).toContain('bar/script.js');
     });
 
     it('excludes files with no always-notify owners', () => {
-      const notifier = new OwnersNotifier(pr, {}, tree, [{
-        filename: 'baz/test.js',
-        sha: '_sha_',
-      }]);
+      const notifier = new OwnersNotifier(pr, {}, tree, [
+        {
+          filename: 'baz/test.js',
+          sha: '_sha_',
+        },
+      ]);
       const notifies = notifier.getOwnersToNotify();
 
       expect(notifies['rando']).toBeUndefined();

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -40,7 +40,7 @@ describe('notifier', () => {
     let notifier;
 
     beforeEach(() => {
-      notifier = new OwnersNotifier(pr, new OwnersTree(), []);
+      notifier = new OwnersNotifier(pr, {}, new OwnersTree(), []);
       sandbox.stub(GitHub.prototype, 'createReviewRequests');
     });
   
@@ -82,7 +82,7 @@ describe('notifier', () => {
       getCommentsStub = sandbox.stub(GitHub.prototype, 'getBotComments');
       getCommentsStub.returns([]);
 
-      notifier = new OwnersNotifier(pr, new OwnersTree(), [{
+      notifier = new OwnersNotifier(pr, {}, new OwnersTree(), [{
         filename: 'main.js',
         sha: '_sha_',
       }]);
@@ -181,7 +181,7 @@ describe('notifier', () => {
         ])
       );
 
-      notifier = new OwnersNotifier(pr, tree, [{
+      notifier = new OwnersNotifier(pr, {}, tree, [{
         filename: 'foo/script.js',
         sha: '_sha_',
       }]);
@@ -220,7 +220,7 @@ describe('notifier', () => {
     tree.addRule(new OwnersRule('baz/OWNERS.yaml', [new UserOwner('rando')]));
 
     it('includes user owners with the always-notify modifier', () => {
-      const notifier = new OwnersNotifier(pr, tree, [
+      const notifier = new OwnersNotifier(pr, {}, tree, [
         {filename: 'foo/main.js', sha: '_sha_'},
         {filename: 'foo/bar.js', sha: '_sha_'},
       ]);
@@ -230,7 +230,7 @@ describe('notifier', () => {
     });
 
     it('includes team owners with the always-notify modifier', () => {
-      const notifier = new OwnersNotifier(pr, tree, [{
+      const notifier = new OwnersNotifier(pr, {}, tree, [{
         filename: 'bar/script.js',
         sha: '_sha_',
       }]);
@@ -240,7 +240,7 @@ describe('notifier', () => {
     });
 
     it('excludes files with no always-notify owners', () => {
-      const notifier = new OwnersNotifier(pr, tree, [{
+      const notifier = new OwnersNotifier(pr, {}, tree, [{
         filename: 'baz/test.js',
         sha: '_sha_',
       }]);

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -74,16 +74,23 @@ describe('notifier', () => {
       sandbox.assert.notCalled(github.createReviewRequests);
       done();
     });
+  
+    it('returns an empty list', async () => {
+      expect.assertions(1);
+      const requested = await notifier.requestReviews(github, ['auser']);
+
+      expect(requested).toEqual([]);
+    });
 
     describe('when the PR description contains #addowners', () => {
       beforeEach(() => {
+        sandbox
+          .stub(OwnersNotifier.prototype, 'getReviewersToRequest')
+          .returns(['auser']);
         pr.description = 'Assign reviewers please #addowners';
       });
 
       it('requests reviewers', async done => {
-        sandbox
-          .stub(OwnersNotifier.prototype, 'getReviewersToRequest')
-          .returns(['auser']);
         await notifier.requestReviews(github, ['auser', 'anotheruser']);
 
         sandbox.assert.calledWith(notifier.getReviewersToRequest, [
@@ -92,6 +99,16 @@ describe('notifier', () => {
         ]);
         sandbox.assert.calledWith(github.createReviewRequests, 1337, ['auser']);
         done();
+      });
+
+      it('returns the requested reviewers', async () => {
+        expect.assertions(1);
+        const requested = await notifier.requestReviews(
+          github,
+          ['auser', 'anotheruser']
+        );
+
+        expect(requested).toEqual(['auser']);
       });
     });
   });

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -15,7 +15,7 @@
  */
 
 const sinon = require('sinon');
-const {Team} = require('../src/github');
+const {GitHub, Team} = require('../src/github');
 const {OwnersTree} = require('../src/owners_tree');
 const {OwnersRule} = require('../src/rules');
 const {UserOwner, TeamOwner, OWNER_MODIFIER} = require('../src/owner');
@@ -23,8 +23,99 @@ const {OwnersNotifier} = require('../src/notifier');
 
 describe('notifier', () => {
   const sandbox = sinon.createSandbox();
+  const loggerStub = sinon.stub();
+  const github = new GitHub(
+    sinon.stub(),
+    'ampproject',
+    'amphtml',
+    loggerStub,
+  );
+
   afterEach(() => {
     sandbox.restore();
+  });
+
+  describe('createNotifications', () => {
+    const fileTreeMap = {'main.js': new OwnersTree()};
+    let getCommentsStub;
+    let notifier;
+
+    beforeEach(() => {
+      sandbox.stub(GitHub.prototype, 'createBotComment');
+      sandbox.stub(GitHub.prototype, 'updateComment').returns();
+      getCommentsStub = sandbox.stub(GitHub.prototype, 'getBotComments');
+      getCommentsStub.returns([]);
+
+      notifier = new OwnersNotifier(fileTreeMap);
+    });
+
+    it('gets users and teams to notify', async done => {
+      sandbox.stub(OwnersNotifier.prototype, 'getOwnersToNotify').returns([]);
+      await notifier.createNotificationComments(github, 1337);
+
+      sandbox.assert.calledOnce(notifier.getOwnersToNotify);
+      done();
+    });
+
+    describe('when there are users or teams to notify', () => {
+      beforeEach(() => {
+        sandbox.stub(OwnersNotifier.prototype, 'getOwnersToNotify').returns({
+          'a_subscriber': ['foo/main.js'],
+          'ampproject/some_team': ['foo/main.js'],
+        });
+      });
+
+      describe('when a comment by the bot already exists', () => {
+        beforeEach(() => {
+          getCommentsStub.returns([{id: 42, body: 'a comment'}]);
+        });
+
+        it('does not create a comment', async done => {
+          await notifier.createNotificationComments(github, 1337);
+
+          sandbox.assert.notCalled(github.createBotComment);
+          done();
+        });
+
+        it('updates the existing comment', async () => {
+          expect.assertions(2);
+          await notifier.createNotificationComments(github, 1337);
+
+          sandbox.assert.calledOnce(github.updateComment);
+          const [commentId, comment] = github.updateComment.getCall(0).args;
+          expect(commentId).toEqual(42);
+          expect(comment).toContain(
+            'Hey @a_subscriber, these files were changed:\n- foo/main.js',
+            'Hey @ampproject/some_team, these files were changed:\n- foo/main.js'
+          );
+        });
+      });
+
+      describe('when no comment by the bot exists yet', () => {
+        it('creates a comment tagging users and teams', async () => {
+          expect.assertions(2);
+          await notifier.createNotificationComments(github, 1337);
+
+          sandbox.assert.calledOnce(github.createBotComment);
+          const [prNumber, comment] = github.createBotComment.getCall(0).args;
+          expect(prNumber).toEqual(1337);
+          expect(comment).toContain(
+            'Hey @a_subscriber, these files were changed:\n- foo/main.js',
+            'Hey @ampproject/some_team, these files were changed:\n- foo/main.js'
+          );
+        });
+      });
+    });
+
+    describe('when there are no users or teams to notify', () => {
+      it('does not create or update a comment', async done => {
+        await notifier.createNotificationComments(github, 1337);
+
+        sandbox.assert.notCalled(github.createBotComment);
+        sandbox.assert.notCalled(github.updateComment);
+        done();
+      });
+    });
   });
 
   describe('getReviewersToRequest', () => {

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -36,6 +36,30 @@ describe('notifier', () => {
     sandbox.restore();
   });
 
+  describe('notify', () => {
+    let notifier;
+
+    beforeEach(() => {
+      notifier = new OwnersNotifier(pr, {}, new OwnersTree(), []);
+      sandbox.stub(OwnersNotifier.prototype, 'requestReviews');
+      sandbox.stub(OwnersNotifier.prototype, 'createNotificationComment');
+    });
+
+    it('requests reviews for the suggested reviewers', async done => {
+      await notifier.notify(github, ['auser']);
+
+      sandbox.assert.calledWith(notifier.requestReviews, github, ['auser']);
+      done();
+    });
+
+    it('creates a notification comment', async done => {
+      await notifier.notify(github, ['auser']);
+
+      sandbox.assert.calledWith(notifier.createNotificationComment, github);
+      done();
+    });
+  });
+
   describe('requestReviews', () => {
     let notifier;
 

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -15,7 +15,7 @@
  */
 
 const sinon = require('sinon');
-const {GitHub, Team} = require('../src/github');
+const {GitHub, PullRequest, Team} = require('../src/github');
 const {OwnersTree} = require('../src/owners_tree');
 const {OwnersRule} = require('../src/rules');
 const {UserOwner, TeamOwner, OWNER_MODIFIER} = require('../src/owner');
@@ -30,12 +30,13 @@ describe('notifier', () => {
     'amphtml',
     loggerStub,
   );
+  const pr = new PullRequest(1337, 'the_author', '_test_hash_', 'descrption');
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  describe('createNotifications', () => {
+  describe('createNotificationComment', () => {
     const fileTreeMap = {'main.js': new OwnersTree()};
     let getCommentsStub;
     let notifier;
@@ -51,7 +52,7 @@ describe('notifier', () => {
 
     it('gets users and teams to notify', async done => {
       sandbox.stub(OwnersNotifier.prototype, 'getOwnersToNotify').returns([]);
-      await notifier.createNotificationComments(github, 1337);
+      await notifier.createNotificationComment(github, pr);
 
       sandbox.assert.calledOnce(notifier.getOwnersToNotify);
       done();
@@ -71,7 +72,7 @@ describe('notifier', () => {
         });
 
         it('does not create a comment', async done => {
-          await notifier.createNotificationComments(github, 1337);
+          await notifier.createNotificationComment(github, pr);
 
           sandbox.assert.notCalled(github.createBotComment);
           done();
@@ -79,7 +80,7 @@ describe('notifier', () => {
 
         it('updates the existing comment', async () => {
           expect.assertions(2);
-          await notifier.createNotificationComments(github, 1337);
+          await notifier.createNotificationComment(github, pr);
 
           sandbox.assert.calledOnce(github.updateComment);
           const [commentId, comment] = github.updateComment.getCall(0).args;
@@ -94,7 +95,7 @@ describe('notifier', () => {
       describe('when no comment by the bot exists yet', () => {
         it('creates a comment tagging users and teams', async () => {
           expect.assertions(2);
-          await notifier.createNotificationComments(github, 1337);
+          await notifier.createNotificationComment(github, pr);
 
           sandbox.assert.calledOnce(github.createBotComment);
           const [prNumber, comment] = github.createBotComment.getCall(0).args;
@@ -109,7 +110,7 @@ describe('notifier', () => {
 
     describe('when there are no users or teams to notify', () => {
       it('does not create or update a comment', async done => {
-        await notifier.createNotificationComments(github, 1337);
+        await notifier.createNotificationComment(github, pr);
 
         sandbox.assert.notCalled(github.createBotComment);
         sandbox.assert.notCalled(github.updateComment);

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2019 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const sinon = require('sinon');
+const {Team} = require('../src/github');
+const {OwnersTree} = require('../src/owners_tree');
+const {OwnersRule} = require('../src/rules');
+const {UserOwner, TeamOwner, OWNER_MODIFIER} = require('../src/owner');
+const {OwnersNotifier} = require('../src/notifier');
+
+describe('notifier', () => {
+  const sandbox = sinon.createSandbox();
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('getReviewersToRequest', () => {
+    let tree;
+    const busyTeam = new Team(42, 'ampproject', 'busy_team');
+    busyTeam.members = ['busy_member'];
+    let fileTreeMap;
+    let notifier;
+
+    beforeEach(() => {
+      sandbox
+        .stub(OwnersTree.prototype, 'getModifiedFileOwners')
+        .withArgs(sinon.match.string, OWNER_MODIFIER.SILENT)
+        .returns([new UserOwner('busy_user'), new TeamOwner(busyTeam)]);
+
+      tree = new OwnersTree()
+      tree.addRule(
+        new OwnersRule('foo/OWNERS.yaml', [
+          new UserOwner('busy_user', OWNER_MODIFIER.SILENT),
+        ])
+      );
+      tree.addRule(
+        new OwnersRule('foo/OWNERS.yaml', [
+          new TeamOwner(busyTeam, OWNER_MODIFIER.SILENT),
+        ])
+      );
+
+      fileTreeMap = tree.buildFileTreeMap(['foo/script.js']);
+      notifier = new OwnersNotifier(fileTreeMap);
+    });
+
+    it('includes suggested reviewers', () => {
+      const reviewRequests = notifier.getReviewersToRequest(['auser']);
+      expect(Array.from(reviewRequests)).toContain('auser');
+    });
+
+    it('excludes user owners with the no-notify modifier', () => {
+      const reviewRequests = notifier.getReviewersToRequest(['busy_user']);
+      expect(Array.from(reviewRequests)).not.toContain('busy_user');
+    });
+
+    it('excludes members of team owners with the no-notify modifier', () => {
+      const reviewRequests = notifier.getReviewersToRequest(['busy_member']);
+      expect(Array.from(reviewRequests)).not.toContain('busy_member');
+    });
+  });
+
+  describe('getOwnersToNotify', () => {
+    const tree = new OwnersTree();
+    const relevantTeam = new Team(42, 'ampproject', 'relevant_team');
+    relevantTeam.members = ['relevant_member'];
+    tree.addRule(
+      new OwnersRule('foo/OWNERS.yaml', [
+        new UserOwner('relevant_user', OWNER_MODIFIER.NOTIFY),
+      ])
+    );
+    tree.addRule(
+      new OwnersRule('bar/OWNERS.yaml', [
+        new TeamOwner(relevantTeam, OWNER_MODIFIER.NOTIFY),
+      ])
+    );
+    tree.addRule(new OwnersRule('baz/OWNERS.yaml', [new UserOwner('rando')]));
+
+    it('includes user owners with the always-notify modifier', () => {
+      const fileTreeMap = tree.buildFileTreeMap(['foo/main.js', 'foo/bar.js']);
+      const notifier = new OwnersNotifier(fileTreeMap);
+      const notifies = notifier.getOwnersToNotify(fileTree);
+
+      expect(notifies['relevant_user']).toContain('foo/main.js');
+    });
+
+    it('includes team owners with the always-notify modifier', () => {
+      const fileTreeMap = tree.buildFileTreeMap(['bar/script.js']);
+      const notifier = new OwnersNotifier(fileTreeMap);
+      const notifies = notifier.getOwnersToNotify(fileTree);
+
+      expect(notifies['ampproject/relevant_team']).toContain('bar/script.js');
+    });
+
+    it('excludes files with no always-notify owners', () => {
+      const fileTreeMap = tree.buildFileTreeMap(['baz/test.js']);
+      const notifier = new OwnersNotifier(fileTreeMap);
+      const notifies = notifier.getOwnersToNotify(fileTree);
+
+      expect(notifies['rando']).toBeUndefined();
+    });
+  });
+});

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -17,9 +17,7 @@
 const sinon = require('sinon');
 const {GitHub, PullRequest, Review, Team} = require('../src/github');
 const {LocalRepository} = require('../src/local_repo');
-const {UserOwner, TeamOwner, OWNER_MODIFIER} = require('../src/owner');
 const {OwnersBot} = require('../src/owners_bot');
-const {OwnersRule} = require('../src/rules');
 const {OwnersParser} = require('../src/parser');
 const {OwnersNotifier} = require('../src/notifier');
 const {OwnersTree} = require('../src/owners_tree');
@@ -229,9 +227,10 @@ describe('owners bot', () => {
       sandbox.stub(OwnersNotifier.prototype, 'requestReviews');
       await ownersBot.runOwnersCheck(github, pr);
 
-      sandbox.assert.calledWith(OwnersNotifier.prototype.requestReviews,
+      sandbox.assert.calledWith(
+        OwnersNotifier.prototype.requestReviews,
         github,
-        ['root_owner'],
+        ['root_owner']
       );
       done();
     });
@@ -242,7 +241,7 @@ describe('owners bot', () => {
 
       sandbox.assert.calledWith(
         OwnersNotifier.prototype.createNotificationComment,
-        github,
+        github
       );
       done();
     });

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -40,7 +40,7 @@ describe('owners bot', () => {
 
   let sandbox;
   const github = new GitHub({}, 'ampproject', 'amphtml', silentLogger);
-  const pr = new PullRequest(1337, 'the_author', '_test_hash_', 'descrption');
+  const pr = new PullRequest(1337, 'the_author', '_test_hash_', 'description');
   const localRepo = new LocalRepository('path/to/repo');
   const ownersBot = new OwnersBot(localRepo);
 
@@ -258,7 +258,6 @@ describe('owners bot', () => {
       sandbox.assert.calledWith(
         OwnersNotifier.prototype.createNotificationComment,
         github,
-        pr,
       );
       done();
     });

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -225,30 +225,15 @@ describe('owners bot', () => {
       });
     });
 
-    it('does not create review requests', async done => {
+    it('requests reviewers', async done => {
+      sandbox.stub(OwnersNotifier.prototype, 'requestReviews');
       await ownersBot.runOwnersCheck(github, pr);
 
-      sandbox.assert.notCalled(github.createReviewRequests);
+      sandbox.assert.calledWith(OwnersNotifier.prototype.requestReviews,
+        github,
+        ['root_owner'],
+      );
       done();
-    });
-
-    describe('when the PR description contains #addowners', () => {
-      beforeEach(() => {
-        pr.description = 'Assign reviewers please #addowners';
-      });
-
-      it('requests reviewers', async done => {
-        sandbox
-          .stub(OwnersNotifier.prototype, 'getReviewersToRequest')
-          .returns(['auser', 'anotheruser']);
-        await ownersBot.runOwnersCheck(github, pr);
-
-        sandbox.assert.calledWith(github.createReviewRequests, 1337, [
-          'auser',
-          'anotheruser',
-        ]);
-        done();
-      });
     });
 
     it('creates a notification comment', async done => {


### PR DESCRIPTION
The logic keeping track of who to request and notify was getting complex and scattered enough to merit isolating it. This will make it easier to handle and test notifications separately from the owners check and will make updates like those required for #473 cleaner and more isolated. This PR makes no functional changes, and just shifts code/tests around.

In a follow-up PR addressing #473 , the `currentReviewers` field will be updated to reflect requested reviewers, and then used to filter out reviewers from the notification set. At this time, tests will be added addressing how the notifier handles pending/existing reviews.

Note: Rebasing onto #463 , which changed a signature to take a PullRequest instead of just a PR number, led to the commit history getting a bit tangled. As a result, some tests got messed up along the way and fixed in later commits.