### PR TITLE
[owners] Ignore irrelevant review states from GitHub

### DIFF
--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -244,17 +244,17 @@ class GitHub {
     // possible review states. The only ones we care about are "APPROVED" and
     // "CHANGES_REQUESTED", since the rest do not indicate a definite approval
     // or rejection.
-    const allowedStates = ['approved', 'changes_requested']
+    const allowedStates = ['approved', 'changes_requested'];
     return response.data
-        .filter(({state}) => allowedStates.includes(state.toLowerCase()))
-        .map(
-          json =>
-            new Review(
-              json.user.login.toLowerCase(),
-              json.state,
-              new Date(json.submitted_at)
-            )
-        );
+      .filter(({state}) => allowedStates.includes(state.toLowerCase()))
+      .map(
+        json =>
+          new Review(
+            json.user.login.toLowerCase(),
+            json.state,
+            new Date(json.submitted_at)
+          )
+      );
   }
 
   /**

--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -240,10 +240,13 @@ class GitHub {
     );
     this.logger.debug('[getReviews]', number, response.data);
 
-    // Reviews may also have "commented" state, which should indicate neither
-    // approval or rejection (and often comes after existng approvals)
+    // See https://developer.github.com/v4/enum/pullrequestreviewstate/ for
+    // possible review states. The only ones we care about are "APPROVED" and
+    // "CHANGES_REQUESTED", since the rest do not indicate a definite approval
+    // or rejection.
+    const allowedStates = ['approved', 'changes_requested']
     return response.data
-        .filter(({state}) => state.toLowerCase() !== 'commented')
+        .filter(({state}) => allowedStates.includes(state.toLowerCase()))
         .map(
           json =>
             new Review(

--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -240,14 +240,18 @@ class GitHub {
     );
     this.logger.debug('[getReviews]', number, response.data);
 
-    return response.data.map(
-      json =>
-        new Review(
-          json.user.login.toLowerCase(),
-          json.state,
-          new Date(json.submitted_at)
-        )
-    );
+    // Reviews may also have "commented" state, which should indicate neither
+    // approval or rejection (and often comes after existng approvals)
+    return response.data
+        .filter(({state}) => state.toLowerCase() !== 'commented')
+        .map(
+          json =>
+            new Review(
+              json.user.login.toLowerCase(),
+              json.state,
+              new Date(json.submitted_at)
+            )
+        );
   }
 
   /**

--- a/owners/test/fixtures/reviews/comment_reviews.24686.json
+++ b/owners/test/fixtures/reviews/comment_reviews.24686.json
@@ -1,0 +1,236 @@
+[
+  {
+    "id": 291948551,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MjkxOTQ4NTUx",
+    "user": {
+      "login": "rsimha",
+      "id": 26553114,
+      "node_id": "MDQ6VXNlcjI2NTUzMTE0",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/26553114?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/rsimha",
+      "html_url": "https://github.com/rsimha",
+      "followers_url": "https://api.github.com/users/rsimha/followers",
+      "following_url": "https://api.github.com/users/rsimha/following{/other_user}",
+      "gists_url": "https://api.github.com/users/rsimha/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/rsimha/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/rsimha/subscriptions",
+      "organizations_url": "https://api.github.com/users/rsimha/orgs",
+      "repos_url": "https://api.github.com/users/rsimha/repos",
+      "events_url": "https://api.github.com/users/rsimha/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/rsimha/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "Generally LGTM. Few suggestions below. Approving to unblock.",
+    "state": "APPROVED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291948551",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/24686",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291948551"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/24686"
+      }
+    },
+    "submitted_at": "2019-09-23T17:53:30Z",
+    "commit_id": "0eb0df37c5b84a4f722c4acd0b2cff462011cbf5"
+  },
+  {
+    "id": 291951016,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MjkxOTUxMDE2",
+    "user": {
+      "login": "rsimha",
+      "id": 26553114,
+      "node_id": "MDQ6VXNlcjI2NTUzMTE0",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/26553114?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/rsimha",
+      "html_url": "https://github.com/rsimha",
+      "followers_url": "https://api.github.com/users/rsimha/followers",
+      "following_url": "https://api.github.com/users/rsimha/following{/other_user}",
+      "gists_url": "https://api.github.com/users/rsimha/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/rsimha/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/rsimha/subscriptions",
+      "organizations_url": "https://api.github.com/users/rsimha/orgs",
+      "repos_url": "https://api.github.com/users/rsimha/repos",
+      "events_url": "https://api.github.com/users/rsimha/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/rsimha/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291951016",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/24686",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291951016"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/24686"
+      }
+    },
+    "submitted_at": "2019-09-23T17:54:05Z",
+    "commit_id": "0eb0df37c5b84a4f722c4acd0b2cff462011cbf5"
+  },
+  {
+    "id": 291979719,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MjkxOTc5NzE5",
+    "user": {
+      "login": "estherkim",
+      "id": 44627152,
+      "node_id": "MDQ6VXNlcjQ0NjI3MTUy",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/44627152?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/estherkim",
+      "html_url": "https://github.com/estherkim",
+      "followers_url": "https://api.github.com/users/estherkim/followers",
+      "following_url": "https://api.github.com/users/estherkim/following{/other_user}",
+      "gists_url": "https://api.github.com/users/estherkim/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/estherkim/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/estherkim/subscriptions",
+      "organizations_url": "https://api.github.com/users/estherkim/orgs",
+      "repos_url": "https://api.github.com/users/estherkim/repos",
+      "events_url": "https://api.github.com/users/estherkim/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/estherkim/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291979719",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/24686",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291979719"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/24686"
+      }
+    },
+    "submitted_at": "2019-09-23T18:44:57Z",
+    "commit_id": "0eb0df37c5b84a4f722c4acd0b2cff462011cbf5"
+  },
+  {
+    "id": 291980596,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MjkxOTgwNTk2",
+    "user": {
+      "login": "estherkim",
+      "id": 44627152,
+      "node_id": "MDQ6VXNlcjQ0NjI3MTUy",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/44627152?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/estherkim",
+      "html_url": "https://github.com/estherkim",
+      "followers_url": "https://api.github.com/users/estherkim/followers",
+      "following_url": "https://api.github.com/users/estherkim/following{/other_user}",
+      "gists_url": "https://api.github.com/users/estherkim/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/estherkim/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/estherkim/subscriptions",
+      "organizations_url": "https://api.github.com/users/estherkim/orgs",
+      "repos_url": "https://api.github.com/users/estherkim/repos",
+      "events_url": "https://api.github.com/users/estherkim/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/estherkim/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291980596",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/24686",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291980596"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/24686"
+      }
+    },
+    "submitted_at": "2019-09-23T18:46:38Z",
+    "commit_id": "938507d25ab05f405526945a94228ab1a445b166"
+  },
+  {
+    "id": 291980756,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MjkxOTgwNzU2",
+    "user": {
+      "login": "estherkim",
+      "id": 44627152,
+      "node_id": "MDQ6VXNlcjQ0NjI3MTUy",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/44627152?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/estherkim",
+      "html_url": "https://github.com/estherkim",
+      "followers_url": "https://api.github.com/users/estherkim/followers",
+      "following_url": "https://api.github.com/users/estherkim/following{/other_user}",
+      "gists_url": "https://api.github.com/users/estherkim/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/estherkim/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/estherkim/subscriptions",
+      "organizations_url": "https://api.github.com/users/estherkim/orgs",
+      "repos_url": "https://api.github.com/users/estherkim/repos",
+      "events_url": "https://api.github.com/users/estherkim/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/estherkim/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291980756",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/24686",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291980756"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/24686"
+      }
+    },
+    "submitted_at": "2019-09-23T18:46:55Z",
+    "commit_id": "938507d25ab05f405526945a94228ab1a445b166"
+  },
+  {
+    "id": 291980900,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MjkxOTgwOTAw",
+    "user": {
+      "login": "estherkim",
+      "id": 44627152,
+      "node_id": "MDQ6VXNlcjQ0NjI3MTUy",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/44627152?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/estherkim",
+      "html_url": "https://github.com/estherkim",
+      "followers_url": "https://api.github.com/users/estherkim/followers",
+      "following_url": "https://api.github.com/users/estherkim/following{/other_user}",
+      "gists_url": "https://api.github.com/users/estherkim/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/estherkim/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/estherkim/subscriptions",
+      "organizations_url": "https://api.github.com/users/estherkim/orgs",
+      "repos_url": "https://api.github.com/users/estherkim/repos",
+      "events_url": "https://api.github.com/users/estherkim/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/estherkim/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291980900",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/24686",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291980900"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/24686"
+      }
+    },
+    "submitted_at": "2019-09-23T18:47:09Z",
+    "commit_id": "938507d25ab05f405526945a94228ab1a445b166"
+  }
+]

--- a/owners/test/fixtures/reviews/comment_reviews.24686.json
+++ b/owners/test/fixtures/reviews/comment_reviews.24686.json
@@ -140,7 +140,7 @@
       "site_admin": false
     },
     "body": "",
-    "state": "COMMENTED",
+    "state": "CHANGES_REQUESTED",
     "html_url": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291980596",
     "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/24686",
     "author_association": "MEMBER",
@@ -179,7 +179,7 @@
       "site_admin": false
     },
     "body": "",
-    "state": "COMMENTED",
+    "state": "DISMISSED",
     "html_url": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291980756",
     "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/24686",
     "author_association": "MEMBER",
@@ -218,7 +218,7 @@
       "site_admin": false
     },
     "body": "",
-    "state": "COMMENTED",
+    "state": "PENDING",
     "html_url": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291980900",
     "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/24686",
     "author_association": "MEMBER",

--- a/owners/test/github.test.js
+++ b/owners/test/github.test.js
@@ -24,6 +24,7 @@ const {GitHub, PullRequest, Review, Team} = require('../src/github');
 
 const reviewsApprovedResponse = require('./fixtures/reviews/reviews.35.approved.json');
 const requestedReviewsResponse = require('./fixtures/reviews/requested_reviewers.24574.json');
+const commentReviewsResponse = require('./fixtures/reviews/comment_reviews.24686.json');
 const pullRequestResponse = require('./fixtures/pulls/pull_request.35.json');
 const issueCommentsResponse = require('./fixtures/comments/issue_comments.438.json');
 const listFilesResponse = require('./fixtures/files/files.35.json');
@@ -314,6 +315,20 @@ describe('GitHub API', () => {
         expect(review.reviewer).toEqual('erwinmombay');
         expect(review.isApproved).toBe(true);
         expect(review.submittedAt).toEqual(new Date('2019-02-26T20:39:13Z'));
+      })();
+    });
+
+    it('ignores comment reviews', async () => {
+      expect.assertions(2);
+      nock('https://api.github.com')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews')
+        .reply(200, commentReviewsResponse);
+
+      await withContext(async (context, github) => {
+        const reviews = await github.getReviews(24686);
+
+        expect(reviews[0].isApproved).toBe(true);
+        expect(reviews.length).toEqual(1);
       })();
     });
   });

--- a/owners/test/github.test.js
+++ b/owners/test/github.test.js
@@ -318,8 +318,8 @@ describe('GitHub API', () => {
       })();
     });
 
-    it('ignores comment reviews', async () => {
-      expect.assertions(2);
+    it('returns only approving and rejecting reviews', async () => {
+      expect.assertions(5);
       nock('https://api.github.com')
         .get('/repos/test_owner/test_repo/pulls/24686/reviews')
         .reply(200, commentReviewsResponse);
@@ -327,8 +327,11 @@ describe('GitHub API', () => {
       await withContext(async (context, github) => {
         const reviews = await github.getReviews(24686);
 
+        expect(reviews.length).toEqual(2);
+        expect(reviews[0].reviewer).toBe('rsimha');
         expect(reviews[0].isApproved).toBe(true);
-        expect(reviews.length).toEqual(1);
+        expect(reviews[1].reviewer).toBe('estherkim');
+        expect(reviews[1].isApproved).toBe(false);
       })();
     });
   });


### PR DESCRIPTION
In looking at recent PRs in `ampproject/amphtml`,  I noticed that https://github.com/ampproject/amphtml/pull/24686 listed `@rsimha` as "requested" but not approved, even though he'd given an approving review already. Upon digging into this, I found that the GitHub Reviews API, in addition to returning reviews with expect states (ie. approved & changes requested), it was also including review comments with a "commented" state. This was not documented in the [REST API docs](https://developer.github.com/v3/pulls/reviews/), but is mentioned in the [GraphQL API docs](https://developer.github.com/v4/enum/pullrequestreviewstate/).

As a result, the logic which looks at the most recent review was mistakenly identifying comments as rejecting reviews. Upon reviewing the remaining possible states (pending & dismissed), I determined that neither should be considered at actual review; a dismissed review should not count either way, and a pending review is the same.

This PR updates the GitHub `getReviews` method to return only actual reviews with relevant review states.

Closes #478 