### PR TITLE
[owners] Add env flag to make reviewer assignment opt-in/opt-out

### DIFF
--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -16,6 +16,7 @@
 
 const {OWNER_MODIFIER} = require('./owner');
 const ADD_REVIEWERS_TAG = /#add-?owners/i;
+const DONT_ADD_REVIEWERS_TAG = /#no-?add-?owners/i;
 
 /**
  * Notifier for to tagging and requesting reviewers for a PR.
@@ -58,7 +59,11 @@ class OwnersNotifier {
    * @return {string[]} list of reviewers requested.
    */
   async requestReviews(github, suggestedReviewers) {
-    if (ADD_REVIEWERS_TAG.test(this.pr.description)) {
+    const optOut = process.env.ADD_REVIEWERS_OPT_OUT;
+    const optOutTagPresent = DONT_ADD_REVIEWERS_TAG.test(this.pr.description);
+    const optInTagPresent = ADD_REVIEWERS_TAG.test(this.pr.description);
+
+    if ((optOut && !optOutTagPresent) || (!optOut && optInTagPresent)) {
       const reviewRequests = this.getReviewersToRequest(suggestedReviewers);
       await github.createReviewRequests(this.pr.number, reviewRequests);
       return reviewRequests;

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -72,7 +72,7 @@ describe('notifier', () => {
 
     describe('when reviewer assignment is opt-in', () => {
       beforeEach(() => {
-        sandbox.stub(process, 'env').value({ADD_REVIEWERS_OPT_OUT: false})
+        sandbox.stub(process, 'env').value({ADD_REVIEWERS_OPT_OUT: false});
       });
 
       it('does not create review requests', async done => {
@@ -101,7 +101,9 @@ describe('notifier', () => {
             'auser',
             'anotheruser',
           ]);
-          sandbox.assert.calledWith(github.createReviewRequests, 1337, ['auser']);
+          sandbox.assert.calledWith(github.createReviewRequests, 1337, [
+            'auser',
+          ]);
           done();
         });
 
@@ -119,7 +121,7 @@ describe('notifier', () => {
 
     describe('when reviewer assignment is opt-out', () => {
       beforeEach(() => {
-        sandbox.stub(process, 'env').value({ADD_REVIEWERS_OPT_OUT: true})
+        sandbox.stub(process, 'env').value({ADD_REVIEWERS_OPT_OUT: true});
       });
 
       it('requests reviewers', async done => {

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -25,7 +25,11 @@ describe('notifier', () => {
   const sandbox = sinon.createSandbox();
   const loggerStub = sinon.stub();
   const github = new GitHub(sinon.stub(), 'ampproject', 'amphtml', loggerStub);
-  const pr = new PullRequest(1337, 'the_author', '_test_hash_', 'description');
+  let pr;
+
+  beforeEach(() => {
+    pr = new PullRequest(1337, 'the_author', '_test_hash_', 'description');
+  });
 
   afterEach(() => {
     sandbox.restore();
@@ -61,6 +65,9 @@ describe('notifier', () => {
     beforeEach(() => {
       notifier = new OwnersNotifier(pr, {}, new OwnersTree(), []);
       sandbox.stub(GitHub.prototype, 'createReviewRequests');
+      sandbox
+        .stub(OwnersNotifier.prototype, 'getReviewersToRequest')
+        .returns(['auser']);
     });
 
     describe('when reviewer assignment is opt-in', () => {
@@ -84,9 +91,6 @@ describe('notifier', () => {
 
       describe('when the PR description contains #addowners', () => {
         beforeEach(() => {
-          sandbox
-            .stub(OwnersNotifier.prototype, 'getReviewersToRequest')
-            .returns(['auser']);
           pr.description = 'Assign reviewers please #addowners';
         });
 
@@ -141,10 +145,7 @@ describe('notifier', () => {
 
       describe('when the PR description contains #noaddowners', () => {
         beforeEach(() => {
-          sandbox
-            .stub(OwnersNotifier.prototype, 'getReviewersToRequest')
-            .returns(['auser']);
-          pr.description = 'Do not assign reviewers #noaddowners';
+          pr.description = 'Please do not assign reviewers #noaddowners';
         });
 
         it('does not create review requests', async done => {


### PR DESCRIPTION
For the `amphtml` repository, the plan to to transition reviewer assignment from opt-in to opt-out; however, other repositories or users of the owners bot app may not want the same functionality. In addition, it is preferred to be able to toggle this through configuration rather than code changes.

This PR adds an `ADD_REVIEWERS_OPT_OUT` environment flag. When true, automatic reviewer assignment is enabled by default, and opted out with the `#noaddowners` tag; when false, automatic reviewer assignment does not run by default, and runs *only* when the `#addowners` tag is present (this is the current behavior).