### PR TITLE
[owners] Exclude pending and requested reviewers from the notification comment

### DIFF
--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -122,8 +122,6 @@ class OwnersNotifier {
   /**
    * Determine the set of owners to notify/tag for each file.
    *
-   * TODO(#473): Exclude existing & suggested reviewers from the notify set.
-   *
    * @return {Object<string, string[]>} map from user/team names to filenames.
    */
   getOwnersToNotify() {
@@ -138,6 +136,10 @@ class OwnersNotifier {
           }
           notifies[name].push(filename);
         });
+    });
+    
+    Object.keys(this.currentReviewers).forEach(name => {
+      delete notifies[name];
     });
 
     return notifies;

--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -137,7 +137,7 @@ class OwnersNotifier {
           notifies[name].push(filename);
         });
     });
-    
+
     Object.keys(this.currentReviewers).forEach(name => {
       delete notifies[name];
     });

--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -43,8 +43,11 @@ class OwnersNotifier {
    * @param {string[]} suggestedReviewers suggested reviewers to add.
    */
   async notify(github, suggestedReviewers) {
-    await this.requestReviews(github, suggestedReviewers);
-    // TODO(#473): Add requested reviews to current reviewer set.
+    const requested = await this.requestReviews(github, suggestedReviewers);
+    requested.forEach(reviewer => {
+      this.currentReviewers[reviewer] = false;
+    });
+
     await this.createNotificationComment(github);
   }
 

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -310,11 +310,13 @@ describe('notifier', () => {
           tree,
           [{filename: 'baz/test.js', sha: '_sha_'}]
         );
-      
-        sandbox.stub(OwnersTree.prototype, 'getModifiedFileOwners').returns([
-          new UserOwner('current_approver'),
-          new UserOwner('pending_reviewer'),
-        ]);
+
+        sandbox
+          .stub(OwnersTree.prototype, 'getModifiedFileOwners')
+          .returns([
+            new UserOwner('current_approver'),
+            new UserOwner('pending_reviewer'),
+          ]);
       });
 
       it('excludes approving reviewers', () => {

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -224,7 +224,7 @@ describe('owners bot', () => {
     });
 
     it('requests reviewers', async done => {
-      sandbox.stub(OwnersNotifier.prototype, 'requestReviews');
+      sandbox.stub(OwnersNotifier.prototype, 'requestReviews').callThrough();
       await ownersBot.runOwnersCheck(github, pr);
 
       sandbox.assert.calledWith(


### PR DESCRIPTION
Suggestion: Review commit-by-commit

Currently, the notifier tags users regardless of whether or not they are already present on the PR. It already excludes the PR author from the notification comment; this PR also excludes any current, pending, or requested (newly pending) reviewers.

Closes #473 