### PR TITLE
[owners] Only request reviewers on new pull requests

### DIFF
--- a/owners/index.js
+++ b/owners/index.js
@@ -116,7 +116,7 @@ module.exports = app => {
     await ownersBot.runOwnersCheck(
       GitHub.fromContext(context),
       PullRequest.fromGitHubResponse(context.payload.pull_request),
-      /* requestOwners=*/ true
+      /* requestOwners */ true
     );
   });
 

--- a/owners/index.js
+++ b/owners/index.js
@@ -112,7 +112,15 @@ module.exports = app => {
   });
 
   /** Probot request handlers **/
-  app.on(['pull_request.opened', 'pull_request.synchronize'], async context => {
+  app.on(['pull_request.opened'], async context => {
+    await ownersBot.runOwnersCheck(
+      GitHub.fromContext(context),
+      PullRequest.fromGitHubResponse(context.payload.pull_request),
+      /*requestOwners=*/true,
+    );
+  });
+
+  app.on(['pull_request.synchronize'], async context => {
     await ownersBot.runOwnersCheck(
       GitHub.fromContext(context),
       PullRequest.fromGitHubResponse(context.payload.pull_request)

--- a/owners/index.js
+++ b/owners/index.js
@@ -116,7 +116,7 @@ module.exports = app => {
     await ownersBot.runOwnersCheck(
       GitHub.fromContext(context),
       PullRequest.fromGitHubResponse(context.payload.pull_request),
-      /*requestOwners=*/true,
+      /* requestOwners=*/ true
     );
   });
 

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -96,8 +96,9 @@ class OwnersBot {
    *
    * @param {!GitHub} github GitHub API interface.
    * @param {!PullRequest} pr pull request to run owners check on.
+   * @param {boolean=} requestOwners whether to request reviews from owners.
    */
-  async runOwnersCheck(github, pr) {
+  async runOwnersCheck(github, pr, requestOwners) {
     const {tree, changedFiles, reviewers} = await this.initPr(github, pr);
 
     const checkRunIdMap = await github.getCheckRunIds(pr.headSha);
@@ -115,8 +116,9 @@ class OwnersBot {
       await github.createCheckRun(pr.headSha, ownersCheckResult.checkRun);
     }
 
+    const suggestedReviewers = requestOwners ? ownersCheckResult.reviewers : [];
     const notifier = new OwnersNotifier(pr, reviewers, tree, changedFiles);
-    await notifier.notify(github, ownersCheckResult.reviewers);
+    await notifier.notify(github, suggestedReviewers);
   }
 
   /**

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -223,14 +223,26 @@ describe('owners bot', () => {
       });
     });
 
-    it('requests reviewers', async done => {
+    it('requests reviewers if flag is set', async done => {
+      sandbox.stub(OwnersNotifier.prototype, 'requestReviews').callThrough();
+      await ownersBot.runOwnersCheck(github, pr, true);
+
+      sandbox.assert.calledWith(
+        OwnersNotifier.prototype.requestReviews,
+        github,
+        ['root_owner']
+      );
+      done();
+    });
+
+    it('requests no reviewers by default', async done => {
       sandbox.stub(OwnersNotifier.prototype, 'requestReviews').callThrough();
       await ownersBot.runOwnersCheck(github, pr);
 
       sandbox.assert.calledWith(
         OwnersNotifier.prototype.requestReviews,
         github,
-        ['root_owner']
+        []
       );
       done();
     });


### PR DESCRIPTION
Since the owners bot is webhooked to run after new commits or review status changes, it triggers when someone removes a reviewer, causing the bot to immediately reassign the reviewer. This could also be an issue when commits are added later on, re-adding previously removed reviewers. The desired behavior is instead that reviewer assignment should only occur upon PR creation. This means that you couldn't trigger assignment after the fact, but that's a reasonable trade-off since the owners check will still show suggested reviewers if more are necessary.

Closes #488 