### PR TITLE
[owners] Treat comment-only reviews as rejections

### DIFF
--- a/owners/package.json
+++ b/owners/package.json
@@ -16,7 +16,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "lodash": "4.17.15",
     "minimatch": "3.0.4",
     "probot": "7.5.0",
     "sleep-promise": "8.0.1",

--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -61,8 +61,23 @@ class Review {
     Object.assign(this, {
       reviewer,
       submittedAt,
-      isApproved: state.toLowerCase() === 'approved',
+      state: state.toLowerCase(),
     });
+  }
+
+  /** If the review is an approval */
+  get isApproved() {
+    return this.state === 'approved';
+  }
+
+  /** If the review is a comment */
+  get isComment() {
+    return this.state === 'commented';
+  }
+
+  /** If the review is a rejection */
+  get isRejected() {
+    return !(this.isApproved || this.isComment);
   }
 }
 
@@ -244,7 +259,7 @@ class GitHub {
     // possible review states. The only ones we care about are "APPROVED" and
     // "CHANGES_REQUESTED", since the rest do not indicate a definite approval
     // or rejection.
-    const allowedStates = ['approved', 'changes_requested'];
+    const allowedStates = ['approved', 'changes_requested', 'commented'];
     return response.data
       .filter(({state}) => allowedStates.includes(state.toLowerCase()))
       .map(

--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -61,18 +61,18 @@ class Review {
     Object.assign(this, {
       reviewer,
       submittedAt,
-      state: state.toLowerCase(),
+      _state: state.toLowerCase(),
     });
   }
 
   /** If the review is an approval */
   get isApproved() {
-    return this.state === 'approved';
+    return this._state === 'approved';
   }
 
   /** If the review is a comment */
   get isComment() {
-    return this.state === 'commented';
+    return this._state === 'commented';
   }
 
   /** If the review is a rejection */

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-const _ = require('lodash');
 const sleep = require('sleep-promise');
 const {OwnersCheck} = require('./owners_check');
 const {OwnersParser} = require('./parser');

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -145,13 +145,14 @@ class OwnersBot {
   async _getCurrentReviewers(github, pr) {
     const reviews = await github.getReviews(pr.number);
     // Sort by the latest submitted_at date to get the latest review.
-    const sortedReviews = reviews.sort((a, b) => b.submittedAt - a.submittedAt);
-    // This should always pick out the first instance.
-    const uniqueReviews = _.uniqBy(sortedReviews, 'reviewer');
-
+    const sortedReviews = reviews.sort((a, b) => a.submittedAt - b.submittedAt);
     const approvals = {};
-    uniqueReviews.forEach(review => {
-      approvals[review.reviewer] = review.isApproved;
+    sortedReviews.forEach(review => {
+      // Only treat comments as rejecting reviews if they do not follow an
+      // existing approval or rejection.
+      if (approvals[review.reviewer] === undefined || !review.isComment) {
+        approvals[review.reviewer] = review.isApproved;
+      }
     });
     // The author of a PR implicitly gives approval over files they own.
     approvals[pr.author] = true;

--- a/owners/test/fixtures/reviews/comment_reviews.24686.json
+++ b/owners/test/fixtures/reviews/comment_reviews.24686.json
@@ -159,7 +159,7 @@
     "id": 291980756,
     "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MjkxOTgwNzU2",
     "user": {
-      "login": "estherkim",
+      "login": "rcebulko",
       "id": 44627152,
       "node_id": "MDQ6VXNlcjQ0NjI3MTUy",
       "avatar_url": "https://avatars2.githubusercontent.com/u/44627152?v=4",
@@ -179,7 +179,7 @@
       "site_admin": false
     },
     "body": "",
-    "state": "DISMISSED",
+    "state": "COMMENTED",
     "html_url": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291980756",
     "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/24686",
     "author_association": "MEMBER",
@@ -218,7 +218,7 @@
       "site_admin": false
     },
     "body": "",
-    "state": "PENDING",
+    "state": "DISMISSED",
     "html_url": "https://github.com/ampproject/amphtml/pull/24686#pullrequestreview-291980900",
     "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/24686",
     "author_association": "MEMBER",

--- a/owners/test/github.test.js
+++ b/owners/test/github.test.js
@@ -318,20 +318,92 @@ describe('GitHub API', () => {
       })();
     });
 
-    it('returns only approving and rejecting reviews', async () => {
-      expect.assertions(5);
+    it('returns approvals', async () => {
+      expect.assertions(2);
       nock('https://api.github.com')
         .get('/repos/test_owner/test_repo/pulls/24686/reviews')
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {
         const reviews = await github.getReviews(24686);
+        const review = reviews[0];
 
-        expect(reviews.length).toEqual(2);
-        expect(reviews[0].reviewer).toBe('rsimha');
-        expect(reviews[0].isApproved).toBe(true);
-        expect(reviews[1].reviewer).toBe('estherkim');
-        expect(reviews[1].isApproved).toBe(false);
+        expect(review.reviewer).toEqual('rsimha');
+        expect(review.isApproved).toBe(true);
+      })();
+    });
+
+    it('returns post-review comments', async () => {
+      expect.assertions(2);
+      nock('https://api.github.com')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews')
+        .reply(200, commentReviewsResponse);
+
+      await withContext(async (context, github) => {
+        const reviews = await github.getReviews(24686);
+        const review = reviews[1];
+
+        expect(review.reviewer).toEqual('rsimha');
+        expect(review.isComment).toBe(true);
+      })();
+    });
+
+    it('returns pre-review comments', async () => {
+      expect.assertions(2);
+      nock('https://api.github.com')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews')
+        .reply(200, commentReviewsResponse);
+
+      await withContext(async (context, github) => {
+        const reviews = await github.getReviews(24686);
+        const review = reviews[2];
+
+        expect(review.reviewer).toEqual('estherkim');
+        expect(review.isComment).toBe(true);
+      })();
+    });
+
+    it('returns rejections', async () => {
+      expect.assertions(2);
+      nock('https://api.github.com')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews')
+        .reply(200, commentReviewsResponse);
+
+      await withContext(async (context, github) => {
+        const reviews = await github.getReviews(24686);
+        const review = reviews[3];
+
+        expect(review.reviewer).toEqual('estherkim');
+        expect(review.isRejected).toBe(true);
+      })();
+    });
+
+    it('returns comment-only reviews', async () => {
+      expect.assertions(2);
+      nock('https://api.github.com')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews')
+        .reply(200, commentReviewsResponse);
+
+      await withContext(async (context, github) => {
+        const reviews = await github.getReviews(24686);
+        const review = reviews[4];
+
+        expect(review.reviewer).toEqual('rcebulko');
+        expect(review.isComment).toBe(true);
+      })();
+    });
+
+    it('ignores irrelevant review states', async () => {
+      expect.assertions(1);
+      nock('https://api.github.com')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews')
+        .reply(200, commentReviewsResponse);
+
+      await withContext(async (context, github) => {
+        const reviews = await github.getReviews(24686);
+        const review = reviews[5];
+
+        expect(review).toBeUndefined();
       })();
     });
   });

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -270,7 +270,6 @@ describe('owners bot', () => {
   describe('getCurrentReviewers', () => {
     const today = new Date('2019-01-02T00:00:00Z');
     const yesterday = new Date('2019-01-01T00:00:00Z');
-    const tomorrowTimestamp = '2019-01-03T00:00:00Z';
 
     it("includes true for approvers' usernames", async () => {
       expect.assertions(2);

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -42,11 +42,6 @@ describe('owners bot', () => {
   const localRepo = new LocalRepository('path/to/repo');
   const ownersBot = new OwnersBot(localRepo);
 
-  const timestamp = '2019-01-01T00:00:00Z';
-  const approval = new Review('approver', 'approved', timestamp);
-  const otherApproval = new Review('other_approver', 'approved', timestamp);
-  const rejection = new Review('rejector', 'changes_requested', timestamp);
-
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     sandbox.stub(LocalRepository.prototype, 'checkout');
@@ -90,9 +85,13 @@ describe('owners bot', () => {
 
   describe('initPr', () => {
     beforeEach(() => {
+      const timestamp = new Date('2019-01-02T00:00:00Z');
       sandbox
         .stub(GitHub.prototype, 'getReviews')
-        .returns([approval, otherApproval]);
+        .returns([
+          new Review('approver', 'approved', timestamp),
+          new Review('other_approver', 'approved', timestamp),
+        ]);
       sandbox
         .stub(GitHub.prototype, 'listFiles')
         .returns([
@@ -269,11 +268,18 @@ describe('owners bot', () => {
   });
 
   describe('getCurrentReviewers', () => {
+    const today = new Date('2019-01-02T00:00:00Z');
+    const yesterday = new Date('2019-01-01T00:00:00Z');
+    const tomorrowTimestamp = '2019-01-03T00:00:00Z';
+
     it("includes true for approvers' usernames", async () => {
       expect.assertions(2);
       sandbox
         .stub(GitHub.prototype, 'getReviews')
-        .returns([approval, otherApproval]);
+        .returns([
+          new Review('approver', 'approved', today),
+          new Review('other_approver', 'approved', today),
+        ]);
       const reviewers = await ownersBot._getCurrentReviewers(github, pr);
 
       expect(reviewers['approver']).toBe(true);
@@ -292,10 +298,100 @@ describe('owners bot', () => {
       expect.assertions(1);
       sandbox
         .stub(GitHub.prototype, 'getReviews')
-        .returns([approval, rejection]);
+        .returns([new Review('rejector', 'changes_requested', today)]);
       const reviewers = await ownersBot._getCurrentReviewers(github, pr);
 
       expect(reviewers['rejector']).toBe(false);
+    });
+
+    it('includes false for reviewers who approved then rejected', async () => {
+      expect.assertions(1);
+      sandbox
+        .stub(GitHub.prototype, 'getReviews')
+        .returns([
+          new Review('rejector', 'approved', yesterday),
+          new Review('rejector', 'changes_requested', today),
+        ]);
+      const reviewers = await ownersBot._getCurrentReviewers(github, pr);
+
+      expect(reviewers['rejector']).toBe(false);
+    });
+
+    it('includes true for reviewers who rejected then approved', async () => {
+      expect.assertions(1);
+      sandbox
+        .stub(GitHub.prototype, 'getReviews')
+        .returns([
+          new Review('approver', 'changes_requested', yesterday),
+          new Review('approver', 'approved', today),
+        ]);
+      const reviewers = await ownersBot._getCurrentReviewers(github, pr);
+
+      expect(reviewers['approver']).toBe(true);
+    });
+
+    describe('with comment reviews', () => {
+      it('includes false for reviewers who only commented', async () => {
+        expect.assertions(1);
+        sandbox
+          .stub(GitHub.prototype, 'getReviews')
+          .returns([new Review('commenter', 'commented', today)]);
+        const reviewers = await ownersBot._getCurrentReviewers(github, pr);
+
+        expect(reviewers['commenter']).toBe(false);
+      });
+
+      it('includes false for reviewers who rejected then commented', async () => {
+        expect.assertions(1);
+        sandbox
+          .stub(GitHub.prototype, 'getReviews')
+          .returns([
+            new Review('rejector', 'changes_requested', yesterday),
+            new Review('rejector', 'commented', today),
+          ]);
+        const reviewers = await ownersBot._getCurrentReviewers(github, pr);
+
+        expect(reviewers['rejector']).toBe(false);
+      });
+
+      it('includes true for reviewers who approved then commented', async () => {
+        expect.assertions(1);
+        sandbox
+          .stub(GitHub.prototype, 'getReviews')
+          .returns([
+            new Review('approver', 'approved', yesterday),
+            new Review('approver', 'commented', today),
+          ]);
+        const reviewers = await ownersBot._getCurrentReviewers(github, pr);
+
+        expect(reviewers['approver']).toBe(true);
+      });
+
+      it('includes false for reviewers who commented then rejected', async () => {
+        expect.assertions(1);
+        sandbox
+          .stub(GitHub.prototype, 'getReviews')
+          .returns([
+            new Review('rejector', 'commented', yesterday),
+            new Review('rejector', 'changes_requested', today),
+          ]);
+        const reviewers = await ownersBot._getCurrentReviewers(github, pr);
+
+        expect(reviewers['rejector']).toBe(false);
+      });
+
+      it('includes true for reviewers who commented then approved', async () => {
+        expect.assertions(1);
+        sandbox
+          .stub(GitHub.prototype, 'getReviews')
+          .returns([
+            new Review('approver', 'commented', yesterday),
+            new Review('approver', 'approved', today),
+          ]);
+        const reviewers = await ownersBot._getCurrentReviewers(github, pr);
+
+        expect(reviewers['approver']).toBe(true);
+      });
     });
   });
 });


### PR DESCRIPTION
Closes #492 (see issue for more details)

The initial attempt to ignore comments completely backfired. This PR allows the GitHub interface to return comment reviews, adds far more comprehensive tests around how the owners bot treats different types of reviews in different orders, and fixes the issue.