### PR TITLE
[owners] Cache tree parse on public-facing status server endpoints

### DIFF
--- a/owners/index.js
+++ b/owners/index.js
@@ -31,7 +31,7 @@ const APP_ID = process.env.APP_ID || 'UNKNOWN';
 const APP_COMMIT_SHA = process.env.APP_COMMIT_SHA || 'UNKNOWN';
 const APP_COMMIT_MSG = process.env.APP_COMMIT_MSG || 'UNKNOWN';
 
-CACHED_TREE_REFRESH_MS = 10 * 60 * 1000;
+const CACHED_TREE_REFRESH_MS = 10 * 60 * 1000;
 
 module.exports = app => {
   const localRepo = new LocalRepository(process.env.GITHUB_REPO_DIR);
@@ -92,19 +92,21 @@ module.exports = app => {
     );
   });
 
+  // Since the status server is publicly accessible, we don't want any
+  // endpoints to be making API calls or doing disk I/O. Rather than parsing
+  // the file tree from the local repo on every request, we keep a local copy
+  // and update it every ten minutes.
+  const parser = new OwnersParser(localRepo, ownersBot.teams, app.log);
+  let treeParse = {result: {}, errors: []};
+  /** Updates the cached copy of the parsed ownership tree. */
+  function updateTree() {
+    app.log('Updating cached owners tree');
+    parser.parseOwnersTree().then(parse => {
+      treeParse = parse;
+    });
+  }
+
   if (process.env.NODE_ENV !== 'test') {
-    // Since the status server is publicly accessible, we don't want any
-    // endpoints to be making API calls or doing disk I/O. Rather than parsing
-    // the file tree from the local repo on every request, we keep a local copy
-    // and update it every ten minutes.
-    const parser = new OwnersParser(localRepo, ownersBot.teams, app.log);
-    let treeParse = {result: {}, errors: []};
-    function updateTree() {
-      app.log('Updating cached owners tree');
-      parser.parseOwnersTree().then(parse => {
-        treeParse = parse;
-      });
-    }
     teamsInitialized.then(updateTree);
     setInterval(updateTree, CACHED_TREE_REFRESH_MS);
 

--- a/owners/index.js
+++ b/owners/index.js
@@ -111,6 +111,7 @@ module.exports = app => {
     setInterval(updateTree, CACHED_TREE_REFRESH_MS);
 
     /** Health check server endpoints **/
+    app.log(`Starting status server on port ${process.env.INFO_SERVER_PORT}`);
     server({port: process.env.INFO_SERVER_PORT || 8081}, [
       server.router.get('/status', ctx =>
         [

--- a/owners/index.js
+++ b/owners/index.js
@@ -44,7 +44,7 @@ module.exports = app => {
     app.log
   );
   // TODO(rcebulko): Add a mechanism to periodically refresh teams.
-  ownersBot.initTeams(github);
+  const teamsInitialized = ownersBot.initTeams(github);
 
   // Probot does not stream properly to GCE logs so we need to hook into
   // bunyan explicitly and stream it to process.stdout.
@@ -105,7 +105,7 @@ module.exports = app => {
         treeParse = parse;
       });
     }
-    updateTree();
+    teamsInitialized.then(updateTree);
     setInterval(updateTree, CACHED_TREE_REFRESH_MS);
 
     /** Health check server endpoints **/


### PR DESCRIPTION
Since the goal is to make the status server public-facing, it should not include any calls to rate-limited APIs or an filesystem I/O, as this presents a potential vulnerability to DOS/abuse. Currently, the only endpoint which has this issue is the `/tree` page, which displays the current ownership tree by parsing the locally checked-out repository on the GCE instance filesystem.

This PR instead creates a locally cached tree parse, which is updated on a regular (10 minute) interval, so that the public-facing endpoint does no filesystem I/O and just renders based on the in-memory tree parse.