### PR TITLE
[owners] Catch YAML syntax errors in parser

### DIFF
--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -239,7 +239,7 @@ class OwnersParser {
    */
   parseOwnersFile(ownersPath) {
     const contents = this.localRepo.readFile(ownersPath);
-    
+
     let lines;
     try {
       lines = yaml.parse(contents);

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -239,7 +239,17 @@ class OwnersParser {
    */
   parseOwnersFile(ownersPath) {
     const contents = this.localRepo.readFile(ownersPath);
-    const lines = yaml.parse(contents);
+    
+    let lines;
+    try {
+      lines = yaml.parse(contents);
+    } catch (error) {
+      return {
+        result: [],
+        errors: [new OwnersParserError(ownersPath, error.toString())],
+      };
+    }
+
     const errors = [];
     const rules = [];
 

--- a/owners/test/parser.test.js
+++ b/owners/test/parser.test.js
@@ -90,10 +90,18 @@ describe('owners parser', () => {
 
     it('parses a wildcard owner', () => {
       sandbox.stub(repo, 'readFile').returns('- "*"');
-      const fileParse = parser.parseOwnersFile('hat');
+      const fileParse = parser.parseOwnersFile('');
       const rules = fileParse.result;
 
       expect(rules[0].owners).toEqual([new WildcardOwner()]);
+    });
+
+    it('handles and reports YAML syntax errors', () => {
+      sandbox.stub(repo, 'readFile').returns('- *');
+      const {result, errors} = parser.parseOwnersFile('');
+
+      expect(result).toEqual([]);
+      expect(errors[0].message).toContain('<ParseException>');
     });
 
     describe('team rule declarations', () => {


### PR DESCRIPTION
Somehow I wrote all kinds of logic to catch and report syntax errors, yet I never handled YAML parsing errors. :man_facepalming: 