### PR TITLE
Set renovate-bot to update all packages in one PR, once a week

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,10 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "packageRules": [{
+    "packagePatterns": [".*"],
+    "groupName": "packages",
+    "schedule": ["after 9pm on sunday"]
+  }]
 }


### PR DESCRIPTION
I think this is preferable for this repository, given that we have a lot of dependencies that get a `x.x.1` version update every few days...