### PR TITLE
[bundle-size] Create new API endpoint to receive bundleSizes as a JSON payload

### DIFF
--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -264,13 +264,13 @@ module.exports = app => {
     } catch (error) {
       const partialHeadSha = check.head_sha.substr(0, 7);
       const partialBaseSha = baseSha.substr(0, 7);
-      app.log(
+      app.log.error(
         'ERROR: Failed to retrieve the bundle size of ' +
           `${partialHeadSha} (PR #${check.pull_request_id}) with branch ` +
           `point ${partialBaseSha} from GitHub: ${error}`
       );
       if (lastAttempt) {
-        app.log('No more retries left. Reporting failure');
+        app.log.warn('No more retries left. Reporting failure');
         Object.assign(updatedCheckOptions, {
           conclusion: 'action_required',
           output: {
@@ -338,11 +338,11 @@ module.exports = app => {
         ...pullRequest,
       });
     } catch (error) {
-      app.log(
+      app.log.error(
         'ERROR: Failed to add a reviewer to pull request ' +
           `${pullRequest.pull_number}. Skipping...`
       );
-      app.log(`Error message: ${error}`);
+      app.log.error(`Error message: ${error}`);
       throw error;
     }
   }
@@ -482,7 +482,9 @@ module.exports = app => {
       'TRAVIS_IP_ADDRESSES' in process.env &&
       !process.env['TRAVIS_IP_ADDRESSES'].includes(request.ip)
     ) {
-      app.log(`Refused a request to ${request.originalUrl} from ${request.ip}`);
+      app.log.warn(
+        `Refused a request to ${request.originalUrl} from ${request.ip}`
+      );
       response.status(403).end('You are not Travis!');
     } else {
       next();
@@ -607,7 +609,7 @@ module.exports = app => {
           `ERROR: Failed to create the bundle-size/${bundleSizeFile} file in ` +
           'the build artifacts repository on GitHub!\n' +
           `Error message was: ${error}`;
-        app.log(errorMessage);
+        app.log.error(errorMessage);
         return response.status(500).end(errorMessage);
       }
     }
@@ -643,7 +645,7 @@ module.exports = app => {
         `ERROR: Failed to create the bundle-size/${jsonBundleSizeFile} file ` +
         'in the build artifacts repository on GitHub!\n' +
         `Error message was: ${error}`;
-      app.log(errorMessage);
+      app.log.error(errorMessage);
       return response.status(500).end(errorMessage);
     }
 
@@ -700,7 +702,7 @@ module.exports = app => {
         `ERROR: Failed to create the bundle-size/${jsonBundleSizeFile} file ` +
         'in the build artifacts repository on GitHub!\n' +
         `Error message was: ${error}`;
-      app.log(errorMessage);
+      app.log.error(errorMessage);
       return response.status(500).end(errorMessage);
     }
 

--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -68,7 +68,7 @@ async function getBuildArtifactsFile(github, filename) {
 async function storeBuildArtifactsFile(github, filename, contents) {
   return await github.repos.createOrUpdateFile({
     ...getBuildArtifactsFileParams(filename),
-    message: `bundle-size: ${filename} (${contents})`,
+    message: `bundle-size: ${filename}`,
     content: Buffer.from(contents).toString('base64'),
   });
 }
@@ -629,6 +629,63 @@ module.exports = app => {
       const jsonBundleSizeText = JSON.stringify({
         'dist/v0.js': brotliBundleSize,
       });
+      await storeBuildArtifactsFile(
+        userBasedGithub,
+        jsonBundleSizeFile,
+        jsonBundleSizeText
+      );
+      app.log(
+        `Stored the new bundle size file bundle-size/${jsonBundleSizeFile} ` +
+          'the artifacts repository on GitHub'
+      );
+    } catch (error) {
+      const errorMessage =
+        `ERROR: Failed to create the bundle-size/${jsonBundleSizeFile} file ` +
+        'in the build artifacts repository on GitHub!\n' +
+        `Error message was: ${error}`;
+      app.log(errorMessage);
+      return response.status(500).end(errorMessage);
+    }
+
+    response.end();
+  });
+
+  // TODO(danielrozenberg): replace the /store with this one, once the amphtml
+  // repo is in sync with this new change.
+  v0.post('/commit/:headSha/store.json', async (request, response) => {
+    const {headSha} = request.params;
+    const {bundleSizes} = request.body;
+
+    if (request.body['token'] !== process.env.TRAVIS_PUSH_BUILD_TOKEN) {
+      return response.status(403).end('You are not Travis!');
+    }
+    if (
+      !bundleSizes ||
+      Object.values(bundleSizes).some(value => typeof value !== 'number')
+    ) {
+      return response
+        .status(400)
+        .end(
+          'POST request to /store must have a key/value object ' +
+            '(string->numeric) field "bundleSizes"'
+        );
+    }
+
+    const jsonBundleSizeFile = `${headSha}.json`;
+    try {
+      await getBuildArtifactsFile(userBasedGithub, jsonBundleSizeFile);
+      app.log(
+        `The file bundle-size/${jsonBundleSizeFile} already exists in the ` +
+          'build artifacts repository on GitHub. Skipping...'
+      );
+      return response.end();
+    } catch (unusedException) {
+      // The file was not found in the GitHub repository, so continue to
+      // create it...
+    }
+
+    try {
+      const jsonBundleSizeText = JSON.stringify(bundleSizes);
       await storeBuildArtifactsFile(
         userBasedGithub,
         jsonBundleSizeFile,

--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -669,7 +669,7 @@ module.exports = app => {
         .status(400)
         .end(
           'POST request to /store must have a key/value object ' +
-            '(string->numeric) field "bundleSizes"'
+            'Map<string, number> field "bundleSizes"'
         );
     }
 

--- a/bundle-size/test/app.test.js
+++ b/bundle-size/test/app.test.js
@@ -108,858 +108,1029 @@ describe('bundle-size', () => {
     await db.destroy();
   });
 
-  test('create a new pending check when a pull request is opened', async () => {
-    const payload = getFixture('pull_request.opened');
+  describe('GitHub webhooks', () => {
+    describe('pull_request', () => {
+      test('create a new pending check when a pull request is opened', async () => {
+        const payload = getFixture('pull_request.opened');
 
-    const nocks = nock('https://api.github.com')
-      .post('/repos/ampproject/amphtml/check-runs', body => {
-        expect(body).toMatchObject({
+        const nocks = nock('https://api.github.com')
+          .post('/repos/ampproject/amphtml/check-runs', body => {
+            expect(body).toMatchObject({
+              head_sha: '39f787c8132f9ccc956ed465c0af8bc33f641404',
+              name: 'ampproject/bundle-size',
+              output: {
+                title: 'Calculating new bundle size for this PR…',
+              },
+            });
+            return true;
+          })
+          .reply(200, {id: 555555});
+
+        await probot.receive({name: 'pull_request', payload});
+        await waitUntilNockScopeIsDone(nocks);
+
+        expect(await db('checks').select('*')).toMatchObject([
+          {
+            head_sha: '39f787c8132f9ccc956ed465c0af8bc33f641404',
+            owner: 'ampproject',
+            repo: 'amphtml',
+            pull_request_id: 19621,
+            installation_id: 123456,
+            check_run_id: 555555,
+            delta: null,
+          },
+        ]);
+      });
+
+      test('update a pending check when a pull request is synced', async () => {
+        await db('checks').insert({
           head_sha: '39f787c8132f9ccc956ed465c0af8bc33f641404',
-          name: 'ampproject/bundle-size',
-          output: {
-            title: 'Calculating new bundle size for this PR…',
-          },
+          owner: 'ampproject',
+          repo: 'amphtml',
+          pull_request_id: 19621,
+          installation_id: 123456,
+          check_run_id: 444444,
+          delta: null,
         });
-        return true;
-      })
-      .reply(200, {id: 555555});
 
-    await probot.receive({name: 'pull_request', payload});
-    await waitUntilNockScopeIsDone(nocks);
+        const payload = getFixture('pull_request.opened');
 
-    expect(await db('checks').select('*')).toMatchObject([
-      {
-        head_sha: '39f787c8132f9ccc956ed465c0af8bc33f641404',
-        owner: 'ampproject',
-        repo: 'amphtml',
-        pull_request_id: 19621,
-        installation_id: 123456,
-        check_run_id: 555555,
-        delta: null,
-      },
-    ]);
-  });
-
-  test('update a pending check when a pull request is synced', async () => {
-    await db('checks').insert({
-      head_sha: '39f787c8132f9ccc956ed465c0af8bc33f641404',
-      owner: 'ampproject',
-      repo: 'amphtml',
-      pull_request_id: 19621,
-      installation_id: 123456,
-      check_run_id: 444444,
-      delta: null,
-    });
-
-    const payload = getFixture('pull_request.opened');
-
-    const nocks = nock('https://api.github.com')
-      .post('/repos/ampproject/amphtml/check-runs', body => {
-        expect(body).toMatchObject({
-          head_sha: '39f787c8132f9ccc956ed465c0af8bc33f641404',
-          name: 'ampproject/bundle-size',
-          output: {
-            title: 'Calculating new bundle size for this PR…',
-          },
-        });
-        return true;
-      })
-      .reply(200, {id: 555555});
-
-    await probot.receive({name: 'pull_request', payload});
-    await waitUntilNockScopeIsDone(nocks);
-
-    expect(await db('checks').select('*')).toMatchObject([
-      {
-        head_sha: '39f787c8132f9ccc956ed465c0af8bc33f641404',
-        owner: 'ampproject',
-        repo: 'amphtml',
-        pull_request_id: 19621,
-        installation_id: 123456,
-        check_run_id: 555555,
-        delta: null,
-      },
-    ]);
-  });
-
-  test('mark a check as successful when a capable user approves the PR', async () => {
-    const payload = getFixture('pull_request_review.submitted');
-
-    await db('checks').insert({
-      head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
-      owner: 'ampproject',
-      repo: 'amphtml',
-      pull_request_id: 19603,
-      installation_id: 123456,
-      check_run_id: 555555,
-      delta: 0.2,
-    });
-
-    const nocks = nock('https://api.github.com')
-      .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
-        expect(body).toMatchObject({
-          conclusion: 'success',
-          output: {
-            title: 'Δ +0.20KB | approved by @aghassemi',
-          },
-        });
-        return true;
-      })
-      .reply(200);
-
-    await probot.receive({name: 'pull_request_review', payload});
-    await waitUntilNockScopeIsDone(nocks);
-  });
-
-  test(
-    'mark a check as successful when  a capable user approves the PR with ' +
-      'missing size delta',
-    async () => {
-      const payload = getFixture('pull_request_review.submitted');
-
-      await db('checks').insert({
-        head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
-        owner: 'ampproject',
-        repo: 'amphtml',
-        pull_request_id: 19603,
-        installation_id: 123456,
-        check_run_id: 555555,
-        delta: null,
-      });
-
-      const nocks = nock('https://api.github.com')
-        .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
-          expect(body).toMatchObject({
-            conclusion: 'success',
-            output: {
-              title: 'Δ ±?.??KB | approved by @aghassemi',
-            },
-          });
-          return true;
-        })
-        .reply(200);
-
-      await probot.receive({name: 'pull_request_review', payload});
-      await waitUntilNockScopeIsDone(nocks);
-    }
-  );
-
-  test('ignore an approved review by a non-capable reviewer', async () => {
-    const payload = getFixture('pull_request_review.submitted');
-
-    await probot.receive({name: 'pull_request_review', payload});
-  });
-
-  test('ignore a "changes requested" review', async () => {
-    const payload = getFixture('pull_request_review.submitted');
-    payload.state = 'changes_requested';
-
-    await probot.receive({name: 'pull_request_review', payload});
-  });
-
-  test('ignore an approved review by a capable reviewer for small delta', async () => {
-    const payload = getFixture('pull_request_review.submitted');
-
-    await db('checks').insert({
-      head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
-      owner: 'ampproject',
-      repo: 'amphtml',
-      pull_request_id: 19603,
-      installation_id: 123456,
-      check_run_id: 555555,
-      delta: 0.05,
-    });
-
-    await probot.receive({name: 'pull_request_review', payload});
-  });
-
-  test('ignore an approved review by a capable reviewer for unknown PRs', async () => {
-    const payload = getFixture('pull_request_review.submitted');
-
-    await probot.receive({name: 'pull_request_review', payload});
-  });
-
-  test('mark a check "skipped"', async () => {
-    await db('checks').insert({
-      head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
-      owner: 'ampproject',
-      repo: 'amphtml',
-      pull_request_id: 19603,
-      installation_id: 123456,
-      check_run_id: 555555,
-      delta: null,
-    });
-
-    const nocks = nock('https://api.github.com')
-      .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
-        expect(body).toMatchObject({
-          conclusion: 'neutral',
-          output: {
-            title: 'check skipped because PR contains no runtime changes',
-          },
-        });
-        return true;
-      })
-      .reply(200);
-
-    await request(probot.server)
-      .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/skip')
-      .expect(200);
-    await waitUntilNockScopeIsDone(nocks);
-  });
-
-  test('ignore marking a check "skipped" for a missing head SHA', async () => {
-    await request(probot.server)
-      .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/skip')
-      .expect(404);
-  });
-
-  test.each([
-    [12.44, 'Δ -0.10KB | no approval necessary'],
-    [12.34, 'Δ +0.00KB | no approval necessary'],
-    [12.24, 'Δ +0.10KB | no approval necessary'],
-  ])(
-    'update a check on bundle-size report (report/base = 12.34KB/%dKB)',
-    async (baseSize, message) => {
-      await db('checks').insert({
-        head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
-        owner: 'ampproject',
-        repo: 'amphtml',
-        pull_request_id: 19603,
-        installation_id: 123456,
-        check_run_id: 555555,
-        delta: null,
-      });
-
-      const baseBundleSizeFixture = getFixture(
-        '5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-      );
-      baseBundleSizeFixture.content = Buffer.from(
-        `{"dist/v0.js":${baseSize}}`
-      ).toString('base64');
-      const nocks = nock('https://api.github.com')
-        .get(
-          '/repos/ampproject/amphtml-build-artifacts/contents/' +
-            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-        )
-        .reply(200, baseBundleSizeFixture)
-        .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
-          expect(body).toMatchObject({
-            conclusion: 'success',
-            output: {
-              title: message,
-            },
-          });
-          return true;
-        })
-        .reply(200);
-
-      await request(probot.server)
-        .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
-        .send({
-          baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
-          bundleSize: 12.34,
-          brotliBundleSize: 12.34,
-        })
-        .set('Content-Type', 'application/json')
-        .set('Accept', 'application/json')
-        .expect(200);
-      await waitUntilNockScopeIsDone(nocks);
-    }
-  );
-
-  test(
-    'update a check on bundle-size report with no capable reviewers ' +
-      '(report/base = 12.34KB/12.00KB)',
-    async () => {
-      await db('checks').insert({
-        head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
-        owner: 'ampproject',
-        repo: 'amphtml',
-        pull_request_id: 19603,
-        installation_id: 123456,
-        check_run_id: 555555,
-        delta: null,
-      });
-
-      const baseBundleSizeFixture = getFixture(
-        '5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-      );
-      baseBundleSizeFixture.content = Buffer.from('{"dist/v0.js":12}').toString(
-        'base64'
-      );
-      const nocks = nock('https://api.github.com')
-        .get(
-          '/repos/ampproject/amphtml-build-artifacts/contents/' +
-            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-        )
-        .reply(200, baseBundleSizeFixture)
-        .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
-          expect(body).toMatchObject({
-            conclusion: 'action_required',
-            output: {
-              title: 'Δ +0.34KB | approval required',
-            },
-          });
-          return true;
-        })
-        .reply(200)
-        .get('/repos/ampproject/amphtml/pulls/19603/requested_reviewers')
-        .reply(200, getFixture('requested_reviewers'))
-        .get('/repos/ampproject/amphtml/pulls/19603/reviews')
-        .reply(200, getFixture('reviews'))
-        .post(
-          '/repos/ampproject/amphtml/pulls/19603/requested_reviewers',
-          body => {
+        const nocks = nock('https://api.github.com')
+          .post('/repos/ampproject/amphtml/check-runs', body => {
             expect(body).toMatchObject({
-              reviewers: [expect.stringMatching(/erwinmombay|estherkim/)],
+              head_sha: '39f787c8132f9ccc956ed465c0af8bc33f641404',
+              name: 'ampproject/bundle-size',
+              output: {
+                title: 'Calculating new bundle size for this PR…',
+              },
             });
             return true;
-          }
-        )
-        .reply(200);
+          })
+          .reply(200, {id: 555555});
 
-      await request(probot.server)
-        .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
-        .send({
-          baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
-          bundleSize: 12.34,
-          brotliBundleSize: 12.34,
-        })
-        .set('Content-Type', 'application/json')
-        .set('Accept', 'application/json')
-        .expect(200);
-      await waitUntilNockScopeIsDone(nocks);
-    }
-  );
+        await probot.receive({name: 'pull_request', payload});
+        await waitUntilNockScopeIsDone(nocks);
 
-  test(
-    'update a check on bundle-size report with a capable reviewer ' +
-      '(report/base = 12.34KB/12.00KB)',
-    async () => {
-      await db('checks').insert({
-        head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
-        owner: 'ampproject',
-        repo: 'amphtml',
-        pull_request_id: 19603,
-        installation_id: 123456,
-        check_run_id: 555555,
-        delta: null,
+        expect(await db('checks').select('*')).toMatchObject([
+          {
+            head_sha: '39f787c8132f9ccc956ed465c0af8bc33f641404',
+            owner: 'ampproject',
+            repo: 'amphtml',
+            pull_request_id: 19621,
+            installation_id: 123456,
+            check_run_id: 555555,
+            delta: null,
+          },
+        ]);
       });
 
-      const baseBundleSizeFixture = getFixture(
-        '5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-      );
-      baseBundleSizeFixture.content = Buffer.from('{"dist/v0.js":12}').toString(
-        'base64'
-      );
-      const nocks = nock('https://api.github.com')
-        .get(
-          '/repos/ampproject/amphtml-build-artifacts/contents/' +
-            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-        )
-        .reply(200, baseBundleSizeFixture)
-        .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
-          expect(body).toMatchObject({
-            conclusion: 'action_required',
-            output: {
-              title: 'Δ +0.34KB | approval required',
-            },
-          });
-          return true;
-        })
-        .reply(200)
-        .get('/repos/ampproject/amphtml/pulls/19603/requested_reviewers')
-        .reply(200, getFixture('requested_reviewers'))
-        .get('/repos/ampproject/amphtml/pulls/19603/reviews')
-        .reply(200, getFixture('reviews'))
-        .post(
-          '/repos/ampproject/amphtml/pulls/19603/requested_reviewers',
-          body => {
+      test('ignore closed (not merged) pull request', async () => {
+        const pullRequestPayload = getFixture('pull_request.opened');
+        pullRequestPayload.action = 'closed';
+
+        await probot.receive({
+          name: 'pull_request',
+          payload: pullRequestPayload,
+        });
+        expect(await db('merges').select('*')).toMatchObject([]);
+
+        const checkRunPayload = getFixture('check_run.created');
+
+        await probot.receive({name: 'check_run', payload: checkRunPayload});
+      });
+
+      test('skip the check on a merged pull request', async () => {
+        const pullRequestPayload = getFixture('pull_request.opened');
+        pullRequestPayload.action = 'closed';
+        pullRequestPayload.pull_request.merged_at = '2019-02-25T20:21:58Z';
+        pullRequestPayload.pull_request.merge_commit_sha =
+          '4ba02c691d1a3014f70a7521c07d775dc6a1e355';
+
+        await probot.receive({
+          name: 'pull_request',
+          payload: pullRequestPayload,
+        });
+        expect(await db('merges').select('*')).toMatchObject([
+          {merge_commit_sha: '4ba02c691d1a3014f70a7521c07d775dc6a1e355'},
+        ]);
+
+        const checkRunPayload = getFixture('check_run.created');
+
+        const nocks = nock('https://api.github.com')
+          .patch('/repos/ampproject/amphtml/check-runs/68609861', body => {
             expect(body).toMatchObject({
-              reviewers: [expect.stringMatching(/erwinmombay|estherkim/)],
+              conclusion: 'neutral',
+              output: {
+                title: 'Check skipped because this is a merged commit',
+              },
             });
             return true;
-          }
-        )
-        .reply(200);
+          })
+          .reply(200);
 
-      await request(probot.server)
-        .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
-        .send({
-          baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
-          bundleSize: 12.34,
-          brotliBundleSize: 12.34,
-        })
-        .set('Content-Type', 'application/json')
-        .set('Accept', 'application/json')
-        .expect(200);
-      await waitUntilNockScopeIsDone(nocks);
-    }
-  );
-
-  test(
-    'update a check on bundle-size report with an existing capable ' +
-      'reviewer (report/base = 12.34KB/12.00KB)',
-    async () => {
-      await db('checks').insert({
-        head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
-        owner: 'ampproject',
-        repo: 'amphtml',
-        pull_request_id: 19603,
-        installation_id: 123456,
-        check_run_id: 555555,
-        delta: null,
+        await probot.receive({name: 'check_run', payload: checkRunPayload});
+        expect(await db('merges').select('*')).toMatchObject([]);
+        await waitUntilNockScopeIsDone(nocks);
       });
 
-      const baseBundleSizeFixture = getFixture(
-        '5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-      );
-      baseBundleSizeFixture.content = Buffer.from('{"dist/v0.js":12}').toString(
-        'base64'
-      );
-      const reviews = getFixture('reviews');
-      reviews[0].user.login = 'aghassemi';
-      const nocks = nock('https://api.github.com')
-        .get(
-          '/repos/ampproject/amphtml-build-artifacts/contents/' +
-            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-        )
-        .reply(200, baseBundleSizeFixture)
-        .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
-          expect(body).toMatchObject({
-            conclusion: 'action_required',
-            output: {
-              title: 'Δ +0.34KB | approval required',
-            },
+      test('fail when a pull request is reported as merged twice', async () => {
+        const pullRequestPayload = getFixture('pull_request.opened');
+        pullRequestPayload.action = 'closed';
+        pullRequestPayload.pull_request.merged_at = '2019-02-25T20:21:58Z';
+        pullRequestPayload.pull_request.merge_commit_sha =
+          '4ba02c691d1a3014f70a7521c07d775dc6a1e355';
+
+        await probot.receive({
+          name: 'pull_request',
+          payload: pullRequestPayload,
+        });
+        try {
+          await probot.receive({
+            name: 'pull_request',
+            payload: pullRequestPayload,
           });
-          return true;
-        })
-        .reply(200)
-        .get('/repos/ampproject/amphtml/pulls/19603/requested_reviewers')
-        .reply(200, getFixture('requested_reviewers'))
-        .get('/repos/ampproject/amphtml/pulls/19603/reviews')
-        .reply(200, reviews);
-
-      await request(probot.server)
-        .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
-        .send({
-          baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
-          bundleSize: 12.34,
-          brotliBundleSize: 12.34,
-        })
-        .set('Content-Type', 'application/json')
-        .set('Accept', 'application/json')
-        .expect(200);
-      await waitUntilNockScopeIsDone(nocks);
-    }
-  );
-
-  test(
-    'update check on bundle-size report (report/_delayed_-base = ' +
-      '12.34KB/12.34KB)',
-    async () => {
-      await db('checks').insert({
-        head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
-        owner: 'ampproject',
-        repo: 'amphtml',
-        pull_request_id: 19603,
-        installation_id: 123456,
-        check_run_id: 555555,
-        delta: null,
+        } catch (e) {
+          expect(e.message).toContain('UNIQUE constraint failed');
+        }
       });
-
-      const baseBundleSizeFixture = getFixture(
-        '5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-      );
-      baseBundleSizeFixture.content = Buffer.from(
-        '{"dist/v0.js":12.34}'
-      ).toString('base64');
-      const nocks = nock('https://api.github.com')
-        .get(
-          '/repos/ampproject/amphtml-build-artifacts/contents/' +
-            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-        )
-        .times(2)
-        .reply(404)
-        .get(
-          '/repos/ampproject/amphtml-build-artifacts/contents/' +
-            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-        )
-        .reply(200, baseBundleSizeFixture)
-        .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
-          expect(body).toMatchObject({
-            conclusion: 'success',
-            output: {
-              title: 'Δ +0.00KB | no approval necessary',
-            },
-          });
-          return true;
-        })
-        .reply(200);
-
-      await request(probot.server)
-        .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
-        .send({
-          baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
-          bundleSize: 12.34,
-          brotliBundleSize: 12.34,
-        })
-        .set('Content-Type', 'application/json')
-        .set('Accept', 'application/json')
-        .expect(202);
-      await waitUntilNockScopeIsDone(nocks);
-    }
-  );
-
-  test(
-    'update check on bundle-size report (report/_delayed_-base = ' +
-      '12.34KB/12.23KB)',
-    async () => {
-      await db('checks').insert({
-        head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
-        owner: 'ampproject',
-        repo: 'amphtml',
-        pull_request_id: 19603,
-        installation_id: 123456,
-        check_run_id: 555555,
-        delta: null,
-      });
-
-      const baseBundleSizeFixture = getFixture(
-        '5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-      );
-      baseBundleSizeFixture.content = Buffer.from(
-        '{"dist/v0.js":12.23}'
-      ).toString('base64');
-      const nocks = nock('https://api.github.com')
-        .get(
-          '/repos/ampproject/amphtml-build-artifacts/contents/' +
-            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-        )
-        .times(2)
-        .reply(404)
-        .get(
-          '/repos/ampproject/amphtml-build-artifacts/contents/' +
-            'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-        )
-        .reply(200, baseBundleSizeFixture)
-        .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
-          expect(body).toMatchObject({
-            conclusion: 'action_required',
-            output: {
-              title: 'Δ +0.11KB | approval required',
-            },
-          });
-          return true;
-        })
-        .reply(200)
-        .get('/repos/ampproject/amphtml/pulls/19603/requested_reviewers')
-        .reply(200, getFixture('requested_reviewers'))
-        .get('/repos/ampproject/amphtml/pulls/19603/reviews')
-        .reply(200, getFixture('reviews'))
-        .post(
-          '/repos/ampproject/amphtml/pulls/19603/requested_reviewers',
-          body => {
-            expect(body).toMatchObject({
-              reviewers: [expect.stringMatching(/erwinmombay|estherkim/)],
-            });
-            return true;
-          }
-        )
-        .reply(200);
-
-      await request(probot.server)
-        .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
-        .send({
-          baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
-          bundleSize: 12.34,
-          brotliBundleSize: 12.34,
-        })
-        .set('Content-Type', 'application/json')
-        .set('Accept', 'application/json')
-        .expect(202);
-      await waitUntilNockScopeIsDone(nocks);
-    }
-  );
-
-  test('update check on bundle-size report on missing base size', async () => {
-    await db('checks').insert({
-      head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
-      owner: 'ampproject',
-      repo: 'amphtml',
-      pull_request_id: 19603,
-      installation_id: 123456,
-      check_run_id: 555555,
-      delta: null,
     });
 
-    const nocks = nock('https://api.github.com')
-      .get(
-        '/repos/ampproject/amphtml-build-artifacts/contents/' +
-          'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-      )
-      .times(60)
-      .reply(404)
-      .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
-        expect(body).toMatchObject({
-          conclusion: 'action_required',
-          output: {
-            title: 'Failed to retrieve the bundle size of branch point 5f27002',
-          },
+    describe('pull_request_review', () => {
+      test('mark a check as successful when a capable user approves the PR', async () => {
+        const payload = getFixture('pull_request_review.submitted');
+
+        await db('checks').insert({
+          head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
+          owner: 'ampproject',
+          repo: 'amphtml',
+          pull_request_id: 19603,
+          installation_id: 123456,
+          check_run_id: 555555,
+          delta: 0.2,
         });
-        return true;
-      })
-      .reply(200)
-      .get('/repos/ampproject/amphtml/pulls/19603/requested_reviewers')
-      .reply(200, getFixture('requested_reviewers'))
-      .get('/repos/ampproject/amphtml/pulls/19603/reviews')
-      .reply(200, getFixture('reviews'))
-      .post(
-        '/repos/ampproject/amphtml/pulls/19603/requested_reviewers',
-        body => {
-          expect(body).toMatchObject({
-            reviewers: [expect.stringMatching(/erwinmombay|estherkim/)],
+
+        const nocks = nock('https://api.github.com')
+          .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
+            expect(body).toMatchObject({
+              conclusion: 'success',
+              output: {
+                title: 'Δ +0.20KB | approved by @aghassemi',
+              },
+            });
+            return true;
+          })
+          .reply(200);
+
+        await probot.receive({name: 'pull_request_review', payload});
+        await waitUntilNockScopeIsDone(nocks);
+      });
+
+      test('mark a check as successful when a capable user approves the PR with missing size delta', async () => {
+        const payload = getFixture('pull_request_review.submitted');
+
+        await db('checks').insert({
+          head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
+          owner: 'ampproject',
+          repo: 'amphtml',
+          pull_request_id: 19603,
+          installation_id: 123456,
+          check_run_id: 555555,
+          delta: null,
+        });
+
+        const nocks = nock('https://api.github.com')
+          .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
+            expect(body).toMatchObject({
+              conclusion: 'success',
+              output: {
+                title: 'Δ ±?.??KB | approved by @aghassemi',
+              },
+            });
+            return true;
+          })
+          .reply(200);
+
+        await probot.receive({name: 'pull_request_review', payload});
+        await waitUntilNockScopeIsDone(nocks);
+      });
+
+      test('ignore an approved review by a non-capable reviewer', async () => {
+        const payload = getFixture('pull_request_review.submitted');
+
+        await probot.receive({name: 'pull_request_review', payload});
+      });
+
+      test('ignore a "changes requested" review', async () => {
+        const payload = getFixture('pull_request_review.submitted');
+        payload.state = 'changes_requested';
+
+        await probot.receive({name: 'pull_request_review', payload});
+      });
+
+      test('ignore an approved review by a capable reviewer for small delta', async () => {
+        const payload = getFixture('pull_request_review.submitted');
+
+        await db('checks').insert({
+          head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
+          owner: 'ampproject',
+          repo: 'amphtml',
+          pull_request_id: 19603,
+          installation_id: 123456,
+          check_run_id: 555555,
+          delta: 0.05,
+        });
+
+        await probot.receive({name: 'pull_request_review', payload});
+      });
+
+      test('ignore an approved review by a capable reviewer for unknown PRs', async () => {
+        const payload = getFixture('pull_request_review.submitted');
+
+        await probot.receive({name: 'pull_request_review', payload});
+      });
+    });
+  });
+
+  describe('/v0 API', () => {
+    describe('/commit/:headSha/skip', () => {
+      test('mark a check "skipped"', async () => {
+        await db('checks').insert({
+          head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
+          owner: 'ampproject',
+          repo: 'amphtml',
+          pull_request_id: 19603,
+          installation_id: 123456,
+          check_run_id: 555555,
+          delta: null,
+        });
+
+        const nocks = nock('https://api.github.com')
+          .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
+            expect(body).toMatchObject({
+              conclusion: 'neutral',
+              output: {
+                title: 'check skipped because PR contains no runtime changes',
+              },
+            });
+            return true;
+          })
+          .reply(200);
+
+        await request(probot.server)
+          .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/skip')
+          .expect(200);
+        await waitUntilNockScopeIsDone(nocks);
+      });
+
+      test('ignore marking a check "skipped" for a missing head SHA', async () => {
+        await request(probot.server)
+          .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/skip')
+          .expect(404);
+      });
+    });
+
+    describe('/commit/:headSha/report', () => {
+      test.each([
+        [12.44, 'Δ -0.10KB | no approval necessary'],
+        [12.34, 'Δ +0.00KB | no approval necessary'],
+        [12.24, 'Δ +0.10KB | no approval necessary'],
+      ])(
+        'update a check on bundle-size report (report/base = 12.34KB/%dKB)',
+        async (baseSize, message) => {
+          await db('checks').insert({
+            head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
+            owner: 'ampproject',
+            repo: 'amphtml',
+            pull_request_id: 19603,
+            installation_id: 123456,
+            check_run_id: 555555,
+            delta: null,
           });
-          return true;
+
+          const baseBundleSizeFixture = getFixture(
+            '5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+          );
+          baseBundleSizeFixture.content = Buffer.from(
+            `{"dist/v0.js":${baseSize}}`
+          ).toString('base64');
+          const nocks = nock('https://api.github.com')
+            .get(
+              '/repos/ampproject/amphtml-build-artifacts/contents/' +
+                'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+            )
+            .reply(200, baseBundleSizeFixture)
+            .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
+              expect(body).toMatchObject({
+                conclusion: 'success',
+                output: {
+                  title: message,
+                },
+              });
+              return true;
+            })
+            .reply(200);
+
+          await request(probot.server)
+            .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
+            .send({
+              baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
+              bundleSize: 12.34,
+              brotliBundleSize: 12.34,
+            })
+            .set('Content-Type', 'application/json')
+            .set('Accept', 'application/json')
+            .expect(200);
+          await waitUntilNockScopeIsDone(nocks);
         }
-      )
-      .reply(200);
-
-    await request(probot.server)
-      .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
-      .send({
-        baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
-        bundleSize: 12.34,
-        brotliBundleSize: 12.34,
-      })
-      .set('Content-Type', 'application/json')
-      .set('Accept', 'application/json')
-      .expect(202);
-    await waitUntilNockScopeIsDone(nocks);
-  });
-
-  test('ignore bundle-size report for a missing head SHA', async () => {
-    await request(probot.server)
-      .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
-      .send({
-        baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
-        bundleSize: 12.34,
-        brotliBundleSize: 12.34,
-      })
-      .set('Content-Type', 'application/json')
-      .set('Accept', 'application/json')
-      .expect(404);
-  });
-
-  test.each([
-    {},
-    {aFieldThatIsNotBundleSize: 12.34},
-    {baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33', bundleSize: '12.34'},
-    {baseSha: '5f27002', bundleSize: 12.34},
-    {baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33'},
-    {bundleSize: 12.34},
-  ])('ignore bundle-size report with incorrect input: %p', async data => {
-    await request(probot.server)
-      .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
-      .send(data)
-      .set('Content-Type', 'application/json')
-      .set('Accept', 'application/json')
-      .expect(400);
-  });
-
-  test('store new bundle-size', async () => {
-    const nocks = nock('https://api.github.com')
-      .get(
-        '/repos/ampproject/amphtml-build-artifacts/contents/' +
-          'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'
-      )
-      .reply(404)
-      .put(
-        '/repos/ampproject/amphtml-build-artifacts/contents/' +
-          'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br',
-        {
-          message:
-            'bundle-size: 5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br ' +
-            '(12.34KB)',
-          content: Buffer.from('12.34KB').toString('base64'),
-        }
-      )
-      .reply(201)
-      .get(
-        '/repos/ampproject/amphtml-build-artifacts/contents/' +
-          'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-      )
-      .reply(404)
-      .put(
-        '/repos/ampproject/amphtml-build-artifacts/contents/' +
-          'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json',
-        {
-          message:
-            'bundle-size: 5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json ' +
-            '({"dist/v0.js":12.34})',
-          content: Buffer.from('{"dist/v0.js":12.34}').toString('base64'),
-        }
-      )
-      .reply(201);
-
-    await request(probot.server)
-      .post('/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store')
-      .send({
-        token: '0123456789abcdefghijklmnopqrstuvwxyz',
-        brotliBundleSize: 12.34,
-      })
-      .set('Content-Type', 'application/json')
-      .set('Accept', 'application/json')
-      .expect(200);
-    await waitUntilNockScopeIsDone(nocks);
-  });
-
-  test('ignore already existing bundle-size when called to store', async () => {
-    const nocks = nock('https://api.github.com')
-      .get(
-        '/repos/ampproject/amphtml-build-artifacts/contents/' +
-          'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'
-      )
-      .reply(200, getFixture('5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'))
-      .get(
-        '/repos/ampproject/amphtml-build-artifacts/contents/' +
-          'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
-      )
-      .reply(200, getFixture('5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'));
-
-    await request(probot.server)
-      .post('/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store')
-      .send({
-        token: '0123456789abcdefghijklmnopqrstuvwxyz',
-        brotliBundleSize: 12.34,
-      })
-      .set('Content-Type', 'application/json')
-      .set('Accept', 'application/json')
-      .expect(200);
-    await waitUntilNockScopeIsDone(nocks);
-  });
-
-  test('show error when failed to store bundle-size', async () => {
-    const nocks = nock('https://api.github.com')
-      .get(
-        '/repos/ampproject/amphtml-build-artifacts/contents/' +
-          'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'
-      )
-      .reply(404)
-      .put(
-        '/repos/ampproject/amphtml-build-artifacts/contents/' +
-          'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br',
-        {
-          message:
-            'bundle-size: 5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br ' +
-            '(12.34KB)',
-          content: Buffer.from('12.34KB').toString('base64'),
-        }
-      )
-      .reply(418, 'I am a tea pot');
-
-    await request(probot.server)
-      .post('/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store')
-      .send({
-        token: '0123456789abcdefghijklmnopqrstuvwxyz',
-        brotliBundleSize: 12.34,
-      })
-      .set('Content-Type', 'application/json')
-      .set('Accept', 'application/json')
-      .expect(500, /I am a tea pot/);
-    await waitUntilNockScopeIsDone(nocks);
-  });
-
-  test('fail on missing values when called to store bundle-size', async () => {
-    await request(probot.server)
-      .post('/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store')
-      .send({
-        token: '0123456789abcdefghijklmnopqrstuvwxyz',
-        // Deliberately not add a `brotliBundleSize` field,
-      })
-      .set('Content-Type', 'application/json')
-      .set('Accept', 'application/json')
-      .expect(
-        400,
-        'POST request to /store must have numeric field "brotliBundleSize"'
       );
-  });
 
-  test('rejects calls to store without the Travis token', async () => {
-    await request(probot.server)
-      .post('/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store')
-      .send({
-        token: 'wrong token',
-        brotliBundleSize: 12.34,
-      })
-      .set('Content-Type', 'application/json')
-      .set('Accept', 'application/json')
-      .expect(403, 'You are not Travis!');
-  });
+      test(
+        'update a check on bundle-size report with no capable reviewers ' +
+          '(report/base = 12.34KB/12.00KB)',
+        async () => {
+          await db('checks').insert({
+            head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
+            owner: 'ampproject',
+            repo: 'amphtml',
+            pull_request_id: 19603,
+            installation_id: 123456,
+            check_run_id: 555555,
+            delta: null,
+          });
 
-  test('ignore closed (not merged) pull request', async () => {
-    const pullRequestPayload = getFixture('pull_request.opened');
-    pullRequestPayload.action = 'closed';
+          const baseBundleSizeFixture = getFixture(
+            '5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+          );
+          baseBundleSizeFixture.content = Buffer.from(
+            '{"dist/v0.js":12}'
+          ).toString('base64');
+          const nocks = nock('https://api.github.com')
+            .get(
+              '/repos/ampproject/amphtml-build-artifacts/contents/' +
+                'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+            )
+            .reply(200, baseBundleSizeFixture)
+            .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
+              expect(body).toMatchObject({
+                conclusion: 'action_required',
+                output: {
+                  title: 'Δ +0.34KB | approval required',
+                },
+              });
+              return true;
+            })
+            .reply(200)
+            .get('/repos/ampproject/amphtml/pulls/19603/requested_reviewers')
+            .reply(200, getFixture('requested_reviewers'))
+            .get('/repos/ampproject/amphtml/pulls/19603/reviews')
+            .reply(200, getFixture('reviews'))
+            .post(
+              '/repos/ampproject/amphtml/pulls/19603/requested_reviewers',
+              body => {
+                expect(body).toMatchObject({
+                  reviewers: [expect.stringMatching(/erwinmombay|estherkim/)],
+                });
+                return true;
+              }
+            )
+            .reply(200);
 
-    await probot.receive({name: 'pull_request', payload: pullRequestPayload});
-    expect(await db('merges').select('*')).toMatchObject([]);
+          await request(probot.server)
+            .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
+            .send({
+              baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
+              bundleSize: 12.34,
+              brotliBundleSize: 12.34,
+            })
+            .set('Content-Type', 'application/json')
+            .set('Accept', 'application/json')
+            .expect(200);
+          await waitUntilNockScopeIsDone(nocks);
+        }
+      );
 
-    const checkRunPayload = getFixture('check_run.created');
+      test(
+        'update a check on bundle-size report with a capable reviewer ' +
+          '(report/base = 12.34KB/12.00KB)',
+        async () => {
+          await db('checks').insert({
+            head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
+            owner: 'ampproject',
+            repo: 'amphtml',
+            pull_request_id: 19603,
+            installation_id: 123456,
+            check_run_id: 555555,
+            delta: null,
+          });
 
-    await probot.receive({name: 'check_run', payload: checkRunPayload});
-  });
+          const baseBundleSizeFixture = getFixture(
+            '5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+          );
+          baseBundleSizeFixture.content = Buffer.from(
+            '{"dist/v0.js":12}'
+          ).toString('base64');
+          const nocks = nock('https://api.github.com')
+            .get(
+              '/repos/ampproject/amphtml-build-artifacts/contents/' +
+                'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+            )
+            .reply(200, baseBundleSizeFixture)
+            .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
+              expect(body).toMatchObject({
+                conclusion: 'action_required',
+                output: {
+                  title: 'Δ +0.34KB | approval required',
+                },
+              });
+              return true;
+            })
+            .reply(200)
+            .get('/repos/ampproject/amphtml/pulls/19603/requested_reviewers')
+            .reply(200, getFixture('requested_reviewers'))
+            .get('/repos/ampproject/amphtml/pulls/19603/reviews')
+            .reply(200, getFixture('reviews'))
+            .post(
+              '/repos/ampproject/amphtml/pulls/19603/requested_reviewers',
+              body => {
+                expect(body).toMatchObject({
+                  reviewers: [expect.stringMatching(/erwinmombay|estherkim/)],
+                });
+                return true;
+              }
+            )
+            .reply(200);
 
-  test('skip the check on a merged pull request', async () => {
-    const pullRequestPayload = getFixture('pull_request.opened');
-    pullRequestPayload.action = 'closed';
-    pullRequestPayload.pull_request.merged_at = '2019-02-25T20:21:58Z';
-    pullRequestPayload.pull_request.merge_commit_sha =
-      '4ba02c691d1a3014f70a7521c07d775dc6a1e355';
+          await request(probot.server)
+            .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
+            .send({
+              baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
+              bundleSize: 12.34,
+              brotliBundleSize: 12.34,
+            })
+            .set('Content-Type', 'application/json')
+            .set('Accept', 'application/json')
+            .expect(200);
+          await waitUntilNockScopeIsDone(nocks);
+        }
+      );
 
-    await probot.receive({name: 'pull_request', payload: pullRequestPayload});
-    expect(await db('merges').select('*')).toMatchObject([
-      {merge_commit_sha: '4ba02c691d1a3014f70a7521c07d775dc6a1e355'},
-    ]);
+      test(
+        'update a check on bundle-size report with an existing capable ' +
+          'reviewer (report/base = 12.34KB/12.00KB)',
+        async () => {
+          await db('checks').insert({
+            head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
+            owner: 'ampproject',
+            repo: 'amphtml',
+            pull_request_id: 19603,
+            installation_id: 123456,
+            check_run_id: 555555,
+            delta: null,
+          });
 
-    const checkRunPayload = getFixture('check_run.created');
+          const baseBundleSizeFixture = getFixture(
+            '5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+          );
+          baseBundleSizeFixture.content = Buffer.from(
+            '{"dist/v0.js":12}'
+          ).toString('base64');
+          const reviews = getFixture('reviews');
+          reviews[0].user.login = 'aghassemi';
+          const nocks = nock('https://api.github.com')
+            .get(
+              '/repos/ampproject/amphtml-build-artifacts/contents/' +
+                'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+            )
+            .reply(200, baseBundleSizeFixture)
+            .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
+              expect(body).toMatchObject({
+                conclusion: 'action_required',
+                output: {
+                  title: 'Δ +0.34KB | approval required',
+                },
+              });
+              return true;
+            })
+            .reply(200)
+            .get('/repos/ampproject/amphtml/pulls/19603/requested_reviewers')
+            .reply(200, getFixture('requested_reviewers'))
+            .get('/repos/ampproject/amphtml/pulls/19603/reviews')
+            .reply(200, reviews);
 
-    const nocks = nock('https://api.github.com')
-      .patch('/repos/ampproject/amphtml/check-runs/68609861', body => {
-        expect(body).toMatchObject({
-          conclusion: 'neutral',
-          output: {
-            title: 'Check skipped because this is a merged commit',
-          },
+          await request(probot.server)
+            .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
+            .send({
+              baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
+              bundleSize: 12.34,
+              brotliBundleSize: 12.34,
+            })
+            .set('Content-Type', 'application/json')
+            .set('Accept', 'application/json')
+            .expect(200);
+          await waitUntilNockScopeIsDone(nocks);
+        }
+      );
+
+      test(
+        'update check on bundle-size report (report/_delayed_-base = ' +
+          '12.34KB/12.34KB)',
+        async () => {
+          await db('checks').insert({
+            head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
+            owner: 'ampproject',
+            repo: 'amphtml',
+            pull_request_id: 19603,
+            installation_id: 123456,
+            check_run_id: 555555,
+            delta: null,
+          });
+
+          const baseBundleSizeFixture = getFixture(
+            '5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+          );
+          baseBundleSizeFixture.content = Buffer.from(
+            '{"dist/v0.js":12.34}'
+          ).toString('base64');
+          const nocks = nock('https://api.github.com')
+            .get(
+              '/repos/ampproject/amphtml-build-artifacts/contents/' +
+                'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+            )
+            .times(2)
+            .reply(404)
+            .get(
+              '/repos/ampproject/amphtml-build-artifacts/contents/' +
+                'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+            )
+            .reply(200, baseBundleSizeFixture)
+            .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
+              expect(body).toMatchObject({
+                conclusion: 'success',
+                output: {
+                  title: 'Δ +0.00KB | no approval necessary',
+                },
+              });
+              return true;
+            })
+            .reply(200);
+
+          await request(probot.server)
+            .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
+            .send({
+              baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
+              bundleSize: 12.34,
+              brotliBundleSize: 12.34,
+            })
+            .set('Content-Type', 'application/json')
+            .set('Accept', 'application/json')
+            .expect(202);
+          await waitUntilNockScopeIsDone(nocks);
+        }
+      );
+
+      test(
+        'update check on bundle-size report (report/_delayed_-base = ' +
+          '12.34KB/12.23KB)',
+        async () => {
+          await db('checks').insert({
+            head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
+            owner: 'ampproject',
+            repo: 'amphtml',
+            pull_request_id: 19603,
+            installation_id: 123456,
+            check_run_id: 555555,
+            delta: null,
+          });
+
+          const baseBundleSizeFixture = getFixture(
+            '5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+          );
+          baseBundleSizeFixture.content = Buffer.from(
+            '{"dist/v0.js":12.23}'
+          ).toString('base64');
+          const nocks = nock('https://api.github.com')
+            .get(
+              '/repos/ampproject/amphtml-build-artifacts/contents/' +
+                'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+            )
+            .times(2)
+            .reply(404)
+            .get(
+              '/repos/ampproject/amphtml-build-artifacts/contents/' +
+                'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+            )
+            .reply(200, baseBundleSizeFixture)
+            .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
+              expect(body).toMatchObject({
+                conclusion: 'action_required',
+                output: {
+                  title: 'Δ +0.11KB | approval required',
+                },
+              });
+              return true;
+            })
+            .reply(200)
+            .get('/repos/ampproject/amphtml/pulls/19603/requested_reviewers')
+            .reply(200, getFixture('requested_reviewers'))
+            .get('/repos/ampproject/amphtml/pulls/19603/reviews')
+            .reply(200, getFixture('reviews'))
+            .post(
+              '/repos/ampproject/amphtml/pulls/19603/requested_reviewers',
+              body => {
+                expect(body).toMatchObject({
+                  reviewers: [expect.stringMatching(/erwinmombay|estherkim/)],
+                });
+                return true;
+              }
+            )
+            .reply(200);
+
+          await request(probot.server)
+            .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
+            .send({
+              baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
+              bundleSize: 12.34,
+              brotliBundleSize: 12.34,
+            })
+            .set('Content-Type', 'application/json')
+            .set('Accept', 'application/json')
+            .expect(202);
+          await waitUntilNockScopeIsDone(nocks);
+        }
+      );
+
+      test('update check on bundle-size report on missing base size', async () => {
+        await db('checks').insert({
+          head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
+          owner: 'ampproject',
+          repo: 'amphtml',
+          pull_request_id: 19603,
+          installation_id: 123456,
+          check_run_id: 555555,
+          delta: null,
         });
-        return true;
-      })
-      .reply(200);
 
-    await probot.receive({name: 'check_run', payload: checkRunPayload});
-    expect(await db('merges').select('*')).toMatchObject([]);
-    await waitUntilNockScopeIsDone(nocks);
-  });
+        const nocks = nock('https://api.github.com')
+          .get(
+            '/repos/ampproject/amphtml-build-artifacts/contents/' +
+              'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+          )
+          .times(60)
+          .reply(404)
+          .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
+            expect(body).toMatchObject({
+              conclusion: 'action_required',
+              output: {
+                title:
+                  'Failed to retrieve the bundle size of branch point 5f27002',
+              },
+            });
+            return true;
+          })
+          .reply(200)
+          .get('/repos/ampproject/amphtml/pulls/19603/requested_reviewers')
+          .reply(200, getFixture('requested_reviewers'))
+          .get('/repos/ampproject/amphtml/pulls/19603/reviews')
+          .reply(200, getFixture('reviews'))
+          .post(
+            '/repos/ampproject/amphtml/pulls/19603/requested_reviewers',
+            body => {
+              expect(body).toMatchObject({
+                reviewers: [expect.stringMatching(/erwinmombay|estherkim/)],
+              });
+              return true;
+            }
+          )
+          .reply(200);
 
-  test('fail when a pull request is reported as merged twice', async () => {
-    const pullRequestPayload = getFixture('pull_request.opened');
-    pullRequestPayload.action = 'closed';
-    pullRequestPayload.pull_request.merged_at = '2019-02-25T20:21:58Z';
-    pullRequestPayload.pull_request.merge_commit_sha =
-      '4ba02c691d1a3014f70a7521c07d775dc6a1e355';
+        await request(probot.server)
+          .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
+          .send({
+            baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
+            bundleSize: 12.34,
+            brotliBundleSize: 12.34,
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(202);
+        await waitUntilNockScopeIsDone(nocks);
+      });
 
-    await probot.receive({name: 'pull_request', payload: pullRequestPayload});
-    try {
-      await probot.receive({name: 'pull_request', payload: pullRequestPayload});
-    } catch (e) {
-      expect(e.message).toContain('UNIQUE constraint failed');
-    }
-  });
+      test('ignore bundle-size report for a missing head SHA', async () => {
+        await request(probot.server)
+          .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
+          .send({
+            baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
+            bundleSize: 12.34,
+            brotliBundleSize: 12.34,
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(404);
+      });
 
-  test('reject non-Travis IP addresses', async () => {
-    process.env['TRAVIS_IP_ADDRESSES'] = '999.999.999.999,123.456.789.012';
-    await request(probot.server)
-      .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/skip')
-      .expect(403, 'You are not Travis!');
+      test.each([
+        {},
+        {aFieldThatIsNotBundleSize: 12.34},
+        {
+          baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
+          bundleSize: '12.34',
+        },
+        {baseSha: '5f27002', bundleSize: 12.34},
+        {baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33'},
+        {bundleSize: 12.34},
+      ])('ignore bundle-size report with incorrect input: %p', async data => {
+        await request(probot.server)
+          .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
+          .send(data)
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(400);
+      });
+    });
+
+    // TODO(danielrozenberg): remove all legacy code tests once the amphtml repo
+    // is in sync with the new full-json endpoint
+    describe('/commit/:headSha/store (legacy code)', () => {
+      test('store new bundle-size', async () => {
+        const nocks = nock('https://api.github.com')
+          .get(
+            '/repos/ampproject/amphtml-build-artifacts/contents/' +
+              'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'
+          )
+          .reply(404)
+          .put(
+            '/repos/ampproject/amphtml-build-artifacts/contents/' +
+              'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br',
+            {
+              message:
+                'bundle-size: 5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br',
+              content: Buffer.from('12.34KB').toString('base64'),
+            }
+          )
+          .reply(201)
+          .get(
+            '/repos/ampproject/amphtml-build-artifacts/contents/' +
+              'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+          )
+          .reply(404)
+          .put(
+            '/repos/ampproject/amphtml-build-artifacts/contents/' +
+              'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json',
+            {
+              message:
+                'bundle-size: 5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json',
+              content: Buffer.from('{"dist/v0.js":12.34}').toString('base64'),
+            }
+          )
+          .reply(201);
+
+        await request(probot.server)
+          .post('/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store')
+          .send({
+            token: '0123456789abcdefghijklmnopqrstuvwxyz',
+            brotliBundleSize: 12.34,
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(200);
+        await waitUntilNockScopeIsDone(nocks);
+      });
+
+      test('ignore already existing bundle-size when called to store', async () => {
+        const nocks = nock('https://api.github.com')
+          .get(
+            '/repos/ampproject/amphtml-build-artifacts/contents/' +
+              'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'
+          )
+          .reply(200, getFixture('5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'))
+          .get(
+            '/repos/ampproject/amphtml-build-artifacts/contents/' +
+              'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+          )
+          .reply(
+            200,
+            getFixture('5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json')
+          );
+
+        await request(probot.server)
+          .post('/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store')
+          .send({
+            token: '0123456789abcdefghijklmnopqrstuvwxyz',
+            brotliBundleSize: 12.34,
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(200);
+        await waitUntilNockScopeIsDone(nocks);
+      });
+
+      test('show error when failed to store bundle-size', async () => {
+        const nocks = nock('https://api.github.com')
+          .get(
+            '/repos/ampproject/amphtml-build-artifacts/contents/' +
+              'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br'
+          )
+          .reply(404)
+          .put(
+            '/repos/ampproject/amphtml-build-artifacts/contents/' +
+              'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br',
+            {
+              message:
+                'bundle-size: 5f27002526a808c5c1ad5d0f1ab1cec471af0a33.br',
+              content: Buffer.from('12.34KB').toString('base64'),
+            }
+          )
+          .reply(418, 'I am a tea pot');
+
+        await request(probot.server)
+          .post('/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store')
+          .send({
+            token: '0123456789abcdefghijklmnopqrstuvwxyz',
+            brotliBundleSize: 12.34,
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(500, /I am a tea pot/);
+        await waitUntilNockScopeIsDone(nocks);
+      });
+
+      test('fail on missing values when called to store bundle-size', async () => {
+        await request(probot.server)
+          .post('/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store')
+          .send({
+            token: '0123456789abcdefghijklmnopqrstuvwxyz',
+            // Deliberately not add a `brotliBundleSize` field,
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(
+            400,
+            'POST request to /store must have numeric field "brotliBundleSize"'
+          );
+      });
+
+      test('rejects calls to store without the Travis token', async () => {
+        await request(probot.server)
+          .post('/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store')
+          .send({
+            token: 'wrong token',
+            brotliBundleSize: 12.34,
+          })
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(403, 'You are not Travis!');
+      });
+    });
+
+    describe('/commit/:headSha/store.json', () => {
+      let jsonPayload;
+
+      beforeEach(() => {
+        jsonPayload = {
+          token: '0123456789abcdefghijklmnopqrstuvwxyz',
+          bundleSizes: {
+            'dist/v0.js': 12.34,
+            'dist/amp4ads-v0.js': 11.22,
+          },
+        };
+      });
+
+      test('store new bundle-size', async () => {
+        const nocks = nock('https://api.github.com')
+          .get(
+            '/repos/ampproject/amphtml-build-artifacts/contents/' +
+              'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+          )
+          .reply(404)
+          .put(
+            '/repos/ampproject/amphtml-build-artifacts/contents/' +
+              'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json',
+            {
+              message:
+                'bundle-size: 5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json',
+              content: Buffer.from(
+                JSON.stringify(jsonPayload.bundleSizes)
+              ).toString('base64'),
+            }
+          )
+          .reply(201);
+
+        await request(probot.server)
+          .post(
+            '/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store.json'
+          )
+          .send(jsonPayload)
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(200);
+        await waitUntilNockScopeIsDone(nocks);
+      });
+
+      test('ignore already existing bundle-size when called to store', async () => {
+        const nocks = nock('https://api.github.com')
+          .get(
+            '/repos/ampproject/amphtml-build-artifacts/contents/' +
+              'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+          )
+          .reply(
+            200,
+            getFixture('5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json')
+          );
+
+        await request(probot.server)
+          .post(
+            '/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store.json'
+          )
+          .send(jsonPayload)
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(200);
+        await waitUntilNockScopeIsDone(nocks);
+      });
+
+      test('show error when failed to store bundle-size', async () => {
+        const nocks = nock('https://api.github.com')
+          .get(
+            '/repos/ampproject/amphtml-build-artifacts/contents/' +
+              'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json'
+          )
+          .reply(404)
+          .put(
+            '/repos/ampproject/amphtml-build-artifacts/contents/' +
+              'bundle-size/5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json',
+            {
+              message:
+                'bundle-size: 5f27002526a808c5c1ad5d0f1ab1cec471af0a33.json',
+              content: Buffer.from(
+                JSON.stringify(jsonPayload.bundleSizes)
+              ).toString('base64'),
+            }
+          )
+          .reply(418, 'I am a tea pot');
+
+        await request(probot.server)
+          .post(
+            '/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store.json'
+          )
+          .send(jsonPayload)
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(500, /I am a tea pot/);
+        await waitUntilNockScopeIsDone(nocks);
+      });
+
+      test('fail on non-numeric values when called to store bundle-size', async () => {
+        jsonPayload.bundleSizes['dist/shadow-v0.js'] = '23.45KB';
+
+        await request(probot.server)
+          .post(
+            '/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store.json'
+          )
+          .send(jsonPayload)
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(
+            400,
+            'POST request to /store must have a key/value object (string->numeric) field "bundleSizes"'
+          );
+      });
+
+      test('fail on missing values when called to store bundle-size', async () => {
+        delete jsonPayload.bundleSizes;
+
+        await request(probot.server)
+          .post(
+            '/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store.json'
+          )
+          .send(jsonPayload)
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(
+            400,
+            'POST request to /store must have a key/value object (string->numeric) field "bundleSizes"'
+          );
+      });
+
+      test('rejects calls to store without the Travis token', async () => {
+        jsonPayload.token = 'wrong token';
+
+        await request(probot.server)
+          .post(
+            '/v0/commit/5f27002526a808c5c1ad5d0f1ab1cec471af0a33/store.json'
+          )
+          .send(jsonPayload)
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .expect(403, 'You are not Travis!');
+      });
+    });
+
+    test('reject non-Travis IP addresses', async () => {
+      process.env['TRAVIS_IP_ADDRESSES'] = '999.999.999.999,123.456.789.012';
+      await request(probot.server)
+        .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/skip')
+        .expect(403, 'You are not Travis!');
+    });
   });
 });

--- a/bundle-size/test/app.test.js
+++ b/bundle-size/test/app.test.js
@@ -1092,7 +1092,7 @@ describe('bundle-size', () => {
           .set('Accept', 'application/json')
           .expect(
             400,
-            'POST request to /store must have a key/value object (string->numeric) field "bundleSizes"'
+            'POST request to /store must have a key/value object Map<string, number> field "bundleSizes"'
           );
       });
 
@@ -1108,7 +1108,7 @@ describe('bundle-size', () => {
           .set('Accept', 'application/json')
           .expect(
             400,
-            'POST request to /store must have a key/value object (string->numeric) field "bundleSizes"'
+            'POST request to /store must have a key/value object Map<string, number> field "bundleSizes"'
           );
       });
 


### PR DESCRIPTION
More changes included in this PR:
* Removes the text portion of the commit message now that the complete JSON is going to be included
* Reorganizes the tests into sub-sections using `describe`s. It might be easier to review these changes using a better diff program, such as Meld :) otherwise, trust that most of the test file changes is just shuffles (modulo required changes to the tests to cater to the aforementioned text removal), except for the addition of the `/commit/:headSha/store.json` test sub-section