### PR TITLE
[owners] Adds support for required reviewers

### DIFF
--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -121,6 +121,8 @@ class OwnersCheck {
           delete fileTreeMap[filename];
         }
       });
+
+      // TODO(#516): Include missing required reviewers.
       const reviewSuggestions = ReviewerSelection.pickReviews(fileTreeMap);
       const reviewers = reviewSuggestions.map(([reviewer, files]) => reviewer);
       const suggestionsText = this.buildReviewSuggestionsText(

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -177,9 +177,10 @@ class OwnersCheck {
    * @return {Owner[]} required owners that have not approved.
    */
   _missingRequiredOwners(filename, subtree) {
-    return subtree.getModifiedFileOwners(filename, OWNER_MODIFIER.REQUIRE)
-      .filter(owner =>
-        !owner.allUsernames.some(username => this.reviewers[username])
+    return subtree
+      .getModifiedFileOwners(filename, OWNER_MODIFIER.REQUIRE)
+      .filter(
+        owner => !owner.allUsernames.some(username => this.reviewers[username])
       );
   }
 
@@ -207,8 +208,10 @@ class OwnersCheck {
    * @return {boolean} if the file is approved.
    */
   _hasFullOwnersCoverage(filename, subtree) {
-    return this._hasOwnersReview(filename, subtree, true) &&
-      this._hasRequiredOwnersApproval(filename, subtree);
+    return (
+      this._hasOwnersReview(filename, subtree, true) &&
+      this._hasRequiredOwnersApproval(filename, subtree)
+    );
   }
 
   /**
@@ -243,15 +246,16 @@ class OwnersCheck {
         const pending = reviewers
           .filter(([username, approved]) => !approved)
           .map(([username, approved]) => username);
-        const missing = this._missingRequiredOwners(filename, subtree)
-          .map(owner => owner.name);
+        const missing = this._missingRequiredOwners(filename, subtree).map(
+          owner => owner.name
+        );
 
         if (approving.length && !missing.length) {
           return `- ${filename} _(${approving.join(', ')})_`;
         } else {
           let line = `- **[NEEDS APPROVAL]** ${filename}`;
 
-          let names = [];
+          const names = [];
           if (pending.length) {
             names.push(`requested: ${pending.join(', ')}`);
           }
@@ -260,7 +264,7 @@ class OwnersCheck {
           }
 
           if (names.length) {
-            line += ` _(${names.join('; ')})_`
+            line += ` _(${names.join('; ')})_`;
           }
           return line;
         }

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -98,7 +98,7 @@ class OwnersCheck {
       // approved, so we build the coverage text first.
       this.changedFilenames.forEach(filename => {
         const subtree = fileTreeMap[filename];
-        if (this._hasOwnersApproval(filename, subtree)) {
+        if (this._hasFullOwnersCoverage(filename, subtree)) {
           delete fileTreeMap[filename];
         }
       });
@@ -148,20 +148,34 @@ class OwnersCheck {
   }
 
   /**
-   * Tests whether a file has been approved by an owner.
+   * Tests whether a file has an owner in the reviewer set.
    *
    * Must be called after `init`.
    *
    * @param {!string} filename file to check.
    * @param {!OwnersTree} subtree nearest ownership tree to file.
    * @param {boolean} isApproved approval status to filter by.
-   * @return {boolean} if the file is approved.
+   * @return {boolean} if the file is reviewed.
    */
   _hasOwnersReview(filename, subtree, isApproved) {
     return Object.entries(this.reviewers)
       .filter(([username, approved]) => approved === isApproved)
       .map(([username, approved]) => username)
       .some(approver => this.tree.fileHasOwner(filename, approver));
+  }
+
+  /**
+   * Tests whether a file has full owners coverage, including any required
+   * reviewers.
+   *
+   * Must be called after `init`.
+   *
+   * @param {!string} filename file to check.
+   * @param {!OwnersTree} subtree nearest ownership tree to file.
+   * @return {boolean} if the file has approval coverage.
+   */
+  _hasRequiredOwnersApproval(filename, subtree) {
+    return true;
   }
 
   /**
@@ -173,8 +187,9 @@ class OwnersCheck {
    * @param {!OwnersTree} subtree nearest ownership tree to file.
    * @return {boolean} if the file is approved.
    */
-  _hasOwnersApproval(filename, subtree) {
-    return this._hasOwnersReview(filename, subtree, true);
+  _hasFullOwnersCoverage(filename, subtree) {
+    return this._hasOwnersReview(filename, subtree, true) &&
+      this._hasRequiredOwnersApproval(filename, subtree);
   }
 
   /**

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -241,13 +241,24 @@ class OwnersCheck {
         const pending = reviewers
           .filter(([username, approved]) => !approved)
           .map(([username, approved]) => username);
+        const missing = this._missingRequiredOwners(filename, subtree)
+          .map(owner => owner.name);
 
-        if (approving.length) {
+        if (approving.length && !missing.length) {
           return `- ${filename} _(${approving.join(', ')})_`;
         } else {
           let line = `- **[NEEDS APPROVAL]** ${filename}`;
+
+          let names = [];
           if (pending.length) {
-            line += ` _(requested: ${pending.join(', ')})_`;
+            names.push(`requested: ${pending.join(', ')}`);
+          }
+          if (missing.length) {
+            names.push(`required: ${missing.join(', ')}`);
+          }
+
+          if (names.length) {
+            line += ` _(${names.join('; ')})_`
           }
           return line;
         }

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+const {OWNER_MODIFIER} = require('./owner');
 const {ReviewerSelection} = require('./reviewer_selection');
 
 const GITHUB_CHECKRUN_NAME = 'ampproject/owners-check';
@@ -165,6 +166,22 @@ class OwnersCheck {
   }
 
   /**
+   * Determines the set of missing required owners.
+   *
+   * Must be called after `init`.
+   *
+   * @param {!string} filename file to check.
+   * @param {!OwnersTree} subtree nearest ownership tree to file.
+   * @return {Owner[]} required owners that have not approved.
+   */
+  _missingRequiredOwners(filename, subtree) {
+    return subtree.getModifiedFileOwners(filename, OWNER_MODIFIER.REQUIRE)
+      .filter(owner =>
+        !owner.allUsernames.some(username => this.reviewers[username])
+      );
+  }
+
+  /**
    * Tests whether a file has full owners coverage, including any required
    * reviewers.
    *
@@ -175,7 +192,7 @@ class OwnersCheck {
    * @return {boolean} if the file has approval coverage.
    */
   _hasRequiredOwnersApproval(filename, subtree) {
-    return true;
+    return this._missingRequiredOwners(filename, subtree).length === 0;
   }
 
   /**

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -257,22 +257,22 @@ describe('owners check', () => {
     });
   });
 
-  describe('hasOwnersApproval', () => {
+  describe('hasFullOwnersCoverage', () => {
     it('returns true if any approver is an owner of the file', () => {
       expect(
-        ownersCheck._hasOwnersApproval(
+        ownersCheck._hasFullOwnersCoverage(
           'foo/test.js',
           ownersCheck.tree.atPath('foo/test.js')
         )
       ).toBe(true);
       expect(
-        ownersCheck._hasOwnersApproval(
+        ownersCheck._hasFullOwnersCoverage(
           'bar/baz/file.txt',
           ownersCheck.tree.atPath('bar/baz/file.txt')
         )
       ).toBe(true);
       expect(
-        ownersCheck._hasOwnersApproval(
+        ownersCheck._hasFullOwnersCoverage(
           'buzz/README.md',
           ownersCheck.tree.atPath('buzz/README.md')
         )
@@ -281,13 +281,13 @@ describe('owners check', () => {
 
     it('returns false if no owner has given approval', () => {
       expect(
-        ownersCheck._hasOwnersApproval(
+        ownersCheck._hasFullOwnersCoverage(
           'main.js',
           ownersCheck.tree.atPath('main.js')
         )
       ).toBe(false);
       expect(
-        ownersCheck._hasOwnersApproval(
+        ownersCheck._hasFullOwnersCoverage(
           'baz/README.md',
           ownersCheck.tree.atPath('baz/README.md')
         )
@@ -296,7 +296,7 @@ describe('owners check', () => {
 
     it('ignores reviewers that have not yet approved', () => {
       expect(
-        ownersCheck._hasOwnersApproval(
+        ownersCheck._hasFullOwnersCoverage(
           'extra/script.js',
           ownersCheck.tree.atPath('extra/script.js')
         )

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -486,6 +486,11 @@ describe('owners check', () => {
     let coverageText;
 
     beforeEach(() => {
+      ownersTree.addRule(
+        new OwnersRule('foo/required/OWNERS', [
+          new UserOwner('required_reviewer', OWNER_MODIFIER.REQUIRE)
+        ])
+      );
       const fileTreeMap = ownersCheck.tree.buildFileTreeMap(
         ownersCheck.changedFilenames
       );
@@ -508,6 +513,14 @@ describe('owners check', () => {
       expect(coverageText).toContain('### Current Coverage');
       expect(coverageText).toContain(
         '- **[NEEDS APPROVAL]** extra/script.js _(requested: extra_reviewer)_'
+      );
+    });
+
+    it('shows missing required', () => {
+      expect(coverageText).toContain('### Current Coverage');
+      expect(coverageText).toContain(
+        '- **[NEEDS APPROVAL]** foo/required/info.html ' +
+        '_(required: required_reviewer)_'
       );
     });
   });

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -270,7 +270,7 @@ describe('owners check', () => {
       it('fails if required user owners have not yet approved', () => {
         ownersTree.addRule(
           new OwnersRule('foo/required/OWNERS', [
-            new UserOwner('required_reviewer', OWNER_MODIFIER.REQUIRE)
+            new UserOwner('required_reviewer', OWNER_MODIFIER.REQUIRE),
           ])
         );
         expect(
@@ -284,7 +284,7 @@ describe('owners check', () => {
       it('fails if required user owners are pending approval', () => {
         ownersTree.addRule(
           new OwnersRule('foo/required/OWNERS', [
-            new UserOwner('extra_reviewerr', OWNER_MODIFIER.REQUIRE)
+            new UserOwner('extra_reviewerr', OWNER_MODIFIER.REQUIRE),
           ])
         );
         expect(
@@ -298,7 +298,7 @@ describe('owners check', () => {
       it('passes if required user owners have approved', () => {
         ownersTree.addRule(
           new OwnersRule('foo/required/OWNERS', [
-            new UserOwner('approver', OWNER_MODIFIER.REQUIRE)
+            new UserOwner('approver', OWNER_MODIFIER.REQUIRE),
           ])
         );
         expect(
@@ -317,7 +317,7 @@ describe('owners check', () => {
 
         ownersTree.addRule(
           new OwnersRule('foo/required/OWNERS', [
-            new TeamOwner(team, OWNER_MODIFIER.REQUIRE)
+            new TeamOwner(team, OWNER_MODIFIER.REQUIRE),
           ])
         );
         expect(
@@ -334,7 +334,7 @@ describe('owners check', () => {
 
         ownersTree.addRule(
           new OwnersRule('foo/required/OWNERS', [
-            new TeamOwner(team, OWNER_MODIFIER.REQUIRE)
+            new TeamOwner(team, OWNER_MODIFIER.REQUIRE),
           ])
         );
         expect(
@@ -351,7 +351,7 @@ describe('owners check', () => {
 
         ownersTree.addRule(
           new OwnersRule('foo/required/OWNERS', [
-            new TeamOwner(team, OWNER_MODIFIER.REQUIRE)
+            new TeamOwner(team, OWNER_MODIFIER.REQUIRE),
           ])
         );
         expect(
@@ -367,7 +367,7 @@ describe('owners check', () => {
       beforeEach(() => {
         ownersTree.addRule(
           new OwnersRule('foo/required/OWNERS', [
-            new UserOwner('approver', OWNER_MODIFIER.REQUIRE)
+            new UserOwner('approver', OWNER_MODIFIER.REQUIRE),
           ])
         );
       });
@@ -375,7 +375,7 @@ describe('owners check', () => {
       it('fails if not all required rules are satisfied', () => {
         ownersTree.addRule(
           new OwnersRule('foo/required/OWNERS', [
-            new UserOwner('required_reviewer', OWNER_MODIFIER.REQUIRE)
+            new UserOwner('required_reviewer', OWNER_MODIFIER.REQUIRE),
           ])
         );
         expect(
@@ -392,12 +392,12 @@ describe('owners check', () => {
 
         ownersTree.addRule(
           new OwnersRule('foo/required/OWNERS', [
-            new UserOwner('the_author', OWNER_MODIFIER.REQUIRE)
+            new UserOwner('the_author', OWNER_MODIFIER.REQUIRE),
           ])
         );
         ownersTree.addRule(
           new OwnersRule('foo/required/OWNERS', [
-            new TeamOwner(team, OWNER_MODIFIER.REQUIRE)
+            new TeamOwner(team, OWNER_MODIFIER.REQUIRE),
           ])
         );
 
@@ -458,10 +458,9 @@ describe('owners check', () => {
     });
 
     it('fails if it does not have required reviewer approval', () => {
-      sandbox.stub(
-        OwnersCheck.prototype,
-        '_hasRequiredOwnersApproval',
-      ).returns(false);
+      sandbox
+        .stub(OwnersCheck.prototype, '_hasRequiredOwnersApproval')
+        .returns(false);
       expect(
         ownersCheck._hasFullOwnersCoverage(
           'foo/required/info.html',
@@ -488,7 +487,7 @@ describe('owners check', () => {
     beforeEach(() => {
       ownersTree.addRule(
         new OwnersRule('foo/required/OWNERS', [
-          new UserOwner('required_reviewer', OWNER_MODIFIER.REQUIRE)
+          new UserOwner('required_reviewer', OWNER_MODIFIER.REQUIRE),
         ])
       );
       const fileTreeMap = ownersCheck.tree.buildFileTreeMap(
@@ -520,7 +519,7 @@ describe('owners check', () => {
       expect(coverageText).toContain('### Current Coverage');
       expect(coverageText).toContain(
         '- **[NEEDS APPROVAL]** foo/required/info.html ' +
-        '_(required: required_reviewer)_'
+          '_(required: required_reviewer)_'
       );
     });
   });

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -284,7 +284,7 @@ describe('owners check', () => {
       it('fails if required user owners are pending approval', () => {
         ownersTree.addRule(
           new OwnersRule('foo/required/OWNERS', [
-            new UserOwner('extra_reviewerr', OWNER_MODIFIER.REQUIRE),
+            new UserOwner('extra_reviewer', OWNER_MODIFIER.REQUIRE),
           ])
         );
         expect(


### PR DESCRIPTION
This PR adds support for checking required reviewers. It does not include parser changes to allow specifying required reviewers.

For context, see #516 

~Notably, this will also address #499 , since we can require approval from `ampproject/reviewers-amphtml` on all files.~
^^^ This won't work since that would make all reviewers owners of all files =/