### PR TITLE
[owners] Add support for an optional allowed reviewer set

### DIFF
--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -103,14 +103,28 @@ class OwnersCheck {
           delete fileTreeMap[filename];
         }
       });
-      const passing = !Object.keys(fileTreeMap).length;
+      const prHasFullOwnersCoverage = !Object.keys(fileTreeMap).length;
+      const prHasReviewerSetApproval = this._prHasReviewerSetApproval();
 
-      if (passing) {
+      if (prHasFullOwnersCoverage && prHasReviewerSetApproval) {
         return {
           checkRun: new CheckRun(
             CheckRunConclusion.SUCCESS,
             'All files in this PR have OWNERS approval',
             coverageText
+          ),
+          reviewers: [],
+        };
+      } else if (prHasFullOwnersCoverage) {
+        const reviewerSetText = this.buildReviewerSetText(
+          this.tree.reviewerSetRule.owners
+        );
+
+        return {
+          checkRun: new CheckRun(
+            CheckRunConclusion.ACTION_REQUIRED,
+            'Missing review from a member of the reviewer set',
+            `${reviewerSetText}\n\n${coverageText}`
           ),
           reviewers: [],
         };

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -307,6 +307,17 @@ class OwnersCheck {
 
     return ['### Suggested Reviewers', ...suggestionsText].join('\n\n');
   }
+
+  /**
+   * Build the check-run comment describing the need for a reviewer approval.
+   *
+   * @param {Owner[]} reviewers list of reviewer owners.
+   * @return {string} explanation of reviewer set, if present.
+   */
+  buildReviewerSetText(reviewers) {
+    return 'All PRs need approval from at least one member of the reviewer ' +
+      `set: ${reviewers.join(', ')}`;
+  }
 }
 
 module.exports = {

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -235,16 +235,14 @@ class OwnersCheck {
    *
    * @return {boolean} if the PR has reviewer approval.
    */
-   _prHasReviewerSetApproval() {
+  _prHasReviewerSetApproval() {
     return Object.entries(this.reviewers)
       .filter(([username, approved]) => approved)
       .map(([username]) => username)
-      .some(
-        username => this.tree.reviewerSetRule.owners.some(
-          owner => owner.includes(username)
-        )
+      .some(username =>
+        this.tree.reviewerSetRule.owners.some(owner => owner.includes(username))
       );
-    }
+  }
   /**
    * Build the check-run comment describing current approval coverage.
    *

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -329,8 +329,10 @@ class OwnersCheck {
    * @return {string} explanation of reviewer set, if present.
    */
   buildReviewerSetText(reviewers) {
-    return 'All PRs need approval from at least one member of the reviewer ' +
-      `set: ${reviewers.join(', ')}`;
+    return (
+      'All PRs need approval from at least one member of the reviewer ' +
+      `set: ${reviewers.join(', ')}`
+    );
   }
 }
 

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -228,6 +228,24 @@ class OwnersCheck {
   }
 
   /**
+   * Tests whether the PR has been approved by a member of the reviewer set, if
+   * present.
+   *
+   * Must be called after `init`.
+   *
+   * @return {boolean} if the PR has reviewer approval.
+   */
+   _prHasReviewerSetApproval() {
+    return Object.entries(this.reviewers)
+      .filter(([username, approved]) => approved)
+      .map(([username]) => username)
+      .some(
+        username => this.tree.reviewerSetRule.owners.some(
+          owner => owner.includes(username)
+        )
+      );
+    }
+  /**
    * Build the check-run comment describing current approval coverage.
    *
    * @param {!FileTreeMap} fileTreeMap map from filenames to ownership subtrees.

--- a/owners/src/owners_tree.js
+++ b/owners/src/owners_tree.js
@@ -15,6 +15,7 @@
  */
 
 const path = require('path');
+const {ReviewerSetRule} = require('./rules');
 
 /**
  * A tree of ownership keyed by directory.
@@ -34,6 +35,7 @@ class OwnersTree {
     this.depth = this.isRoot ? 0 : this.parent.depth + 1;
 
     this.rules = [];
+    this.reviewerSetRule = null;
     this.children = {};
   }
 
@@ -58,7 +60,12 @@ class OwnersTree {
    */
   addRule(rule) {
     if (rule.dirPath === this.dirPath) {
-      this.rules.push(rule);
+      if (rule instanceof ReviewerSetRule) {
+        this.reviewerSetRule = rule;
+      } else {
+        this.rules.push(rule);
+      }
+
       return this;
     }
 

--- a/owners/src/owners_tree.js
+++ b/owners/src/owners_tree.js
@@ -35,7 +35,7 @@ class OwnersTree {
     this.depth = this.isRoot ? 0 : this.parent.depth + 1;
 
     this.rules = [];
-    this.reviewerSetRule = null;
+    this.reviewerSetRule = new ReviewerSetRule('OWNERS');
     this.children = {};
   }
 

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -487,10 +487,9 @@ describe('owners check', () => {
 
     beforeEach(() => {
       reviewerTeam = new Team(0, 'ampproject', 'reviewers-amphtml');
-      reviewerSetRule = new ReviewerSetRule(
-        'OWNERS',
-        [new TeamOwner(reviewerTeam)],
-      );
+      reviewerSetRule = new ReviewerSetRule('OWNERS', [
+        new TeamOwner(reviewerTeam),
+      ]);
     });
 
     it('returns true if there is no reviewer set', () => {

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -611,14 +611,11 @@ describe('owners check', () => {
     it('displays review suggestions', () => {
       const team = new Team(0, 'ampproject', 'my_team');
       team.members.push('someone');
-      const reviewers = [
-        new UserOwner('rcebulko'),
-        new TeamOwner(team),
-      ];
+      const reviewers = [new UserOwner('rcebulko'), new TeamOwner(team)];
 
       expect(ownersCheck.buildReviewerSetText(reviewers)).toEqual(
         'All PRs need approval from at least one member of the reviewer set: ' +
-        'rcebulko, ampproject/my_team [someone]'
+          'rcebulko, ampproject/my_team [someone]'
       );
     });
   });

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -579,4 +579,20 @@ describe('owners check', () => {
       );
     });
   });
+
+  describe('buildReviewerSetText', () => {
+    it('displays review suggestions', () => {
+      const team = new Team(0, 'ampproject', 'my_team');
+      team.members.push('someone');
+      const reviewers = [
+        new UserOwner('rcebulko'),
+        new TeamOwner(team),
+      ];
+
+      expect(ownersCheck.buildReviewerSetText(reviewers)).toEqual(
+        'All PRs need approval from at least one member of the reviewer set: ' +
+        'rcebulko, ampproject/my_team [someone]'
+      );
+    });
+  });
 });

--- a/owners/test/owners_tree.test.js
+++ b/owners/test/owners_tree.test.js
@@ -95,10 +95,9 @@ describe('owners tree', () => {
     });
 
     it('saves a reviewer set rule', () => {
-      const reviewerSetRule = new ReviewerSetRule(
-        'OWNERS',
-        [new UserOwner('rcebulko')],
-      );
+      const reviewerSetRule = new ReviewerSetRule('OWNERS', [
+        new UserOwner('rcebulko'),
+      ]);
       tree.addRule(reviewerSetRule);
 
       expect(tree.rules).not.toContain(reviewerSetRule);

--- a/owners/test/owners_tree.test.js
+++ b/owners/test/owners_tree.test.js
@@ -26,6 +26,7 @@ const {
   OwnersRule,
   PatternOwnersRule,
   SameDirPatternOwnersRule,
+  ReviewerSetRule,
 } = require('../src/rules');
 
 describe('owners tree', () => {
@@ -91,6 +92,17 @@ describe('owners tree', () => {
       const subtree = tree.addRule(descendantDirRule);
 
       expect(subtree.dirPath).toEqual('foo/bar/baz');
+    });
+
+    it('saves a reviewer set rule', () => {
+      const reviewerSetRule = new ReviewerSetRule(
+        'OWNERS',
+        [new UserOwner('rcebulko')],
+      );
+      tree.addRule(reviewerSetRule);
+
+      expect(tree.rules).not.toContain(reviewerSetRule);
+      expect(tree.reviewerSetRule).toEqual(reviewerSetRule);
     });
   });
 

--- a/owners/test/rules.test.js
+++ b/owners/test/rules.test.js
@@ -18,6 +18,7 @@ const {
   OwnersRule,
   PatternOwnersRule,
   SameDirPatternOwnersRule,
+  ReviewerSetRule,
   RULE_PRIORITY,
 } = require('../src/rules');
 
@@ -186,6 +187,42 @@ describe('owners rules', () => {
             new SameDirPatternOwnersRule('OWNERS', [], '*.js')
           ).toMatchFile('main.js');
         });
+      });
+    });
+  });
+
+  describe('reviewer set', () => {
+    describe('constructor', () => {
+      it('throws an error in non-root owners files', () => {
+        expect(() => new ReviewerSetRule('src/OWNERS', [])).toThrow(
+          'A reviewer team rule may only be specified at the repository root'
+        );
+      });
+    });
+
+    describe('matchesFile', () => {
+      it('matches all files', () => {
+        const rule = new ReviewerSetRule('OWNERS', []);
+
+        expect(rule).toMatchFile('src/foo.txt');
+        expect(rule).toMatchFile('src/foo/bar.txt');
+        expect(rule).toMatchFile('src/foo/bar/baz.txt');
+      });
+    });
+
+    describe('label', () => {
+      it('is "Reviewers"', () => {
+        const rule = new ReviewerSetRule('OWNERS', []);
+
+        expect(rule.label).toEqual('Reviewers');
+      });
+    });
+
+    describe('toString', () => {
+      it('lists all owners', () => {
+        const rule = new ReviewerSetRule('OWNERS', ['rcebulko', 'erwinmombay']);
+
+        expect(rule.toString()).toEqual('Reviewers: rcebulko, erwinmombay');
       });
     });
   });


### PR DESCRIPTION
Addresses #522 

This PR adds support for an optional reviewer set. It modifies the owners check to fail unless at least one approving review comes from a member of the "reviewer set". The reviewer set defaults to a wildcard owner, so by default it will do nothing. If a reviewer set rule is specified, it must be satisfied, or the check-run will have an `action_required` status with a message indicating that a reviewer is required.

This PR does not include any changes to reviewer suggestion logic, nor does it implement the actual parsing to produce a reviewer set rule. This will come in a future PR.