### PR TITLE
[owners] Add support for parsing the reviewer team option

### DIFF
--- a/owners/OWNERS.example
+++ b/owners/OWNERS.example
@@ -128,11 +128,19 @@
       pattern: "*.{js,css}",
       owners: [{ name: "frontend" }],
     },
-  ]
+  ],
+
+  // The root-level owners file--and ONLY the root-level owners file--may
+  // specify an optional `reviewerTeam` property, providing the name of a GitHub
+  // team. If present, the owners check will require that at least one member of
+  // this team has given approval. It is possible that one reviewer is both a
+  // member of this reviewer team and provides owners coverage.
+  reviewerTeam: 'ampproject/reviewers-amphtml'
 }
 
 // The result of parsing this file would be a tree with these rules:
 //
+// Reviewers: ampproject/reviewers-amphtml [members...]
 // **/*: someuser, dontdothis, ampproject/wg-cool-team [members...],
 //       dvoytenko (never notify), rcebulko (always notify), rando
 // ./{package.json}: packager

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -301,7 +301,7 @@ class OwnersParser {
         try {
           rules.push(
             new ReviewerSetRule(ownersPath, [new TeamOwner(reviewerTeam)])
-          )
+          );
         } catch (error) {
           errors.push(new OwnersParserError(ownersPath, error.message));
         }
@@ -311,7 +311,7 @@ class OwnersParser {
         new OwnersParserError(
           ownersPath,
           'Expected "reviewerTeam" to be a string; ' +
-          `got ${typeof fileDef.reviewerTeam}`
+            `got ${typeof fileDef.reviewerTeam}`
         )
       );
     }

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -19,6 +19,7 @@ const {
   OwnersRule,
   PatternOwnersRule,
   SameDirPatternOwnersRule,
+  ReviewerSetRule,
 } = require('./rules');
 const {OwnersTree} = require('./owners_tree');
 const {
@@ -165,14 +166,13 @@ class OwnersParser {
     if (ownerName.includes('/')) {
       const team = this.teamMap[ownerName];
 
-      if (team) {
-        return {errors, result: new TeamOwner(team, modifier)};
-      } else {
+      if (!team) {
         errors.push(
           new OwnersParserError(ownersPath, `Unrecognized team: '${ownerName}'`)
         );
+        return {errors};
       }
-      return {errors};
+      return {errors, result: new TeamOwner(team, modifier)};
     }
 
     if (ownerName === '*') {
@@ -286,6 +286,35 @@ class OwnersParser {
   parseOwnersFileDefinition(ownersPath, fileDef) {
     const rules = [];
     const errors = [];
+
+    if (typeof fileDef.reviewerTeam === 'string') {
+      const reviewerTeam = this.teamMap[fileDef.reviewerTeam];
+
+      if (!reviewerTeam) {
+        errors.push(
+          new OwnersParserError(
+            ownersPath,
+            `Unrecognized team: '${fileDef.reviewerTeam}`
+          )
+        );
+      } else {
+        try {
+          rules.push(
+            new ReviewerSetRule(ownersPath, [new TeamOwner(reviewerTeam)])
+          )
+        } catch (error) {
+          errors.push(new OwnersParserError(ownersPath, error.message));
+        }
+      }
+    } else if (fileDef.reviewerTeam !== undefined) {
+      errors.push(
+        new OwnersParserError(
+          ownersPath,
+          'Expected "reviewerTeam" to be a string; ' +
+          `got ${typeof fileDef.reviewerTeam}`
+        )
+      );
+    }
 
     if (fileDef.rules instanceof Array) {
       fileDef.rules.forEach(ruleDef => {

--- a/owners/test/parser.test.js
+++ b/owners/test/parser.test.js
@@ -31,6 +31,7 @@ const {
   OwnersRule,
   PatternOwnersRule,
   SameDirPatternOwnersRule,
+  ReviewerSetRule,
 } = require('../src/rules');
 
 const EXAMPLE_FILE_PATH = path.resolve(__dirname, '../OWNERS.example');
@@ -57,6 +58,7 @@ describe('owners parser', () => {
   const wgCool = new Team(1, 'ampproject', 'wg-cool-team');
   const wgCaching = new Team(2, 'ampproject', 'wg-caching');
   const wgInfra = new Team(3, 'ampproject', 'wg-infra');
+  const reviewerTeam = new Team(0, 'ampproject', 'reviewers-amphtml');
 
   beforeEach(() => {
     myTeam = new Team(1337, 'ampproject', 'my_team');
@@ -68,6 +70,7 @@ describe('owners parser', () => {
       'ampproject/wg-cool-team': wgCool,
       'ampproject/wg-caching': wgCaching,
       'ampproject/wg-infra': wgInfra,
+      'ampproject/reviewers-amphtml': reviewerTeam,
     });
 
     sandbox.stub(repo, 'getAbsolutePath').callsFake(relativePath => {
@@ -446,6 +449,75 @@ describe('owners parser', () => {
         expect(rule.matchesFile('main.js')).toBe(true);
         expect(rule.matchesFile('main.html')).toBe(false);
         expect(rule.owners[0].name).toEqual('frontend');
+      });
+    });
+
+    describe('reviewer team', () => {
+      describe('in the repository root OWNERS file', () => {
+        it('records the reviewer set from "reviewerTeam', () => {
+          const fileDef = {
+            reviewerTeam: 'ampproject/reviewers-amphtml',
+            rules: [],
+          }
+          const {result, errors} = parser.parseOwnersFileDefinition(
+            'OWNERS',
+            fileDef,
+          );
+
+          expect(result[0]).toEqual(
+            new ReviewerSetRule('OWNERS', [new TeamOwner(reviewerTeam)])
+          );
+        });
+      });
+
+      describe('specified outside the repository root OWNERS file', () => {
+        const fileDef = {
+          reviewerTeam: 'ampproject/reviewers-amphtml',
+          rules: [],
+        };
+
+        it('reports an error', () => {
+          const {result, errors} = parser.parseOwnersFileDefinition(
+            'src/OWNERS',
+            fileDef,
+          );
+          expect(errors[0].message).toEqual(
+            'A reviewer team rule may only be specified at the repository root'
+          );
+        });
+
+        it('does not produce a reviewer set rule', () => {
+          const {result, errors} = parser.parseOwnersFileDefinition(
+            'src/OWNERS',
+            fileDef,
+          );
+          expect(result.length).toEqual(0);
+        });
+      });
+
+      describe('for a non-string "reviewerTeam" property', () => {
+        const fileDef = {
+          reviewerTeam: { name: 'ampproject/reviewers-amphtml' },
+          rules: [],
+        };
+
+        it('reports an error', () => {
+          const {result, errors} = parser.parseOwnersFileDefinition(
+            'OWNERS',
+            fileDef,
+          );
+          expect(errors[0].message).toEqual(
+            'Expected "reviewerTeam" to be a string; got object'
+          );
+        });
+
+        it('does not produce a reviewer set rule', () => {
+          const {result, errors} = parser.parseOwnersFileDefinition(
+            'OWNERS',
+            fileDef,
+          );
+          expect(result.length).toEqual(0);
+        });
       });
     });
   });

--- a/owners/test/parser.test.js
+++ b/owners/test/parser.test.js
@@ -366,12 +366,20 @@ describe('owners parser', () => {
 
         errors = fileParse.errors;
         Object.assign(rules, {
-          basic: fileParse.result[0],
-          filename: fileParse.result[1],
-          pattern: fileParse.result[2],
-          recursive: fileParse.result[3],
-          braces: fileParse.result[4],
+          reviewerSet: fileParse.result[0],
+          basic: fileParse.result[1],
+          filename: fileParse.result[2],
+          pattern: fileParse.result[3],
+          recursive: fileParse.result[4],
+          braces: fileParse.result[5],
         });
+      });
+
+      it('parses the reviewer team', () => {
+        const rule = rules.reviewerSet;
+        expect(rule.owners.map(owner => owner.name)).toEqual(
+          ['ampproject/reviewers-amphtml']
+        );
       });
 
       it('parses basic owner rules', () => {

--- a/owners/test/parser.test.js
+++ b/owners/test/parser.test.js
@@ -377,9 +377,9 @@ describe('owners parser', () => {
 
       it('parses the reviewer team', () => {
         const rule = rules.reviewerSet;
-        expect(rule.owners.map(owner => owner.name)).toEqual(
-          ['ampproject/reviewers-amphtml']
-        );
+        expect(rule.owners.map(owner => owner.name)).toEqual([
+          'ampproject/reviewers-amphtml',
+        ]);
       });
 
       it('parses basic owner rules', () => {
@@ -466,11 +466,8 @@ describe('owners parser', () => {
           const fileDef = {
             reviewerTeam: 'ampproject/reviewers-amphtml',
             rules: [],
-          }
-          const {result, errors} = parser.parseOwnersFileDefinition(
-            'OWNERS',
-            fileDef,
-          );
+          };
+          const {result} = parser.parseOwnersFileDefinition('OWNERS', fileDef);
 
           expect(result[0]).toEqual(
             new ReviewerSetRule('OWNERS', [new TeamOwner(reviewerTeam)])
@@ -485,9 +482,9 @@ describe('owners parser', () => {
         };
 
         it('reports an error', () => {
-          const {result, errors} = parser.parseOwnersFileDefinition(
+          const {errors} = parser.parseOwnersFileDefinition(
             'src/OWNERS',
-            fileDef,
+            fileDef
           );
           expect(errors[0].message).toEqual(
             'A reviewer team rule may only be specified at the repository root'
@@ -495,9 +492,9 @@ describe('owners parser', () => {
         });
 
         it('does not produce a reviewer set rule', () => {
-          const {result, errors} = parser.parseOwnersFileDefinition(
+          const {result} = parser.parseOwnersFileDefinition(
             'src/OWNERS',
-            fileDef,
+            fileDef
           );
           expect(result.length).toEqual(0);
         });
@@ -505,25 +502,19 @@ describe('owners parser', () => {
 
       describe('for a non-string "reviewerTeam" property', () => {
         const fileDef = {
-          reviewerTeam: { name: 'ampproject/reviewers-amphtml' },
+          reviewerTeam: {name: 'ampproject/reviewers-amphtml'},
           rules: [],
         };
 
         it('reports an error', () => {
-          const {result, errors} = parser.parseOwnersFileDefinition(
-            'OWNERS',
-            fileDef,
-          );
+          const {errors} = parser.parseOwnersFileDefinition('OWNERS', fileDef);
           expect(errors[0].message).toEqual(
             'Expected "reviewerTeam" to be a string; got object'
           );
         });
 
         it('does not produce a reviewer set rule', () => {
-          const {result, errors} = parser.parseOwnersFileDefinition(
-            'OWNERS',
-            fileDef,
-          );
+          const {result} = parser.parseOwnersFileDefinition('OWNERS', fileDef);
           expect(result.length).toEqual(0);
         });
       });


### PR DESCRIPTION
Addresses #522 ; adds parser support for reviewer set added in #525 . Also includes update to example owners file.