### PR TITLE
[owners] Bugfix: Auto-page reviews from GitHub API

### DIFF
--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -203,7 +203,7 @@ class GitHub {
     this.logger.info(`Fetching teams for organization '${this.owner}'`);
 
     const teamsList = [];
-    let pageNum = 0;
+    let pageNum = 1;
     let isNextLink = true;
     while (isNextLink) {
       const response = await this._customRequest(
@@ -261,17 +261,29 @@ class GitHub {
   async getReviews(number) {
     this.logger.info(`Fetching reviews for PR #${number}`);
 
-    const response = await this.client.pullRequests.listReviews(
-      this.repo({number})
-    );
-    this.logger.debug('[getReviews]', number, response.data);
+    const reviewList = [];
+    let pageNum = 1;
+    let isNextLink = true;
+    while (isNextLink) {
+      const response = await this._customRequest(
+        'GET',
+        `/repos/${this.owner}/${this.repository}/pulls/${number}/reviews?page=${pageNum}`
+      );
+      const nextLink = response.headers.link || '';
+      isNextLink = nextLink.includes('rel="next"');
+
+      const reviewPage = response.data;
+      reviewList.push(...reviewPage);
+      pageNum++;
+    }
+    this.logger.debug('[getReviews]', number, reviewList);
 
     // See https://developer.github.com/v4/enum/pullrequestreviewstate/ for
     // possible review states. The only ones we care about are "APPROVED" and
     // "CHANGES_REQUESTED", since the rest do not indicate a definite approval
     // or rejection.
     const allowedStates = ['approved', 'changes_requested', 'commented'];
-    return response.data
+    return reviewList
       .filter(({state}) => allowedStates.includes(state.toLowerCase()))
       .map(
         json =>

--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+const MAX_REVIEWS_PER_PAGE = 100;
+
 /**
  * Maps the github json payload to a simpler data structure.
  */
@@ -267,7 +269,8 @@ class GitHub {
     while (isNextLink) {
       const response = await this._customRequest(
         'GET',
-        `/repos/${this.owner}/${this.repository}/pulls/${number}/reviews?page=${pageNum}`
+        `/repos/${this.owner}/${this.repository}/pulls/${number}/reviews` +
+        `?page=${pageNum}&per_page=${MAX_REVIEWS_PER_PAGE}`
       );
       const nextLink = response.headers.link || '';
       isNextLink = nextLink.includes('rel="next"');

--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -270,7 +270,7 @@ class GitHub {
       const response = await this._customRequest(
         'GET',
         `/repos/${this.owner}/${this.repository}/pulls/${number}/reviews` +
-        `?page=${pageNum}&per_page=${MAX_REVIEWS_PER_PAGE}`
+          `?page=${pageNum}&per_page=${MAX_REVIEWS_PER_PAGE}`
       );
       const nextLink = response.headers.link || '';
       isNextLink = nextLink.includes('rel="next"');

--- a/owners/test/fixtures/reviews/many_reviews.23928.page_1.json
+++ b/owners/test/fixtures/reviews/many_reviews.23928.page_1.json
@@ -1,0 +1,1172 @@
+[
+  {
+    "id": 274633696,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjc0NjMzNjk2",
+    "user": {
+      "login": "lannka",
+      "id": 8496897,
+      "node_id": "MDQ6VXNlcjg0OTY4OTc=",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/8496897?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/lannka",
+      "html_url": "https://github.com/lannka",
+      "followers_url": "https://api.github.com/users/lannka/followers",
+      "following_url": "https://api.github.com/users/lannka/following{/other_user}",
+      "gists_url": "https://api.github.com/users/lannka/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/lannka/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/lannka/subscriptions",
+      "organizations_url": "https://api.github.com/users/lannka/orgs",
+      "repos_url": "https://api.github.com/users/lannka/repos",
+      "events_url": "https://api.github.com/users/lannka/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/lannka/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-274633696",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "CONTRIBUTOR",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-274633696"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-08-14T01:39:26Z",
+    "commit_id": "6384f771816f8448085d9d96808cd85cf5c5dea8"
+  },
+  {
+    "id": 286960863,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjg2OTYwODYz",
+    "user": {
+      "login": "lannka",
+      "id": 8496897,
+      "node_id": "MDQ6VXNlcjg0OTY4OTc=",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/8496897?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/lannka",
+      "html_url": "https://github.com/lannka",
+      "followers_url": "https://api.github.com/users/lannka/followers",
+      "following_url": "https://api.github.com/users/lannka/following{/other_user}",
+      "gists_url": "https://api.github.com/users/lannka/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/lannka/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/lannka/subscriptions",
+      "organizations_url": "https://api.github.com/users/lannka/orgs",
+      "repos_url": "https://api.github.com/users/lannka/repos",
+      "events_url": "https://api.github.com/users/lannka/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/lannka/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "DISMISSED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-286960863",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "CONTRIBUTOR",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-286960863"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-09-11T17:48:43Z",
+    "commit_id": "5902f0bcd1dca1b00dc32d71fc5ccced34bf2cf0"
+  },
+  {
+    "id": 287041788,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjg3MDQxNzg4",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-287041788",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-287041788"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-09-11T20:07:15Z",
+    "commit_id": "1e8378807cbd2b80ab6961da4e6984cc6c8b7dff"
+  },
+  {
+    "id": 287041850,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjg3MDQxODUw",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-287041850",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-287041850"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-09-11T20:07:22Z",
+    "commit_id": "1e8378807cbd2b80ab6961da4e6984cc6c8b7dff"
+  },
+  {
+    "id": 287042005,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjg3MDQyMDA1",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-287042005",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-287042005"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-09-11T20:07:43Z",
+    "commit_id": "1e8378807cbd2b80ab6961da4e6984cc6c8b7dff"
+  },
+  {
+    "id": 287042078,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjg3MDQyMDc4",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-287042078",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-287042078"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-09-11T20:07:53Z",
+    "commit_id": "1e8378807cbd2b80ab6961da4e6984cc6c8b7dff"
+  },
+  {
+    "id": 287072647,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjg3MDcyNjQ3",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-287072647",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-287072647"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-09-11T21:04:06Z",
+    "commit_id": "6c6ff8343346fb397d2b12b225b6d745bfd32bce"
+  },
+  {
+    "id": 288257390,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjg4MjU3Mzkw",
+    "user": {
+      "login": "lannka",
+      "id": 8496897,
+      "node_id": "MDQ6VXNlcjg0OTY4OTc=",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/8496897?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/lannka",
+      "html_url": "https://github.com/lannka",
+      "followers_url": "https://api.github.com/users/lannka/followers",
+      "following_url": "https://api.github.com/users/lannka/following{/other_user}",
+      "gists_url": "https://api.github.com/users/lannka/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/lannka/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/lannka/subscriptions",
+      "organizations_url": "https://api.github.com/users/lannka/orgs",
+      "repos_url": "https://api.github.com/users/lannka/repos",
+      "events_url": "https://api.github.com/users/lannka/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/lannka/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-288257390",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "CONTRIBUTOR",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-288257390"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-09-13T21:24:11Z",
+    "commit_id": "eb877b8f74ddd10d63109327909421440a1ee2eb"
+  },
+  {
+    "id": 288712866,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjg4NzEyODY2",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-288712866",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-288712866"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-09-16T15:27:23Z",
+    "commit_id": "253be0d093b650c04fb9e09c9af175a10616ad0c"
+  },
+  {
+    "id": 288713035,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjg4NzEzMDM1",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-288713035",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-288713035"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-09-16T15:27:34Z",
+    "commit_id": "253be0d093b650c04fb9e09c9af175a10616ad0c"
+  },
+  {
+    "id": 295130085,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1MTMwMDg1",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295130085",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295130085"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-09-30T17:23:05Z",
+    "commit_id": "253be0d093b650c04fb9e09c9af175a10616ad0c"
+  },
+  {
+    "id": 295131369,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1MTMxMzY5",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295131369",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295131369"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-09-30T17:25:23Z",
+    "commit_id": "253be0d093b650c04fb9e09c9af175a10616ad0c"
+  },
+  {
+    "id": 295132061,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1MTMyMDYx",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295132061",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295132061"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-09-30T17:26:33Z",
+    "commit_id": "253be0d093b650c04fb9e09c9af175a10616ad0c"
+  },
+  {
+    "id": 295132212,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1MTMyMjEy",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295132212",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295132212"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-09-30T17:26:49Z",
+    "commit_id": "253be0d093b650c04fb9e09c9af175a10616ad0c"
+  },
+  {
+    "id": 295132338,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1MTMyMzM4",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295132338",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295132338"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-09-30T17:27:03Z",
+    "commit_id": "253be0d093b650c04fb9e09c9af175a10616ad0c"
+  },
+  {
+    "id": 295167200,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1MTY3MjAw",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295167200",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295167200"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-09-30T18:28:41Z",
+    "commit_id": "253be0d093b650c04fb9e09c9af175a10616ad0c"
+  },
+  {
+    "id": 295167674,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1MTY3Njc0",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295167674",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295167674"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-09-30T18:29:34Z",
+    "commit_id": "253be0d093b650c04fb9e09c9af175a10616ad0c"
+  },
+  {
+    "id": 295762136,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1NzYyMTM2",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295762136",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295762136"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-01T17:18:51Z",
+    "commit_id": "12cf6184d66854cd1b3c1d112117c40e61358cbb"
+  },
+  {
+    "id": 295762642,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1NzYyNjQy",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295762642",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295762642"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-01T17:19:41Z",
+    "commit_id": "12cf6184d66854cd1b3c1d112117c40e61358cbb"
+  },
+  {
+    "id": 295765458,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1NzY1NDU4",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295765458",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295765458"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-01T17:24:20Z",
+    "commit_id": "12cf6184d66854cd1b3c1d112117c40e61358cbb"
+  },
+  {
+    "id": 295793877,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1NzkzODc3",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295793877",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295793877"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-01T18:11:28Z",
+    "commit_id": "12cf6184d66854cd1b3c1d112117c40e61358cbb"
+  },
+  {
+    "id": 295795494,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1Nzk1NDk0",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295795494",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295795494"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-01T18:14:10Z",
+    "commit_id": "12cf6184d66854cd1b3c1d112117c40e61358cbb"
+  },
+  {
+    "id": 295796084,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1Nzk2MDg0",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295796084",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295796084"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-01T18:15:08Z",
+    "commit_id": "12cf6184d66854cd1b3c1d112117c40e61358cbb"
+  },
+  {
+    "id": 295796342,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1Nzk2MzQy",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295796342",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295796342"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-01T18:15:35Z",
+    "commit_id": "12cf6184d66854cd1b3c1d112117c40e61358cbb"
+  },
+  {
+    "id": 295797044,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1Nzk3MDQ0",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295797044",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295797044"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-01T18:16:40Z",
+    "commit_id": "12cf6184d66854cd1b3c1d112117c40e61358cbb"
+  },
+  {
+    "id": 295798057,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1Nzk4MDU3",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295798057",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295798057"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-01T18:18:24Z",
+    "commit_id": "06f9928ad705cda5265742885a208e844ff876e8"
+  },
+  {
+    "id": 295812550,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1ODEyNTUw",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295812550",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295812550"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-01T18:42:37Z",
+    "commit_id": "ce4f74809dc51d6a2b7750e88b426d457015907f"
+  },
+  {
+    "id": 295813855,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1ODEzODU1",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295813855",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295813855"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-01T18:44:47Z",
+    "commit_id": "ce4f74809dc51d6a2b7750e88b426d457015907f"
+  },
+  {
+    "id": 295818820,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1ODE4ODIw",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295818820",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295818820"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-01T18:53:00Z",
+    "commit_id": "2e1361cbc0bffff52ad90b46b7291ea86d39c41b"
+  },
+  {
+    "id": 295830439,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1ODMwNDM5",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295830439",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295830439"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-01T19:12:52Z",
+    "commit_id": "2e1361cbc0bffff52ad90b46b7291ea86d39c41b"
+  }
+]

--- a/owners/test/fixtures/reviews/many_reviews.23928.page_2.json
+++ b/owners/test/fixtures/reviews/many_reviews.23928.page_2.json
@@ -1,0 +1,509 @@
+[
+  {
+    "id": 295866858,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk1ODY2ODU4",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295866858",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-295866858"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-01T20:18:21Z",
+    "commit_id": "2e1361cbc0bffff52ad90b46b7291ea86d39c41b"
+  },
+  {
+    "id": 296386520,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk2Mzg2NTIw",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-296386520",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-296386520"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-02T17:00:41Z",
+    "commit_id": "2e1361cbc0bffff52ad90b46b7291ea86d39c41b"
+  },
+  {
+    "id": 296569568,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk2NTY5NTY4",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-296569568",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-296569568"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-02T22:54:10Z",
+    "commit_id": "2e1361cbc0bffff52ad90b46b7291ea86d39c41b"
+  },
+  {
+    "id": 296886060,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk2ODg2MDYw",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-296886060",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-296886060"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-03T13:52:02Z",
+    "commit_id": "44f0cae1409e66c7a41dc896eba9e30ba022cd96"
+  },
+  {
+    "id": 297591116,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk3NTkxMTE2",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-297591116",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-297591116"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-04T16:40:31Z",
+    "commit_id": "e43fb550b6e8864514c4675a50c55c0963eb4d7a"
+  },
+  {
+    "id": 297591499,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk3NTkxNDk5",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-297591499",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-297591499"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-04T16:41:24Z",
+    "commit_id": "e43fb550b6e8864514c4675a50c55c0963eb4d7a"
+  },
+  {
+    "id": 297591777,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk3NTkxNzc3",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-297591777",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-297591777"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-04T16:42:01Z",
+    "commit_id": "e43fb550b6e8864514c4675a50c55c0963eb4d7a"
+  },
+  {
+    "id": 297633717,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk3NjMzNzE3",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-297633717",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-297633717"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-04T18:05:02Z",
+    "commit_id": "10ae65b77b2d80f6ad72cdc98a86df29d5dc80a9"
+  },
+  {
+    "id": 297633770,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk3NjMzNzcw",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-297633770",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-297633770"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-04T18:05:07Z",
+    "commit_id": "10ae65b77b2d80f6ad72cdc98a86df29d5dc80a9"
+  },
+  {
+    "id": 297633820,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk3NjMzODIw",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-297633820",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-297633820"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-04T18:05:12Z",
+    "commit_id": "10ae65b77b2d80f6ad72cdc98a86df29d5dc80a9"
+  },
+  {
+    "id": 298913005,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk4OTEzMDA1",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-298913005",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-298913005"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-08T17:04:40Z",
+    "commit_id": "10ae65b77b2d80f6ad72cdc98a86df29d5dc80a9"
+  },
+  {
+    "id": 299471766,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk5NDcxNzY2",
+    "user": {
+      "login": "triso07",
+      "id": 235373,
+      "node_id": "MDQ6VXNlcjIzNTM3Mw==",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/235373?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/triso07",
+      "html_url": "https://github.com/triso07",
+      "followers_url": "https://api.github.com/users/triso07/followers",
+      "following_url": "https://api.github.com/users/triso07/following{/other_user}",
+      "gists_url": "https://api.github.com/users/triso07/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/triso07/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/triso07/subscriptions",
+      "organizations_url": "https://api.github.com/users/triso07/orgs",
+      "repos_url": "https://api.github.com/users/triso07/repos",
+      "events_url": "https://api.github.com/users/triso07/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/triso07/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "COMMENTED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-299471766",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "NONE",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-299471766"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-09T14:50:23Z",
+    "commit_id": "8eed75de656de55a8be13e90231396cba5474c12"
+  },
+  {
+    "id": 299519096,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3Mjk5NTE5MDk2",
+    "user": {
+      "login": "calebcordry",
+      "id": 16087874,
+      "node_id": "MDQ6VXNlcjE2MDg3ODc0",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16087874?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/calebcordry",
+      "html_url": "https://github.com/calebcordry",
+      "followers_url": "https://api.github.com/users/calebcordry/followers",
+      "following_url": "https://api.github.com/users/calebcordry/following{/other_user}",
+      "gists_url": "https://api.github.com/users/calebcordry/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/calebcordry/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/calebcordry/subscriptions",
+      "organizations_url": "https://api.github.com/users/calebcordry/orgs",
+      "repos_url": "https://api.github.com/users/calebcordry/repos",
+      "events_url": "https://api.github.com/users/calebcordry/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/calebcordry/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "state": "APPROVED",
+    "html_url": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-299519096",
+    "pull_request_url": "https://api.github.com/repos/ampproject/amphtml/pulls/23928",
+    "author_association": "MEMBER",
+    "_links": {
+      "html": {
+        "href": "https://github.com/ampproject/amphtml/pull/23928#pullrequestreview-299519096"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/ampproject/amphtml/pulls/23928"
+      }
+    },
+    "submitted_at": "2019-10-09T15:54:00Z",
+    "commit_id": "8eed75de656de55a8be13e90231396cba5474c12"
+  }
+]

--- a/owners/test/github.test.js
+++ b/owners/test/github.test.js
@@ -25,6 +25,8 @@ const {GitHub, PullRequest, Review, Team} = require('../src/github');
 const reviewsApprovedResponse = require('./fixtures/reviews/reviews.35.approved.json');
 const requestedReviewsResponse = require('./fixtures/reviews/requested_reviewers.24574.json');
 const commentReviewsResponse = require('./fixtures/reviews/comment_reviews.24686.json');
+const manyReviewsPage1Response = require('./fixtures/reviews/many_reviews.23928.page_1.json');
+const manyReviewsPage2Response = require('./fixtures/reviews/many_reviews.23928.page_2.json');
 const pullRequestResponse = require('./fixtures/pulls/pull_request.35.json');
 const issueCommentsResponse = require('./fixtures/comments/issue_comments.438.json');
 const listFilesResponse = require('./fixtures/files/files.35.json');
@@ -250,7 +252,7 @@ describe('GitHub API', () => {
     it('returns a list of team objects', async () => {
       expect.assertions(3);
       nock('https://api.github.com')
-        .get('/orgs/test_owner/teams?page=0')
+        .get('/orgs/test_owner/teams?page=1')
         .reply(200, [{id: 1337, slug: 'my_team'}]);
 
       await withContext(async (context, github) => {
@@ -265,12 +267,12 @@ describe('GitHub API', () => {
     it('pages automatically', async () => {
       expect.assertions(1);
       nock('https://api.github.com')
-        .get('/orgs/test_owner/teams?page=0')
+        .get('/orgs/test_owner/teams?page=1')
         .reply(200, Array(30).fill([{id: 1337, slug: 'my_team'}]), {
           link: '<https://api.github.com/blah/blah?page=2>; rel="next"',
         });
       nock('https://api.github.com')
-        .get('/orgs/test_owner/teams?page=1')
+        .get('/orgs/test_owner/teams?page=2')
         .reply(200, Array(10).fill([{id: 1337, slug: 'my_team'}]));
 
       await withContext(async (context, github) => {
@@ -317,7 +319,7 @@ describe('GitHub API', () => {
     it('fetches a list of reviews', async () => {
       expect.assertions(3);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/35/reviews')
+        .get('/repos/test_owner/test_repo/pulls/35/reviews?page=1')
         .reply(200, reviewsApprovedResponse);
 
       await withContext(async (context, github) => {
@@ -329,10 +331,28 @@ describe('GitHub API', () => {
       })();
     });
 
+    it('pages automatically', async () => {
+      expect.assertions(1);
+      nock('https://api.github.com')
+        .get('/repos/test_owner/test_repo/pulls/23928/reviews?page=1')
+        .reply(200, manyReviewsPage1Response, {
+          link: '<https://api.github.com/blah/blah?page=2>; rel="next"',
+        });
+      nock('https://api.github.com')
+        .get('/repos/test_owner/test_repo/pulls/23928/reviews?page=2')
+        .reply(200, manyReviewsPage2Response);
+
+      await withContext(async (context, github) => {
+        const reviews = await github.getReviews(23928);
+
+        expect(reviews.length).toEqual(42);
+      })();
+    });
+
     it('returns approvals', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1')
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {
@@ -347,7 +367,7 @@ describe('GitHub API', () => {
     it('returns post-review comments', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1')
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {
@@ -362,7 +382,7 @@ describe('GitHub API', () => {
     it('returns pre-review comments', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1')
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {
@@ -377,7 +397,7 @@ describe('GitHub API', () => {
     it('returns rejections', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1')
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {
@@ -392,7 +412,7 @@ describe('GitHub API', () => {
     it('returns comment-only reviews', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1')
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {
@@ -407,7 +427,7 @@ describe('GitHub API', () => {
     it('ignores irrelevant review states', async () => {
       expect.assertions(1);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1')
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {

--- a/owners/test/github.test.js
+++ b/owners/test/github.test.js
@@ -334,12 +334,16 @@ describe('GitHub API', () => {
     it('pages automatically', async () => {
       expect.assertions(1);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/23928/reviews?page=1&per_page=100')
+        .get(
+          '/repos/test_owner/test_repo/pulls/23928/reviews?page=1&per_page=100'
+        )
         .reply(200, manyReviewsPage1Response, {
           link: '<https://api.github.com/blah/blah?page=2>; rel="next"',
         });
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/23928/reviews?page=2&per_page=100')
+        .get(
+          '/repos/test_owner/test_repo/pulls/23928/reviews?page=2&per_page=100'
+        )
         .reply(200, manyReviewsPage2Response);
 
       await withContext(async (context, github) => {
@@ -352,7 +356,9 @@ describe('GitHub API', () => {
     it('returns approvals', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100')
+        .get(
+          '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
+        )
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {
@@ -367,7 +373,9 @@ describe('GitHub API', () => {
     it('returns post-review comments', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100')
+        .get(
+          '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
+        )
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {
@@ -382,7 +390,9 @@ describe('GitHub API', () => {
     it('returns pre-review comments', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100')
+        .get(
+          '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
+        )
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {
@@ -397,7 +407,9 @@ describe('GitHub API', () => {
     it('returns rejections', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100')
+        .get(
+          '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
+        )
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {
@@ -412,7 +424,9 @@ describe('GitHub API', () => {
     it('returns comment-only reviews', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100')
+        .get(
+          '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
+        )
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {
@@ -427,7 +441,9 @@ describe('GitHub API', () => {
     it('ignores irrelevant review states', async () => {
       expect.assertions(1);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100')
+        .get(
+          '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
+        )
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {

--- a/owners/test/github.test.js
+++ b/owners/test/github.test.js
@@ -319,7 +319,7 @@ describe('GitHub API', () => {
     it('fetches a list of reviews', async () => {
       expect.assertions(3);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/35/reviews?page=1')
+        .get('/repos/test_owner/test_repo/pulls/35/reviews?page=1&per_page=100')
         .reply(200, reviewsApprovedResponse);
 
       await withContext(async (context, github) => {
@@ -334,12 +334,12 @@ describe('GitHub API', () => {
     it('pages automatically', async () => {
       expect.assertions(1);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/23928/reviews?page=1')
+        .get('/repos/test_owner/test_repo/pulls/23928/reviews?page=1&per_page=100')
         .reply(200, manyReviewsPage1Response, {
           link: '<https://api.github.com/blah/blah?page=2>; rel="next"',
         });
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/23928/reviews?page=2')
+        .get('/repos/test_owner/test_repo/pulls/23928/reviews?page=2&per_page=100')
         .reply(200, manyReviewsPage2Response);
 
       await withContext(async (context, github) => {
@@ -352,7 +352,7 @@ describe('GitHub API', () => {
     it('returns approvals', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100')
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {
@@ -367,7 +367,7 @@ describe('GitHub API', () => {
     it('returns post-review comments', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100')
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {
@@ -382,7 +382,7 @@ describe('GitHub API', () => {
     it('returns pre-review comments', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100')
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {
@@ -397,7 +397,7 @@ describe('GitHub API', () => {
     it('returns rejections', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100')
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {
@@ -412,7 +412,7 @@ describe('GitHub API', () => {
     it('returns comment-only reviews', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100')
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {
@@ -427,7 +427,7 @@ describe('GitHub API', () => {
     it('ignores irrelevant review states', async () => {
       expect.assertions(1);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1')
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100')
         .reply(200, commentReviewsResponse);
 
       await withContext(async (context, github) => {

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -100,7 +100,9 @@ describe('owners bot', () => {
       // We need the reviews to check if a pull request has been approved or
       // not.
       nock('https://api.github.com')
-        .get('/repos/erwinmombay/github-owners-bot-test-repo/pulls/35/reviews')
+        .get(
+          '/repos/erwinmombay/github-owners-bot-test-repo/pulls/35/reviews?page=1&per_page=100'
+        )
         .reply(200, reviews35);
 
       nock('https://api.github.com')
@@ -159,7 +161,9 @@ describe('owners bot', () => {
       // We need the reviews to check if a pull request has been approved or
       // not.
       nock('https://api.github.com')
-        .get('/repos/erwinmombay/github-owners-bot-test-repo/pulls/35/reviews')
+        .get(
+          '/repos/erwinmombay/github-owners-bot-test-repo/pulls/35/reviews?page=1&per_page=100'
+        )
         .reply(200, reviews35);
 
       // Get check runs for a specific commit
@@ -222,7 +226,9 @@ describe('owners bot', () => {
       // We need the reviews to check if a pull request has been approved or
       // not.
       nock('https://api.github.com')
-        .get('/repos/erwinmombay/github-owners-bot-test-repo/pulls/35/reviews')
+        .get(
+          '/repos/erwinmombay/github-owners-bot-test-repo/pulls/35/reviews?page=1&per_page=100'
+        )
         .reply(200, reviews35);
 
       nock('https://api.github.com')
@@ -279,7 +285,9 @@ describe('owners bot', () => {
       // We need the reviews to check if a pull request has been approved or
       // not.
       nock('https://api.github.com')
-        .get('/repos/erwinmombay/github-owners-bot-test-repo/pulls/35/reviews')
+        .get(
+          '/repos/erwinmombay/github-owners-bot-test-repo/pulls/35/reviews?page=1&per_page=100'
+        )
         .reply(200, reviews35);
 
       nock('https://api.github.com')
@@ -346,7 +354,9 @@ describe('owners bot', () => {
       // We need the reviews to check if a pull request has been approved or
       // not.
       nock('https://api.github.com')
-        .get('/repos/erwinmombay/github-owners-bot-test-repo/pulls/35/reviews')
+        .get(
+          '/repos/erwinmombay/github-owners-bot-test-repo/pulls/35/reviews?page=1&per_page=100'
+        )
         .reply(200, reviews35);
 
       nock('https://api.github.com')
@@ -408,7 +418,9 @@ describe('owners bot', () => {
       // We need the reviews to check if a pull request has been approved or
       // not.
       nock('https://api.github.com')
-        .get('/repos/erwinmombay/github-owners-bot-test-repo/pulls/35/reviews')
+        .get(
+          '/repos/erwinmombay/github-owners-bot-test-repo/pulls/35/reviews?page=1&per_page=100'
+        )
         .reply(200, reviews35Approved);
 
       nock('https://api.github.com')
@@ -462,7 +474,9 @@ describe('owners bot', () => {
       // We need the reviews to check if a pull request has been approved or
       // not.
       nock('https://api.github.com')
-        .get('/repos/erwinmombay/github-owners-bot-test-repo/pulls/36/reviews')
+        .get(
+          '/repos/erwinmombay/github-owners-bot-test-repo/pulls/36/reviews?page=1&per_page=100'
+        )
         .reply(200, reviews35);
 
       nock('https://api.github.com')
@@ -520,7 +534,9 @@ describe('owners bot', () => {
       // We need the reviews to check if a pull request has been approved or
       // not.
       nock('https://api.github.com')
-        .get('/repos/erwinmombay/github-owners-bot-test-repo/pulls/35/reviews')
+        .get(
+          '/repos/erwinmombay/github-owners-bot-test-repo/pulls/35/reviews?page=1&per_page=100'
+        )
         .reply(200, reviews35Approved);
 
       nock('https://api.github.com')


### PR DESCRIPTION
Raised by https://github.com/ampproject/amphtml/pull/23928

The GitHub API returns reviews in chronological order, but in pages. For PRs with long/active conversation threads, this can mean that approvals end up on the second page, which the existing GitHub interface was not accounting for. This PR adds the API responses from this failing PR and tests around it, then adds the auto-paging to the GitHub interface.