### PR TITLE
[owners] Update startup script with (redacted) current startup script and reorganize

### DIFF
--- a/owners/gce/startup-script.sh
+++ b/owners/gce/startup-script.sh
@@ -12,22 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This is the current contents of the GCE instance Metadata `startup-script`,
+# which is automatically executed when the `gcloud compute instances reset`
+# command is run.
+# TODO(#500): Move as much of this as possible to checked-in scripts and split
+#   startup code from re-deployment code.
 # [START startup]
 set -v
 
-REPO="my/repo"
+APP_ID=22611
+NODE_ENV="production"
+LOG_LEVEL="trace"
+REPO="ampproject/amphtml"
+#REPO="erwinmombay/github-owners-bot-test-repo"
 APP_DIR="/opt/app"
-REPO_DIR="/opt/repo"
-GITHUB_BOT_USERNAME="mybotsname"
-SECRET_TOKEN="mysecrettoken"
-CLOUD_BUCKET="gs://my-cloud-bucket"
-GITHUB_ACCESS_TOKEN=""
-OAUTH2_CLIENT_ID=""
-OAUTH2_CLIENT_SECRET=""
+REPO_DIR="/opt/amphtml"
+#REPO_DIR="/opt/github-owners-bot-test-repo"
+GITHUB_BOT_USERNAME="amp-owners-bot"
+WEBHOOK_SECRET="[REDACTED]"
+CLOUD_BUCKET="[REDACTED]"
+GITHUB_ACCESS_TOKEN="[REDACTED]"
+OAUTH2_CLIENT_ID="[REDACTED]"
+OAUTH2_CLIENT_SECRET="[REDACTED]"
+ADD_REVIEWERS_OPT_OUT=1
 
 # Talk to the metadata server to get the project id
 PROJECTID=$(curl -s "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")
-
+echo "Project ID ${PROJECTID}"
+supervisorctl stop nodeapp
 
 # Install logging monitor. The monitor will automatically pick up logs sent to
 # syslog.
@@ -42,7 +54,7 @@ apt-get install -yq ca-certificates git nodejs build-essential supervisor
 
 # Install nodejs
 mkdir /opt/nodejs
-curl https://nodejs.org/dist/v6.9.1/node-v6.9.1-linux-x64.tar.gz | tar xvzf - -C /opt/nodejs --strip-components=1
+curl https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-x64.tar.gz | tar xvzf - -C /opt/nodejs --strip-components=1
 ln -s /opt/nodejs/bin/node /usr/bin/node
 ln -s /opt/nodejs/bin/npm /usr/bin/npm
 
@@ -50,13 +62,26 @@ ln -s /opt/nodejs/bin/npm /usr/bin/npm
 # git requires $HOME and it's not set during the startup script.
 export HOME=/root
 git config --global credential.helper gcloud.sh
-git clone https://source.developers.google.com/p/$PROJECTID "${APP_DIR}"
+rm -rf "${APP_DIR}"
+git clone https://source.developers.google.com/p/$PROJECTID/r/amp-owners-bot "${APP_DIR}"
+mkdir -p ${APP_DIR}/.env
+
+cat > ${APP_DIR}/.env/amp-owners-bot.2019-01-22.private-key.pem << EOF
+-----BEGIN RSA PRIVATE KEY-----
+[REDACTED]
+-----END RSA PRIVATE KEY-----
+EOF
+
+PRIVATE_KEY_PATH="${APP_DIR}/.env/amp-owners-bot.2019-01-22.private-key.pem"
 
 # Install app dependencies
 cd "${APP_DIR}"
+APP_COMMIT_SHA=$(git log --max-count=1 --pretty='format:%h')
+APP_COMMIT_MSG=$(git log --max-count=1 --pretty='format:%s')
 npm install
-npm run start
 
+# get a clean copy of the target repository to be evaluated
+rm -rf "${REPO_DIR}"
 git clone "https://github.com/${REPO}.git" "${REPO_DIR}"
 
 # Create a nodeapp user. The application will run as this user.
@@ -68,13 +93,16 @@ chown -R nodeapp:nodeapp "${REPO_DIR}"
 cat >/etc/supervisor/conf.d/node-app.conf << EOF
 [program:nodeapp]
 directory=${APP_DIR}
-command=npm start
+command=npm run start
 autostart=true
 autorestart=true
 user=nodeapp
-environment=HOME="/home/nodeapp",USER="nodeapp",NODE_ENV="production",GCLOUD_PROJECT="${PROJECTID}",CLOUD_BUCKET="${CLOUD_BUCKET}",DATA_BACKEND="datastore",OAUTH2_CLIENT_ID="${OAUTH2_CLIENT_ID}",OAUTH2_CLIENT_SECRET="${OAUTH2_CLIENT_SECRET}",GITHUB_ACCESS_TOKEN="${GITHUB_ACCESS_TOKEN}",GITHUB_REPO_DIR="${REPO_DIR}",SECRET_TOKEN="${SECRET_TOKEN}",GITHUB_BOT_USERNAME="${GITHUB_BOT_USERNAME}"
+environment=HOME="/home/nodeapp",USER="nodeapp",NODE_ENV="${NODE_ENV}",LOG_LEVEL="${LOG_LEVEL}",GCLOUD_PROJECT="${PROJECTID}",CLOUD_BUCKET="${CLOUD_BUCKET}",DATA_BACKEND="datastore",OAUTH2_CLIENT_ID="${OAUTH2_CLIENT_ID}",OAUTH2_CLIENT_SECRET="${OAUTH2_CLIENT_SECRET}",GITHUB_ACCESS_TOKEN="${GITHUB_ACCESS_TOKEN}",GITHUB_REPO_DIR="${REPO_DIR}",WEBHOOK_SECRET="${WEBHOOK_SECRET}",GITHUB_BOT_USERNAME="${GITHUB_BOT_USERNAME}",PORT="8080",APP_ID="${APP_ID}",PRIVATE_KEY_PATH="${PRIVATE_KEY_PATH}",GITHUB_REPO="${REPO}",APP_COMMIT_SHA="${APP_COMMIT_SHA}",APP_COMMIT_MSG="${APP_COMMIT_MSG}",ADD_REVIEWERS_OPT_OUT=${ADD_REVIEWERS_OPT_OUT},INFO_SERVER_PORT="8081"
+nodaemon=true
 stdout_logfile=syslog
+stdout_logfile_maxbytes=0
 stderr_logfile=syslog
+stderr_logfile_maxbytes=0
 EOF
 
 supervisorctl reread

--- a/owners/gce/startup-script.sh
+++ b/owners/gce/startup-script.sh
@@ -22,21 +22,22 @@
 set -v
 
 # [START env]
-APP_ID=22611  # Probot
-NODE_ENV="production"  # App
-LOG_LEVEL="trace"  # Probot + App
-REPO="ampproject/amphtml"  # Startup + App
-#REPO="erwinmombay/github-owners-bot-test-repo"
 APP_DIR="/opt/app"  # Startup
 REPO_DIR="/opt/amphtml"  # Startup + App
-#REPO_DIR="/opt/github-owners-bot-test-repo"
-GITHUB_BOT_USERNAME="amp-owners-bot"  # App
+REPO="ampproject/amphtml"  # Startup + App
+
+APP_ID=22611  # Probot
 WEBHOOK_SECRET="[REDACTED]"  # Probot
-CLOUD_BUCKET="[REDACTED]"  # Unused
+LOG_LEVEL="trace"  # Probot + App
+
+GITHUB_BOT_USERNAME="amp-owners-bot"  # App
+NODE_ENV="production"  # App
 GITHUB_ACCESS_TOKEN="[REDACTED]"  # App
+ADD_REVIEWERS_OPT_OUT=1  # App
+
+CLOUD_BUCKET="[REDACTED]"  # Unused
 OAUTH2_CLIENT_ID="[REDACTED]"  # Unknown
 OAUTH2_CLIENT_SECRET="[REDACTED]"  # Unknown
-ADD_REVIEWERS_OPT_OUT=1  # App
 # [END env]
 
 # Talk to the metadata server to get the project id

--- a/owners/gce/startup-script.sh
+++ b/owners/gce/startup-script.sh
@@ -66,13 +66,12 @@ rm -rf "${APP_DIR}"
 git clone https://source.developers.google.com/p/$PROJECTID/r/amp-owners-bot "${APP_DIR}"
 mkdir -p ${APP_DIR}/.env
 
-cat > ${APP_DIR}/.env/amp-owners-bot.2019-01-22.private-key.pem << EOF
+PRIVATE_KEY=$(echo | base64 << EOF
 -----BEGIN RSA PRIVATE KEY-----
 [REDACTED]
 -----END RSA PRIVATE KEY-----
 EOF
-
-PRIVATE_KEY_PATH="${APP_DIR}/.env/amp-owners-bot.2019-01-22.private-key.pem"
+)
 
 # Install app dependencies
 cd "${APP_DIR}"
@@ -97,7 +96,7 @@ command=npm run start
 autostart=true
 autorestart=true
 user=nodeapp
-environment=HOME="/home/nodeapp",USER="nodeapp",NODE_ENV="${NODE_ENV}",LOG_LEVEL="${LOG_LEVEL}",GCLOUD_PROJECT="${PROJECTID}",DATA_BACKEND="datastore",GITHUB_ACCESS_TOKEN="${GITHUB_ACCESS_TOKEN}",GITHUB_REPO_DIR="${REPO_DIR}",WEBHOOK_SECRET="${WEBHOOK_SECRET}",GITHUB_BOT_USERNAME="${GITHUB_BOT_USERNAME}",PORT="8080",APP_ID="${APP_ID}",PRIVATE_KEY_PATH="${PRIVATE_KEY_PATH}",GITHUB_REPO="${REPO}",APP_COMMIT_SHA="${APP_COMMIT_SHA}",APP_COMMIT_MSG="${APP_COMMIT_MSG}",ADD_REVIEWERS_OPT_OUT=${ADD_REVIEWERS_OPT_OUT},INFO_SERVER_PORT="8081"
+environment=HOME="/home/nodeapp",USER="nodeapp",NODE_ENV="${NODE_ENV}",LOG_LEVEL="${LOG_LEVEL}",GCLOUD_PROJECT="${PROJECTID}",DATA_BACKEND="datastore",GITHUB_ACCESS_TOKEN="${GITHUB_ACCESS_TOKEN}",GITHUB_REPO_DIR="${REPO_DIR}",WEBHOOK_SECRET="${WEBHOOK_SECRET}",GITHUB_BOT_USERNAME="${GITHUB_BOT_USERNAME}",PORT="8080",APP_ID="${APP_ID}",PRIVATE_KEY="${PRIVATE_KEY}",GITHUB_REPO="${REPO}",APP_COMMIT_SHA="${APP_COMMIT_SHA}",APP_COMMIT_MSG="${APP_COMMIT_MSG}",ADD_REVIEWERS_OPT_OUT=${ADD_REVIEWERS_OPT_OUT},INFO_SERVER_PORT="8081"
 nodaemon=true
 stdout_logfile=syslog
 stdout_logfile_maxbytes=0

--- a/owners/gce/startup-script.sh
+++ b/owners/gce/startup-script.sh
@@ -34,14 +34,10 @@ GITHUB_BOT_USERNAME="amp-owners-bot"  # App
 NODE_ENV="production"  # App
 GITHUB_ACCESS_TOKEN="[REDACTED]"  # App
 ADD_REVIEWERS_OPT_OUT=1  # App
-
-CLOUD_BUCKET="[REDACTED]"  # Unused
-OAUTH2_CLIENT_ID="[REDACTED]"  # Unknown
-OAUTH2_CLIENT_SECRET="[REDACTED]"  # Unknown
 # [END env]
 
 # Talk to the metadata server to get the project id
-PROJECTID=$(curl -s "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")  # Startup (logging)
+PROJECTID=$(curl -s "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")  # Startup (logging) + App (info server)
 echo "Project ID ${PROJECTID}"
 supervisorctl stop nodeapp
 
@@ -101,7 +97,7 @@ command=npm run start
 autostart=true
 autorestart=true
 user=nodeapp
-environment=HOME="/home/nodeapp",USER="nodeapp",NODE_ENV="${NODE_ENV}",LOG_LEVEL="${LOG_LEVEL}",GCLOUD_PROJECT="${PROJECTID}",CLOUD_BUCKET="${CLOUD_BUCKET}",DATA_BACKEND="datastore",OAUTH2_CLIENT_ID="${OAUTH2_CLIENT_ID}",OAUTH2_CLIENT_SECRET="${OAUTH2_CLIENT_SECRET}",GITHUB_ACCESS_TOKEN="${GITHUB_ACCESS_TOKEN}",GITHUB_REPO_DIR="${REPO_DIR}",WEBHOOK_SECRET="${WEBHOOK_SECRET}",GITHUB_BOT_USERNAME="${GITHUB_BOT_USERNAME}",PORT="8080",APP_ID="${APP_ID}",PRIVATE_KEY_PATH="${PRIVATE_KEY_PATH}",GITHUB_REPO="${REPO}",APP_COMMIT_SHA="${APP_COMMIT_SHA}",APP_COMMIT_MSG="${APP_COMMIT_MSG}",ADD_REVIEWERS_OPT_OUT=${ADD_REVIEWERS_OPT_OUT},INFO_SERVER_PORT="8081"
+environment=HOME="/home/nodeapp",USER="nodeapp",NODE_ENV="${NODE_ENV}",LOG_LEVEL="${LOG_LEVEL}",GCLOUD_PROJECT="${PROJECTID}",DATA_BACKEND="datastore",GITHUB_ACCESS_TOKEN="${GITHUB_ACCESS_TOKEN}",GITHUB_REPO_DIR="${REPO_DIR}",WEBHOOK_SECRET="${WEBHOOK_SECRET}",GITHUB_BOT_USERNAME="${GITHUB_BOT_USERNAME}",PORT="8080",APP_ID="${APP_ID}",PRIVATE_KEY_PATH="${PRIVATE_KEY_PATH}",GITHUB_REPO="${REPO}",APP_COMMIT_SHA="${APP_COMMIT_SHA}",APP_COMMIT_MSG="${APP_COMMIT_MSG}",ADD_REVIEWERS_OPT_OUT=${ADD_REVIEWERS_OPT_OUT},INFO_SERVER_PORT="8081"
 nodaemon=true
 stdout_logfile=syslog
 stdout_logfile_maxbytes=0

--- a/owners/gce/startup-script.sh
+++ b/owners/gce/startup-script.sh
@@ -17,27 +17,30 @@
 # command is run.
 # TODO(#500): Move as much of this as possible to checked-in scripts and split
 #   startup code from re-deployment code.
+
 # [START startup]
 set -v
 
-APP_ID=22611
-NODE_ENV="production"
-LOG_LEVEL="trace"
-REPO="ampproject/amphtml"
+# [START env]
+APP_ID=22611  # Probot
+NODE_ENV="production"  # App
+LOG_LEVEL="trace"  # Probot + App
+REPO="ampproject/amphtml"  # Startup + App
 #REPO="erwinmombay/github-owners-bot-test-repo"
-APP_DIR="/opt/app"
-REPO_DIR="/opt/amphtml"
+APP_DIR="/opt/app"  # Startup
+REPO_DIR="/opt/amphtml"  # Startup + App
 #REPO_DIR="/opt/github-owners-bot-test-repo"
-GITHUB_BOT_USERNAME="amp-owners-bot"
-WEBHOOK_SECRET="[REDACTED]"
-CLOUD_BUCKET="[REDACTED]"
-GITHUB_ACCESS_TOKEN="[REDACTED]"
-OAUTH2_CLIENT_ID="[REDACTED]"
-OAUTH2_CLIENT_SECRET="[REDACTED]"
-ADD_REVIEWERS_OPT_OUT=1
+GITHUB_BOT_USERNAME="amp-owners-bot"  # App
+WEBHOOK_SECRET="[REDACTED]"  # Probot
+CLOUD_BUCKET="[REDACTED]"  # Unused
+GITHUB_ACCESS_TOKEN="[REDACTED]"  # App
+OAUTH2_CLIENT_ID="[REDACTED]"  # Unknown
+OAUTH2_CLIENT_SECRET="[REDACTED]"  # Unknown
+ADD_REVIEWERS_OPT_OUT=1  # App
+# [END env]
 
 # Talk to the metadata server to get the project id
-PROJECTID=$(curl -s "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")
+PROJECTID=$(curl -s "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")  # Startup (logging)
 echo "Project ID ${PROJECTID}"
 supervisorctl stop nodeapp
 


### PR DESCRIPTION
This updates the checked-in startup script to match the version living in the GCE metadata (minus any private keys), adds comments, and uses the private key as an env var directly instead of writing it to a file and passing the file path (Probot [accepts either format](https://probot.github.io/docs/configuration/))

Adresses #500 
