### PR TITLE
[owners] Split info server into standalone module

### DIFF
--- a/owners/index.js
+++ b/owners/index.js
@@ -17,23 +17,18 @@
 require('dotenv').config();
 
 const Octokit = require('@octokit/rest');
+const express = require('express');
+
 const {GitHub, PullRequest, Team} = require('./src/github');
 const {LocalRepository} = require('./src/repo');
 const {OwnersBot} = require('./src/owners_bot');
 const {OwnersParser} = require('./src/parser');
 const {OwnersCheck} = require('./src/owners_check');
-const express = require('express');
 
 const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
 const GITHUB_REPO = process.env.GITHUB_REPO || 'ampproject/amphtml';
 const [GITHUB_REPO_OWNER, GITHUB_REPO_NAME] = GITHUB_REPO.split('/');
-
-const APP_ID = process.env.APP_ID || 'UNKNOWN';
-const APP_COMMIT_SHA = process.env.APP_COMMIT_SHA || 'UNKNOWN';
-const APP_COMMIT_MSG = process.env.APP_COMMIT_MSG || 'UNKNOWN';
 const INFO_SERVER_PORT = Number(process.env.INFO_SERVER_PORT || 8081);
-
-const CACHED_TREE_REFRESH_MS = 10 * 60 * 1000;
 
 module.exports = app => {
   const localRepo = new LocalRepository(process.env.GITHUB_REPO_DIR);
@@ -100,71 +95,14 @@ module.exports = app => {
     }
   );
 
-  // Since the status server is publicly accessible, we don't want any
-  // endpoints to be making API calls or doing disk I/O. Rather than parsing
-  // the file tree from the local repo on every request, we keep a local copy
-  // and update it every ten minutes.
-  const parser = new OwnersParser(localRepo, ownersBot.teams, app.log);
-  let treeParse = {result: {}, errors: []};
-  /** Updates the cached copy of the parsed ownership tree. */
-  function updateTree() {
-    app.log('Updating cached owners tree');
-    parser.parseOwnersTree().then(parse => {
-      treeParse = parse;
-    });
-  }
-
   if (process.env.NODE_ENV !== 'test') {
-    updateTree();
-    teamsInitialized.then(updateTree);
-    setInterval(updateTree, CACHED_TREE_REFRESH_MS);
-
-    /** Health check server endpoints **/
-    const expressApp = express();
-    expressApp.get('/status', (req, res) => {
-      res.send(
-        [
-          `The OWNERS bot is live and running on ${GITHUB_REPO}!`,
-          `App ID: ${APP_ID}`,
-          `Deployed commit: <code>${APP_COMMIT_SHA}</code> ${APP_COMMIT_MSG}`,
-          '<a href="/tree">Owners Tree</a>',
-          '<a href="/teams">Organization Teams</a>',
-        ].join('<br>')
-      );
-    });
-
-    expressApp.get('/tree', (req, res) => {
-      const treeHeader = '<h3>OWNERS tree</h3>';
-      const treeDisplay = `<pre>${treeParse.result.toString()}</pre>`;
-
-      let output = `${treeHeader}${treeDisplay}`;
-      if (treeParse.errors.length) {
-        const errorHeader = '<h3>Parser Errors</h3>';
-        const errorDisplay = treeParse.errors
-          .map(error => error.toString())
-          .join('<br>');
-        output += `${errorHeader}<code>${errorDisplay}</code>`;
-      }
-
-      res.send(output);
-    });
-
-    expressApp.get('/teams', (req, res) => {
-      const teamSections = [];
-      Object.entries(ownersBot.teams).forEach(([name, team]) => {
-        teamSections.push(
-          [
-            `Team "${name}" (ID: ${team.id}):`,
-            ...team.members.map(username => `- ${username}`),
-          ].join('<br>')
-        );
-      });
-
-      res.send(['<h2>Teams</h2>', ...teamSections].join('<br><br>'));
-    });
-
-    expressApp.listen(INFO_SERVER_PORT, () => {
-      app.log(`Starting status server on port ${INFO_SERVER_PORT}`);
+    // Since the status server is publicly accessible, we don't want any
+    // endpoints to be making API calls or doing disk I/O. Rather than parsing
+    // the file tree from the local repo on every request, we keep a local copy
+    // and update it every ten minutes.
+    const parser = new OwnersParser(localRepo, ownersBot.teams, app.log);
+    teamsInitialized.then(() => {
+      healthServer(INFO_SERVER_PORT, parser, app.log);
     });
   }
 

--- a/owners/index.js
+++ b/owners/index.js
@@ -17,8 +17,8 @@
 require('dotenv').config();
 
 const Octokit = require('@octokit/rest');
-const express = require('express');
 
+const infoServer = require('./info_server');
 const {GitHub, PullRequest, Team} = require('./src/github');
 const {LocalRepository} = require('./src/repo');
 const {OwnersBot} = require('./src/owners_bot');
@@ -32,7 +32,6 @@ const INFO_SERVER_PORT = Number(process.env.INFO_SERVER_PORT || 8081);
 
 module.exports = app => {
   const localRepo = new LocalRepository(process.env.GITHUB_REPO_DIR);
-
   const ownersBot = new OwnersBot(localRepo);
   const github = new GitHub(
     new Octokit({auth: `token ${GITHUB_ACCESS_TOKEN}`}),
@@ -102,7 +101,7 @@ module.exports = app => {
     // and update it every ten minutes.
     const parser = new OwnersParser(localRepo, ownersBot.teams, app.log);
     teamsInitialized.then(() => {
-      healthServer(INFO_SERVER_PORT, parser, app.log);
+      infoServer(INFO_SERVER_PORT, parser, app.log);
     });
   }
 

--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -15,7 +15,6 @@
  */
 
 const express = require('express');
-const JSON5 = require('json5');
 const bodyParser = require('body-parser');
 
 const GITHUB_REPO = process.env.GITHUB_REPO || 'ampproject/amphtml';

--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -19,11 +19,6 @@ const JSON5 = require('json5');
 const bodyParser = require('body-parser');
 
 const GITHUB_REPO = process.env.GITHUB_REPO || 'ampproject/amphtml';
-const GCLOUD_PROJECT = process.env.GCLOUD_PROJECT || 'UNKNOWN';
-const APP_ID = process.env.APP_ID || 'UNKNOWN';
-const APP_COMMIT_SHA = process.env.APP_COMMIT_SHA || 'UNKNOWN';
-const APP_COMMIT_MSG = process.env.APP_COMMIT_MSG || 'UNKNOWN';
-
 const CACHED_TREE_REFRESH_MS = 10 * 60 * 1000;
 
 /**
@@ -53,9 +48,6 @@ module.exports = (port, parser, logger) => {
     res.send(
       [
         `The OWNERS bot is live and running on ${GITHUB_REPO}!`,
-        `Project: ${GCLOUD_PROJECT}`,
-        `App ID: ${APP_ID}`,
-        `Deployed commit: <code>${APP_COMMIT_SHA}</code> ${APP_COMMIT_MSG}`,
         '<a href="/tree">Owners Tree</a>',
         '<a href="/teams">Organization Teams</a>',
       ].join('<br>')
@@ -93,6 +85,6 @@ module.exports = (port, parser, logger) => {
   });
 
   app.listen(port, () => {
-    logger.info(`Starting status server on port ${port}`);
+    logger.info(`Starting info server on port ${port}`);
   });
 };

--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2019 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const express = require('express');
+const JSON5 = require('json5');
+const bodyParser = require('body-parser');
+
+const GITHUB_REPO = process.env.GITHUB_REPO || 'ampproject/amphtml';
+const GCLOUD_PROJECT = process.env.GCLOUD_PROJECT || 'UNKNOWN';
+const APP_ID = process.env.APP_ID || 'UNKNOWN';
+const APP_COMMIT_SHA = process.env.APP_COMMIT_SHA || 'UNKNOWN';
+const APP_COMMIT_MSG = process.env.APP_COMMIT_MSG || 'UNKNOWN';
+
+const CACHED_TREE_REFRESH_MS = 10 * 60 * 1000;
+
+/**
+ * Info server entrypoint.
+ *
+ * @param {number} port port to run the server on.
+ * @param {!OwnersParser} parser owners file parser.
+ * @param {!Logger} logger logging interface.
+ */
+module.exports = (port, parser, logger) => {
+  let treeParse = {result: {}, errors: []};
+
+  /** Updates the cached copy of the parsed ownership tree. */
+  function updateTree() {
+    app.log('Updating cached owners tree');
+    parser.parseOwnersTree().then(parse => {
+      treeParse = parse;
+    });
+  }
+  updateTree();
+  setInterval(updateTree, CACHED_TREE_REFRESH_MS);
+
+  const app = express();
+  app.use(bodyParser.json());
+
+  app.get('/status', (req, res) => {
+    res.send(
+      [
+        `The OWNERS bot is live and running on ${GITHUB_REPO}!`,
+        `Project: ${GCLOUD_PROJECT}`,
+        `App ID: ${APP_ID}`,
+        `Deployed commit: <code>${APP_COMMIT_SHA}</code> ${APP_COMMIT_MSG}`,
+        '<a href="/tree">Owners Tree</a>',
+        '<a href="/teams">Organization Teams</a>',
+      ].join('<br>')
+    );
+  });
+
+  app.get('/tree', (req, res) => {
+    const treeHeader = '<h3>OWNERS tree</h3>';
+    const treeDisplay = `<pre>${treeParse.result.toString()}</pre>`;
+
+    let output = `${treeHeader}${treeDisplay}`;
+    if (treeParse.errors.length) {
+      const errorHeader = '<h3>Parser Errors</h3>';
+      const errorDisplay = treeParse.errors
+        .map(error => error.toString())
+        .join('<br>');
+      output += `${errorHeader}<code>${errorDisplay}</code>`;
+    }
+
+    res.send(output);
+  });
+
+  app.get('/teams', (req, res) => {
+    const teamSections = [];
+    Object.entries(parser.teamMap).forEach(([name, team]) => {
+      teamSections.push(
+        [
+          `Team "${name}" (ID: ${team.id}):`,
+          ...team.members.map(username => `- ${username}`),
+        ].join('<br>')
+      );
+    });
+
+    res.send(['<h2>Teams</h2>', ...teamSections].join('<br><br>'));
+  });
+
+  app.listen(port, () => {
+    logger.info(`Starting status server on port ${port}`);
+  });
+};


### PR DESCRIPTION
The purpose of this is two-fold. The first is simply cleanup; the info server kinda fell into place as a debugging tool, then `index.js` got a bit cluttered. The second is to enable easier testing, since the info server will eventually take on the role of providing a syntax-check API for Travis