### PR TITLE
[owners] Cleanup and hoist owners tree to shared property of owners bot

### DIFF
--- a/owners/index.js
+++ b/owners/index.js
@@ -97,9 +97,7 @@ module.exports = app => {
   );
 
   if (process.env.NODE_ENV !== 'test') {
-    teamsInitialized.then(() => {
-      infoServer(INFO_SERVER_PORT, ownersBot, app.log);
-    });
+    infoServer(INFO_SERVER_PORT, ownersBot, app.log);
   }
 
   // Since this endpoint triggers a ton of GitHub API requests, there is a risk

--- a/owners/index.js
+++ b/owners/index.js
@@ -91,13 +91,8 @@ module.exports = app => {
   );
 
   if (process.env.NODE_ENV !== 'test') {
-    // Since the status server is publicly accessible, we don't want any
-    // endpoints to be making API calls or doing disk I/O. Rather than parsing
-    // the file tree from the local repo on every request, we keep a local copy
-    // and update it every ten minutes.
-    const parser = new OwnersParser(localRepo, ownersBot.teams, app.log);
     teamsInitialized.then(() => {
-      infoServer(INFO_SERVER_PORT, parser, app.log);
+      infoServer(INFO_SERVER_PORT, ownersBot.parser, app.log);
     });
   }
 

--- a/owners/index.js
+++ b/owners/index.js
@@ -100,8 +100,12 @@ module.exports = app => {
   // of it being spammed; so it is not exposed through the info server.
   app.route('/admin').get('/check/:prNumber', async (req, res) => {
     const pr = await sharedGithub.getPullRequest(req.params.prNumber);
-    const {tree, changedFiles, reviewers} = await ownersBot.initPr(github, pr);
-    const ownersCheck = new OwnersCheck(tree, changedFiles, reviewers);
+    const {changedFiles, reviewers} = await ownersBot.initPr(sharedGithub, pr);
+    const ownersCheck = new OwnersCheck(
+      ownersBot.treeParse.result,
+      changedFiles,
+      reviewers,
+    );
 
     const {checkRun} = ownersCheck.run();
 

--- a/owners/index.js
+++ b/owners/index.js
@@ -33,51 +33,50 @@ const INFO_SERVER_PORT = Number(process.env.INFO_SERVER_PORT || 8081);
 module.exports = app => {
   const localRepo = new LocalRepository(process.env.GITHUB_REPO_DIR);
   const ownersBot = new OwnersBot(localRepo);
-  const github = new GitHub(
+  const sharedGithub = new GitHub(
     new Octokit({auth: `token ${GITHUB_ACCESS_TOKEN}`}),
     GITHUB_REPO_OWNER,
     GITHUB_REPO_NAME,
     app.log
   );
-  const teamsInitialized = ownersBot.initTeams(github);
+  const teamsInitialized = ownersBot.initTeams(sharedGithub);
+
+  function listen(events, cb) {
+    app.on(events, async context => {
+      let github;
+      try {
+        github = GitHub.fromContext(context);
+      } catch (e) {
+        // Some webhooks do not provide a GitHub instance in their context.
+        github = sharedGithub;
+      }
+
+      await cb(github, context.payload);
+    });
+  }
 
   /** Probot request handlers **/
-  app.on(['pull_request.opened'], async context => {
-    await ownersBot.runOwnersCheck(
-      GitHub.fromContext(context),
-      PullRequest.fromGitHubResponse(context.payload.pull_request),
-      /* requestOwners */ true
-    );
+  listen('pull_request.opened', async (github, payload) => {
+    const pr = PullRequest.fromGitHubResponse(payload.pull_request);
+    await ownersBot.runOwnersCheck(github, pr, /* requestOwners */ true);
   });
 
-  app.on(['pull_request.synchronize'], async context => {
-    await ownersBot.runOwnersCheck(
-      GitHub.fromContext(context),
-      PullRequest.fromGitHubResponse(context.payload.pull_request)
-    );
+  listen('pull_request.synchronize', async (github, payload) => {
+    const pr = PullRequest.fromGitHubResponse(payload.pull_request);
+    await ownersBot.runOwnersCheck(github, pr);
   });
 
-  app.on('check_run.rerequested', async context => {
-    const payload = context.payload;
+  listen('check_run.rerequested', async (github, payload) => {
     const prNumber = payload.check_run.check_suite.pull_requests[0].number;
-
-    await ownersBot.runOwnersCheckOnPrNumber(
-      GitHub.fromContext(context),
-      prNumber
-    );
+    await ownersBot.runOwnersCheckOnPrNumber(github, prNumber);
   });
 
-  app.on('pull_request_review.submitted', async context => {
-    const payload = context.payload;
+  listen('pull_request_review.submitted', async (github, payload) => {
     const prNumber = payload.pull_request.number;
-
-    await ownersBot.runOwnersCheckOnPrNumber(
-      GitHub.fromContext(context),
-      prNumber
-    );
+    await ownersBot.runOwnersCheckOnPrNumber(github, prNumber);
   });
 
-  app.on(
+  listen(
     [
       'team.created',
       'team.deleted',
@@ -85,8 +84,8 @@ module.exports = app => {
       'membership.added',
       'membership.removed',
     ],
-    async context => {
-      const {id, slug} = context.payload.team;
+    async (github, payload) => {
+      const {id, slug} = payload.team;
       await ownersBot.syncTeam(new Team(id, GITHUB_REPO_OWNER, slug), github);
     }
   );
@@ -105,7 +104,7 @@ module.exports = app => {
   // Since this endpoint triggers a ton of GitHub API requests, there is a risk
   // of it being spammed; so it is not exposed through the info server.
   app.route('/admin').get('/check/:prNumber', async (req, res) => {
-    const pr = await github.getPullRequest(req.params.prNumber);
+    const pr = await sharedGithub.getPullRequest(req.params.prNumber);
     const {tree, changedFiles, reviewers} = await ownersBot.initPr(github, pr);
     const ownersCheck = new OwnersCheck(tree, changedFiles, reviewers);
 

--- a/owners/index.js
+++ b/owners/index.js
@@ -87,10 +87,7 @@ module.exports = app => {
     ],
     async context => {
       const {id, slug} = context.payload.team;
-      const team = new Team(id, GITHUB_REPO_OWNER, slug);
-
-      await team.fetchMembers(github);
-      ownersBot.teams[team.toString()] = team;
+      await ownersBot.syncTeam(new Team(id, GITHUB_REPO_OWNER, slug), github);
     }
   );
 

--- a/owners/index.js
+++ b/owners/index.js
@@ -22,7 +22,6 @@ const infoServer = require('./info_server');
 const {GitHub, PullRequest, Team} = require('./src/github');
 const {LocalRepository} = require('./src/repo');
 const {OwnersBot} = require('./src/owners_bot');
-const {OwnersParser} = require('./src/parser');
 const {OwnersCheck} = require('./src/owners_check');
 
 const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
@@ -41,6 +40,13 @@ module.exports = app => {
   );
   ownersBot.initTeams(sharedGithub);
 
+  /**
+   * Listen for webhooks and provide handlers with a GitHub interface and the
+   * event payload.
+   *
+   * @param {!string|string[]} events event or list of events to listen to.
+   * @param {!function} cb callback function.
+   */
   function listen(events, cb) {
     app.on(events, async context => {
       let github;
@@ -104,7 +110,7 @@ module.exports = app => {
     const ownersCheck = new OwnersCheck(
       ownersBot.treeParse.result,
       changedFiles,
-      reviewers,
+      reviewers
     );
 
     const {checkRun} = ownersCheck.run();

--- a/owners/index.js
+++ b/owners/index.js
@@ -39,7 +39,7 @@ module.exports = app => {
     GITHUB_REPO_NAME,
     app.log
   );
-  const teamsInitialized = ownersBot.initTeams(sharedGithub);
+  ownersBot.initTeams(sharedGithub);
 
   function listen(events, cb) {
     app.on(events, async context => {
@@ -92,7 +92,7 @@ module.exports = app => {
 
   if (process.env.NODE_ENV !== 'test') {
     teamsInitialized.then(() => {
-      infoServer(INFO_SERVER_PORT, ownersBot.parser, app.log);
+      infoServer(INFO_SERVER_PORT, ownersBot, app.log);
     });
   }
 

--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -24,22 +24,10 @@ const CACHED_TREE_REFRESH_MS = 10 * 60 * 1000;
  * Info server entrypoint.
  *
  * @param {number} port port to run the server on.
- * @param {!OwnersParser} parser owners file parser.
+ * @param {!OwnersBot} ownersBot owners bot instance.
  * @param {!Logger} logger logging interface.
  */
-module.exports = (port, parser, logger) => {
-  let treeParse = {result: {}, errors: []};
-
-  /** Updates the cached copy of the parsed ownership tree. */
-  function updateTree() {
-    app.log('Updating cached owners tree');
-    parser.parseOwnersTree().then(parse => {
-      treeParse = parse;
-    });
-  }
-  updateTree();
-  setInterval(updateTree, CACHED_TREE_REFRESH_MS);
-
+module.exports = (port, ownersBot, logger) => {
   const app = express();
   app.use(bodyParser.json());
 
@@ -54,15 +42,14 @@ module.exports = (port, parser, logger) => {
   });
 
   app.get('/tree', (req, res) => {
+    const {result, errors} = ownersBot.treeParse;
     const treeHeader = '<h3>OWNERS tree</h3>';
-    const treeDisplay = `<pre>${treeParse.result.toString()}</pre>`;
+    const treeDisplay = `<pre>${result.toString()}</pre>`;
 
     let output = `${treeHeader}${treeDisplay}`;
-    if (treeParse.errors.length) {
+    if (errors.length) {
       const errorHeader = '<h3>Parser Errors</h3>';
-      const errorDisplay = treeParse.errors
-        .map(error => error.toString())
-        .join('<br>');
+      const errorDisplay = errors.join('<br>');
       output += `${errorHeader}<code>${errorDisplay}</code>`;
     }
 
@@ -71,7 +58,7 @@ module.exports = (port, parser, logger) => {
 
   app.get('/teams', (req, res) => {
     const teamSections = [];
-    Object.entries(parser.teamMap).forEach(([name, team]) => {
+    Object.entries(ownersBot.teams).forEach(([name, team]) => {
       teamSections.push(
         [
           `Team "${name}" (ID: ${team.id}):`,

--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -18,7 +18,6 @@ const express = require('express');
 const bodyParser = require('body-parser');
 
 const GITHUB_REPO = process.env.GITHUB_REPO || 'ampproject/amphtml';
-const CACHED_TREE_REFRESH_MS = 10 * 60 * 1000;
 
 /**
  * Info server entrypoint.

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -73,6 +73,18 @@ class OwnersBot {
   }
 
   /**
+   * Update the owners tree.
+   *
+   * @param {!Logger=} logger logging interface
+   */
+  async refreshTree(logger) {
+    logger = logger || console;
+    await this.repo.checkout();
+    this.treeParse = await this.parser.parseOwnersTree();
+    this.treeParse.errors.forEach(logger.warn, logger);
+  }
+
+  /**
    * Fetch and initialize key data for running checks on PR.
    *
    * @param {!GitHub} github GitHub API interface.
@@ -83,12 +95,7 @@ class OwnersBot {
    * }} key structures needed to check PR ownership.
    */
   async initPr(github, pr) {
-    await this.repo.checkout();
-
-    this.treeParse = await this.parser.parseOwnersTree();
-    this.treeParse.errors.forEach(error => {
-      github.logger.warn(error);
-    });
+    await this.refreshTree(github.logger);
 
     const changedFiles = await github.listFiles(pr.number);
     const reviewers = await this._getCurrentReviewers(github, pr);

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -52,10 +52,20 @@ class OwnersBot {
   async initTeams(github) {
     const teamList = await github.getTeams();
     for (const team of teamList) {
-      await team.fetchMembers(github);
-      this.teams[team.toString()] = team;
+      await this.syncTeam(team, github);
       sleep(this.GITHUB_GET_MEMBERS_DELAY);
     }
+  }
+
+  /**
+   * Fetch or update a team's members.
+   *
+   * @param {!Team} team GitHub Team to update.
+   * @param {!GitHub} github GitHub API interface.
+   */
+  async syncTeam(team, github) {
+    await team.fetchMembers(github);
+    this.teams[team.toString()] = team;
   }
 
   /**

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -37,7 +37,7 @@ class OwnersBot {
     this.repo = repo;
     this.teams = {};
     this.parser = new OwnersParser(this.repo, this.teams);
-    this.treeParse = { errors: [], result: new OwnersTree() };
+    this.treeParse = {errors: [], result: new OwnersTree()};
 
     // Defined as a property, to allow overriding in tests.
     this.GITHUB_CHECKRUN_DELAY = GITHUB_CHECKRUN_DELAY;

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -35,6 +35,8 @@ class OwnersBot {
   constructor(repo) {
     this.repo = repo;
     this.teams = {};
+    this.parser = new OwnersParser(this.repo, this.teams);
+
     // Defined as a property, to allow overriding in tests.
     this.GITHUB_CHECKRUN_DELAY = GITHUB_CHECKRUN_DELAY;
     this.GITHUB_GET_MEMBERS_DELAY = GITHUB_GET_MEMBERS_DELAY;
@@ -82,8 +84,7 @@ class OwnersBot {
   async initPr(github, pr) {
     await this.repo.checkout();
 
-    const parser = new OwnersParser(this.repo, this.teams);
-    const treeParse = await parser.parseOwnersTree();
+    const treeParse = await this.parser.parseOwnersTree();
     treeParse.errors.forEach(error => {
       github.logger.warn(error);
     });

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -75,7 +75,7 @@ class OwnersBot {
   /**
    * Update the owners tree.
    *
-   * @param {!Logger=} logger logging interface
+   * @param {Logger=} logger logging interface
    */
   async refreshTree(logger) {
     logger = logger || console;

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -82,7 +82,7 @@ class OwnersBot {
   async initPr(github, pr) {
     await this.repo.checkout();
 
-    const parser = new OwnersParser(this.repo, this.teams, github.log);
+    const parser = new OwnersParser(this.repo, this.teams);
     const treeParse = await parser.parseOwnersTree();
     treeParse.errors.forEach(error => {
       github.logger.warn(error);

--- a/owners/src/parser.js
+++ b/owners/src/parser.js
@@ -65,12 +65,10 @@ class OwnersParser {
    *
    * @param {!Repository} repo local repository to read from.
    * @param {!Object<!string, !Team>} teamMap map from team slugs to teams.
-   * @param {!Logger=} logger logging interface (defaults to console).
    */
-  constructor(repo, teamMap, logger) {
+  constructor(repo, teamMap) {
     this.repo = repo;
     this.teamMap = teamMap;
-    this.logger = logger || console;
   }
 
   /**

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -111,7 +111,7 @@ describe('owners bot', () => {
       await ownersBot.syncTeam(myTeam, github);
 
       expect(ownersBot['ampproject/my_team']).toBe(myTeam);
-      expect(myTeam.members).toEqual(['rcebulko'])
+      expect(myTeam.members).toEqual(['rcebulko']);
     });
   });
 

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -46,12 +46,13 @@ describe('owners bot', () => {
     'open'
   );
   const repo = new LocalRepository('path/to/repo');
-  const ownersBot = new OwnersBot(repo);
+  let ownersBot;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     sandbox.stub(LocalRepository.prototype, 'checkout');
     sandbox.stub(LocalRepository.prototype, 'findOwnersFiles').returns([]);
+    ownersBot = new OwnersBot(repo);
     ownersBot.GITHUB_CHECKRUN_DELAY = 0;
     ownersBot.GITHUB_GET_MEMBERS_DELAY = 0;
   });
@@ -86,6 +87,31 @@ describe('owners bot', () => {
       sandbox.assert.calledWith(github.getTeamMembers, 1337);
       sandbox.assert.calledWith(github.getTeamMembers, 42);
       done();
+    });
+  });
+
+  describe('syncTeam', () => {
+    let myTeam;
+
+    beforeEach(() => {
+      myTeam = new Team(1337, 'ampproject', 'my_team');
+      sandbox.stub(GitHub.prototype, 'getTeamMembers').returns(['rcebulko']);
+    });
+
+    it('fetches members for the team', async done => {
+      await ownersBot.syncTeam(myTeam, github);
+      sandbox.assert.calledWith(github.getTeamMembers, 1337);
+      done();
+    });
+
+    it('updates the owners bot team map', async () => {
+      expect.assertions(3);
+      expect(ownersBot['ampproject/my_team']).toBeUndefined();
+
+      await ownersBot.syncTeam(myTeam, github);
+
+      expect(ownersBot['ampproject/my_team']).toBe(myTeam);
+      expect(myTeam.members).toEqual(['rcebulko'])
     });
   });
 

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -108,8 +108,9 @@ describe('owners bot', () => {
 
     it('parses the owners tree', async () => {
       expect.assertions(1);
-      const {tree} = await ownersBot.initPr(github, pr);
-      expect(tree).toBeInstanceOf(OwnersTree);
+      ownersBot.treeParse = null;
+      await ownersBot.initPr(github, pr);
+      expect(ownersBot.treeParse.result).toBeInstanceOf(OwnersTree);
     });
 
     it('warns about parsing errors', async done => {

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -115,6 +115,21 @@ describe('owners bot', () => {
     });
   });
 
+  describe('refreshTree', () => {
+    it('checks out the repository', async done => {
+      await ownersBot.refreshTree();
+      sandbox.assert.calledOnce(repo.checkout);
+      done();
+    });
+
+    it('parses the owners tree', async () => {
+      expect.assertions(1);
+      ownersBot.treeParse = null;
+      await ownersBot.refreshTree();
+      expect(ownersBot.treeParse.result).toBeInstanceOf(OwnersTree);
+    });
+  });
+
   describe('initPr', () => {
     beforeEach(() => {
       const timestamp = new Date('2019-01-02T00:00:00Z');
@@ -130,13 +145,6 @@ describe('owners bot', () => {
       sandbox
         .stub(GitHub.prototype, 'getReviewRequests')
         .returns(['requested']);
-    });
-
-    it('parses the owners tree', async () => {
-      expect.assertions(1);
-      ownersBot.treeParse = null;
-      await ownersBot.initPr(github, pr);
-      expect(ownersBot.treeParse.result).toBeInstanceOf(OwnersTree);
     });
 
     it('warns about parsing errors', async done => {

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -106,11 +106,11 @@ describe('owners bot', () => {
 
     it('updates the owners bot team map', async () => {
       expect.assertions(3);
-      expect(ownersBot['ampproject/my_team']).toBeUndefined();
+      expect(ownersBot.teams['ampproject/my_team']).toBeUndefined();
 
       await ownersBot.syncTeam(myTeam, github);
 
-      expect(ownersBot['ampproject/my_team']).toBe(myTeam);
+      expect(ownersBot.teams['ampproject/my_team']).toBe(myTeam);
       expect(myTeam.members).toEqual(['rcebulko']);
     });
   });


### PR DESCRIPTION
Part of step 4 of #540 

Removes some dead code, cleans up some code around the parser and owners bot, and hoists the owners tree into a shared property of the owners bot singleton.