### PR TITLE
[owners] Add Cloud Storage interface and caches

### DIFF
--- a/owners/example.env
+++ b/owners/example.env
@@ -2,9 +2,13 @@ NODE_ENV=production
 LOG_LEVEL=trace
 PORT=8080
 INFO_SERVER_PORT=8081
+APP_ID=12345
+
+CLOUD_STORAGE_BUCKET=owners-bot-storage
+# Credential file for service account with Storage Object Admin permissions
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/your-gcp-project-2b6c23ae50f1.json
 
 # Provided when creating a new GitHub App
-APP_ID=12345
 WEBHOOK_SECRET=secretsecretsecret
 # `> cat private-key-file.pem | base64 -w 0` to generate
 PRIVATE_KEY=...

--- a/owners/package-lock.json
+++ b/owners/package-lock.json
@@ -32,6 +32,124 @@
         }
       }
     },
+    "@google-cloud/common": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-2.2.3.tgz",
+      "integrity": "sha512-lvw54mGKn8VqVIy2NzAk0l5fntBFX4UwQhHk6HaqkyCQ7WBl5oz4XhzKMtMilozF/3ObPcDogqwuyEWyZ6rnQQ==",
+      "requires": {
+        "@google-cloud/projectify": "^1.0.0",
+        "@google-cloud/promisify": "^1.0.0",
+        "arrify": "^2.0.0",
+        "duplexify": "^3.6.0",
+        "ent": "^2.2.0",
+        "extend": "^3.0.2",
+        "google-auth-library": "^5.5.0",
+        "retry-request": "^4.0.0",
+        "teeny-request": "^5.2.1"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+        }
+      }
+    },
+    "@google-cloud/paginator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-2.0.1.tgz",
+      "integrity": "sha512-HZ6UTGY/gHGNriD7OCikYWL/Eu0sTEur2qqse2w6OVsz+57se3nTkqH14JIPxtf0vlEJ8IJN5w3BdZ22pjCB8g==",
+      "requires": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+        }
+      }
+    },
+    "@google-cloud/projectify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-1.0.1.tgz",
+      "integrity": "sha512-xknDOmsMgOYHksKc1GPbwDLsdej8aRNIA17SlSZgQdyrcC0lx0OGo4VZgYfwoEU1YS8oUxF9Y+6EzDOb0eB7Xg=="
+    },
+    "@google-cloud/promisify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-1.0.2.tgz",
+      "integrity": "sha512-7WfV4R/3YV5T30WRZW0lqmvZy9hE2/p9MvpI34WuKa2Wz62mLu5XplGTFEMK6uTbJCLWUxTcZ4J4IyClKucE5g=="
+    },
+    "@google-cloud/storage": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-4.0.0.tgz",
+      "integrity": "sha512-ZhMSvIrsyULJNGuhB3vK9VKxIh92W/sOjEezaxykKewB/NxK/d09cC1AfpwHFcnxN+ZZcy1fSLAIwfNAnKU+lA==",
+      "requires": {
+        "@google-cloud/common": "^2.1.1",
+        "@google-cloud/paginator": "^2.0.0",
+        "@google-cloud/promisify": "^1.0.0",
+        "arrify": "^2.0.0",
+        "compressible": "^2.0.12",
+        "concat-stream": "^2.0.0",
+        "date-and-time": "^0.10.0",
+        "duplexify": "^3.5.0",
+        "extend": "^3.0.2",
+        "gaxios": "^2.0.1",
+        "gcs-resumable-upload": "^2.2.4",
+        "hash-stream-validation": "^0.2.2",
+        "mime": "^2.2.0",
+        "mime-types": "^2.0.8",
+        "onetime": "^5.1.0",
+        "p-limit": "^2.2.0",
+        "pumpify": "^2.0.0",
+        "readable-stream": "^3.4.0",
+        "snakeize": "^0.1.0",
+        "stream-events": "^1.0.1",
+        "through2": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+        },
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "xdg-basedir": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+          "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
+        }
+      }
+    },
     "@octokit/rest": {
       "version": "15.18.3",
       "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.18.3.tgz",
@@ -118,6 +236,14 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "accepts": {
       "version": "1.3.7",
@@ -1012,6 +1138,11 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -1034,6 +1165,11 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
       "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg=="
+    },
+    "bignumber.js": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
     },
     "binary-extensions": {
       "version": "1.13.1",
@@ -1158,8 +1294,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "bunyan": {
       "version": "1.8.12",
@@ -1542,10 +1677,41 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "compressible": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
+      "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
+      "requires": {
+        "mime-db": ">= 1.40.0 < 2"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "configstore": {
       "version": "3.1.2",
@@ -1614,8 +1780,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -1696,6 +1861,11 @@
           }
         }
       }
+    },
+    "date-and-time": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.10.0.tgz",
+      "integrity": "sha512-IbIzxtvK80JZOVsWF6+NOjunTaoFVYxkAQoyzmflJyuRCJAJebehy48mPiCAedcGp4P7/UO3QYRWa0fe6INftg=="
     },
     "debug": {
       "version": "3.2.6",
@@ -1903,6 +2073,17 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1938,6 +2119,11 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "ent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -2046,6 +2232,11 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventsource": {
       "version": "1.0.7",
@@ -2177,8 +2368,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2233,6 +2423,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-text-encoding": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz",
+      "integrity": "sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ=="
     },
     "fb-watchman": {
       "version": "2.0.0",
@@ -2413,8 +2608,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2435,14 +2629,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2457,20 +2649,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2587,8 +2776,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2600,7 +2788,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2615,7 +2802,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2623,14 +2809,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2649,7 +2833,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2730,8 +2913,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2743,7 +2925,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2829,8 +3010,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2866,7 +3046,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2886,7 +3065,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2930,14 +3108,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2946,6 +3122,126 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "gaxios": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.1.0.tgz",
+      "integrity": "sha512-Gtpb5sdQmb82sgVkT2GnS2n+Kx4dlFwbeMYcDlD395aEvsLCSQXJJcHt7oJ2LrGxDEAeiOkK79Zv2A8Pzt6CFg==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^3.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.3.0"
+      },
+      "dependencies": {
+        "https-proxy-agent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.0.tgz",
+          "integrity": "sha512-y4jAxNEihqvBI5F3SaO2rtsjIOnnNA8sEbuiP+UhJZJHeM2NRm6c09ax2tgqme+SgUUvjao2fJXF4h3D6Cb2HQ==",
+          "requires": {
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        }
+      }
+    },
+    "gcp-metadata": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.2.0.tgz",
+      "integrity": "sha512-ympv+yQ6k5QuWCuwQqnGEvFGS7MBKdcQdj1i188v3bW9QLFIchTGaBCEZxSQapT0jffdn1vdt8oJhB5VBWQO1Q==",
+      "requires": {
+        "gaxios": "^2.0.1",
+        "json-bigint": "^0.3.0"
+      }
+    },
+    "gcs-resumable-upload": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-2.3.0.tgz",
+      "integrity": "sha512-PclXJiEngrVx0c4K0LfE1XOxhmOkBEy39Rrhspdn6jAbbwe4OQMZfjo7Z1LHBrh57+bNZeIN4M+BooYppCoHSg==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "configstore": "^5.0.0",
+        "gaxios": "^2.0.0",
+        "google-auth-library": "^5.0.0",
+        "pumpify": "^2.0.0",
+        "stream-events": "^1.0.4"
+      },
+      "dependencies": {
+        "configstore": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.0.tgz",
+          "integrity": "sha512-eE/hvMs7qw7DlcB5JPRnthmrITuHMmACUJAp89v6PT6iOqzoLS7HRWhBtuHMlhNHo2AhUSA/3Dh1bKNJHcublQ==",
+          "requires": {
+            "dot-prop": "^5.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^3.0.0",
+            "unique-string": "^2.0.0",
+            "write-file-atomic": "^3.0.0",
+            "xdg-basedir": "^4.0.0"
+          }
+        },
+        "crypto-random-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+          "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
+        },
+        "dot-prop": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.1.0.tgz",
+          "integrity": "sha512-n1oC6NBF+KM9oVXtjmen4Yo7HyAVWV2UUl50dCYJdw2924K6dX9bf9TTTWaKtYlRn0FEtxG27KS80ayVLixxJA==",
+          "requires": {
+            "is-obj": "^2.0.0"
+          }
+        },
+        "is-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+        },
+        "make-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+          "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "unique-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+          "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+          "requires": {
+            "crypto-random-string": "^2.0.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
+          "integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
+          }
+        },
+        "xdg-basedir": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+          "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
+        }
+      }
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -3029,6 +3325,49 @@
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
+    "google-auth-library": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.5.0.tgz",
+      "integrity": "sha512-TNeraw4miu6/FhO0jDrHiJuRx3SBrAhxHSPj7+rhif43bKE34UItXX9lejKxo3E8FNytuY4LIVIvpcqMQHSYZw==",
+      "requires": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^2.0.0",
+        "gcp-metadata": "^3.2.0",
+        "gtoken": "^4.1.0",
+        "jws": "^3.1.5",
+        "lru-cache": "^5.0.0"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        }
+      }
+    },
+    "google-p12-pem": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.2.tgz",
+      "integrity": "sha512-UfnEARfJKI6pbmC1hfFFm+UAcZxeIwTiEcHfqKe/drMsXD/ilnVjF7zgOGpHXyhuvX6jNJK3S8A0hOQjwtFxEw==",
+      "requires": {
+        "node-forge": "^0.9.0"
+      }
+    },
     "got": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
@@ -3066,6 +3405,24 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
+    },
+    "gtoken": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.0.tgz",
+      "integrity": "sha512-wqyn2gf5buzEZN4QNmmiiW2i2JkEdZnL7Z/9p44RtZqgt4077m4khRgAYNuu8cBwHWCc6MsP6eDUn/KkF6jFIw==",
+      "requires": {
+        "gaxios": "^2.0.0",
+        "google-p12-pem": "^2.0.0",
+        "jws": "^3.1.5",
+        "mime": "^2.2.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+        }
+      }
     },
     "handlebars": {
       "version": "4.0.14",
@@ -3192,6 +3549,30 @@
           "requires": {
             "is-buffer": "^1.1.5"
           }
+        }
+      }
+    },
+    "hash-stream-validation": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.2.tgz",
+      "integrity": "sha512-cMlva5CxWZOrlS/cY0C+9qAzesn5srhFA8IT1VPiHc9bWWBLkJfEUIZr7MWoi89oOOGmpg8ymchaOjiArsGu5A==",
+      "requires": {
+        "through2": "^2.0.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        },
+        "xtend": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         }
       }
     },
@@ -3338,8 +3719,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "inflight": {
       "version": "1.0.6",
@@ -3627,8 +4007,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -3651,8 +4030,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -4297,6 +4675,14 @@
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
+    "json-bigint": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.0.tgz",
+      "integrity": "sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=",
+      "requires": {
+        "bignumber.js": "^7.0.0"
+      }
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -4909,6 +5295,11 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
+    "node-forge": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+      "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5120,6 +5511,21 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+        }
       }
     },
     "optimist": {
@@ -5509,8 +5915,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "promise-events": {
       "version": "0.1.6",
@@ -5566,6 +5971,39 @@
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "requires": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
+      },
+      "dependencies": {
+        "duplexify": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
+          "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+          "requires": {
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "punycode": {
@@ -5750,7 +6188,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -6267,6 +6704,25 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
+    },
+    "retry-request": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.1.1.tgz",
+      "integrity": "sha512-BINDzVtLI2BDukjWmjAIRZ0oglnCAkpP2vQjM3jdLhmT62h0xnQgciPwBRDAvHqpkPT2Wo1XuUyLyn6nbGrZQQ==",
+      "requires": {
+        "debug": "^4.1.1",
+        "through2": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "rimraf": {
       "version": "2.4.5",
@@ -6809,6 +7265,11 @@
         "validator": "^10.4.0"
       }
     },
+    "snakeize": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
+      "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -7085,6 +7546,19 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "requires": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -7109,7 +7583,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -7147,6 +7620,11 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
+    },
     "superagent": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
@@ -7178,6 +7656,29 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "teeny-request": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-5.3.0.tgz",
+      "integrity": "sha512-sN9E3JvEBe2CFqB/jpJpw1erWD1C7MxyYCxogHFCQSyZfkHYcdf4wzVQSw7FZxbwcfnS+FP0W9BS0mp6SEOKjg==",
+      "requires": {
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^3.0.0",
+        "node-fetch": "^2.2.0",
+        "stream-events": "^1.0.5",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "https-proxy-agent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.0.tgz",
+          "integrity": "sha512-y4jAxNEihqvBI5F3SaO2rtsjIOnnNA8sEbuiP+UhJZJHeM2NRm6c09ax2tgqme+SgUUvjao2fJXF4h3D6Cb2HQ==",
+          "requires": {
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
+          }
+        }
+      }
     },
     "term-size": {
       "version": "1.2.0",
@@ -7250,6 +7751,14 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
+    },
+    "through2": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+      "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+      "requires": {
+        "readable-stream": "2 || 3"
+      }
     },
     "timed-out": {
       "version": "4.0.1",
@@ -7386,6 +7895,19 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
       }
     },
     "uglify-js": {
@@ -7587,8 +8109,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",

--- a/owners/package.json
+++ b/owners/package.json
@@ -16,6 +16,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@google-cloud/storage": "4.0.0",
     "express": "4.17.1",
     "json5": "2.1.1",
     "minimatch": "3.0.4",

--- a/owners/src/cloud_storage.js
+++ b/owners/src/cloud_storage.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2019 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {Storage} = require('@google-cloud/storage');
+
+/**
+ * Google Cloud Storage interface for uploading and downloading files.
+ */
+class CloudStorage {
+  /**
+   * Constructor.
+   *
+   * @param {string} bucketName Cloud Storage bucket name.
+   */
+  constructor(bucketName) {
+    this.storage = new Storage();
+    this.bucketName = bucketName;
+  }
+
+  /**
+   * Get a reference to a file in storage.
+   *
+   * @param {string} filename file to access.
+   * @return {File} reference to a Cloud Storage file.
+   */
+  file(filename) {
+    return this.storage.bucket(this.bucketName).file(filename);
+  }
+
+  /**
+   * Write a file to storage.
+   *
+   * @param {string} filename file to write.
+   * @param {string} contents file contents.
+   */
+  async upload(filename, contents) {
+    await this.file(filename).save(contents, {resumable: false});
+  }
+
+  /**
+   * Read a file from storage.
+   *
+   * @param {string} filename file to download.
+   * @return {string} file contents.
+   */
+  async download(filename) {
+    const [contents] = await this.file(filename).download();
+    return contents.toString('utf8');
+  }
+
+  /**
+   * Delete a file in storage.
+   *
+   * @param {string} filename file to delete.
+   */
+  async delete(filename) {
+    await this.file(filename).delete();
+  }
+}
+
+module.exports = {CloudStorage};

--- a/owners/src/cloud_storage.js
+++ b/owners/src/cloud_storage.js
@@ -71,45 +71,4 @@ class CloudStorage {
   }
 }
 
-/**
- * A Cloud Storage-backed cache.
- */
-class CloudStorageCache {
-  /**
-   * Constructor.
-   *
-   * @param {string} bucketName Cloud Storage bucket name.
-   */
-  constructor(bucketName) {
-    this.storage = new CloudStorage(bucketName);
-  }
-
-  /**
-   * Fetch the contents of a file.
-   *
-   * @param {string} filename file to get contents of.
-   * @param {string} getContents function to get contents if file not in cache.
-   * @return {string} file contents.
-   */
-  async readFile(filename, getContents) {
-    try {
-      return await this.storage.download(filename);
-    } catch (e) {
-      const contents = getContents();
-      // Do not `await`` the upload; this can happen async in the background.
-      this.storage.upload(filename, contents);
-      return contents;
-    };
-  }
-
-  /**
-   * Invalidate the cache for a file.
-   *
-   * @param {string} filename file to drop from the cache.
-   */
-  async invalidate(filename) {
-    await this.storage.delete(filename);
-  }
-}
-
-module.exports = {CloudStorage, CloudStorageCache};
+module.exports = {CloudStorage};

--- a/owners/src/cloud_storage.js
+++ b/owners/src/cloud_storage.js
@@ -71,4 +71,45 @@ class CloudStorage {
   }
 }
 
-module.exports = {CloudStorage};
+/**
+ * A Cloud Storage-backed cache.
+ */
+class CloudStorageCache {
+  /**
+   * Constructor.
+   *
+   * @param {string} bucketName Cloud Storage bucket name.
+   */
+  constructor(bucketName) {
+    this.storage = new CloudStorage(bucketName);
+  }
+
+  /**
+   * Fetch the contents of a file.
+   *
+   * @param {string} filename file to get contents of.
+   * @param {string} getContents function to get contents if file not in cache.
+   * @return {string} file contents.
+   */
+  async readFile(filename, getContents) {
+    try {
+      return await this.storage.download(filename);
+    } catch (e) {
+      const contents = getContents();
+      // Do not `await`` the upload; this can happen async in the background.
+      this.storage.upload(filename, contents);
+      return contents;
+    };
+  }
+
+  /**
+   * Invalidate the cache for a file.
+   *
+   * @param {string} filename file to drop from the cache.
+   */
+  async invalidate(filename) {
+    await this.storage.delete(filename);
+  }
+}
+
+module.exports = {CloudStorage, CloudStorageCache};

--- a/owners/src/file_cache.js
+++ b/owners/src/file_cache.js
@@ -42,7 +42,9 @@ class CloudStorageCache {
     } catch (e) {
       const contents = await getContents();
       // Do not `await`` the upload; this can happen async in the background.
-      this.storage.upload(filename, contents);
+      this.storage.upload(filename, contents).catch(err =>
+        console.error(`Error uploading "${filename}": `, err)
+      );
       return contents;
     }
   }

--- a/owners/src/file_cache.js
+++ b/owners/src/file_cache.js
@@ -42,9 +42,9 @@ class CloudStorageCache {
     } catch (e) {
       const contents = await getContents();
       // Do not `await`` the upload; this can happen async in the background.
-      this.storage.upload(filename, contents).catch(err =>
-        console.error(`Error uploading "${filename}": `, err)
-      );
+      this.storage
+        .upload(filename, contents)
+        .catch(err => console.error(`Error uploading "${filename}": `, err));
       return contents;
     }
   }

--- a/owners/src/file_cache.js
+++ b/owners/src/file_cache.js
@@ -91,7 +91,7 @@ class MemoryCache {
    * @param {string} filename file to drop from the cache.
    */
   async invalidate(filename) {
-    delete this.files.delete(filename);
+    this.files.delete(filename);
   }
 }
 

--- a/owners/src/file_cache.js
+++ b/owners/src/file_cache.js
@@ -44,7 +44,7 @@ class CloudStorageCache {
       // Do not `await`` the upload; this can happen async in the background.
       this.storage.upload(filename, contents);
       return contents;
-    };
+    }
   }
 
   /**
@@ -64,7 +64,7 @@ class MemoryCache {
   /**
    * Constructor.
    */
-  constructor(bucketName) {
+  constructor() {
     this.files = new Map();
   }
 

--- a/owners/src/file_cache.js
+++ b/owners/src/file_cache.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2019 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {CloudStorage} = require('./cloud_storage');
+
+/**
+ * A Cloud Storage-backed cache.
+ */
+class CloudStorageCache {
+  /**
+   * Constructor.
+   *
+   * @param {string} bucketName Cloud Storage bucket name.
+   */
+  constructor(bucketName) {
+    this.storage = new CloudStorage(bucketName);
+  }
+
+  /**
+   * Fetch the contents of a file.
+   *
+   * @param {string} filename file to get contents of.
+   * @param {string} getContents function to get contents if file not in cache.
+   * @return {string} file contents.
+   */
+  async readFile(filename, getContents) {
+    try {
+      return await this.storage.download(filename);
+    } catch (e) {
+      const contents = getContents();
+      // Do not `await`` the upload; this can happen async in the background.
+      this.storage.upload(filename, contents);
+      return contents;
+    };
+  }
+
+  /**
+   * Invalidate the cache for a file.
+   *
+   * @param {string} filename file to drop from the cache.
+   */
+  async invalidate(filename) {
+    await this.storage.delete(filename);
+  }
+}
+
+module.exports = {CloudStorageCache};

--- a/owners/test/cloud_storage.test.js
+++ b/owners/test/cloud_storage.test.js
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-const nock = require('nock');
 const sinon = require('sinon');
 
-const {CloudStorage, CloudStorageCache} = require('../src/cloud_storage');
+const {CloudStorage} = require('../src/cloud_storage');
 
 describe('cloud storage', () => {
   let sandbox;
@@ -81,78 +80,6 @@ describe('cloud storage', () => {
         sandbox.assert.calledOnce(fileStub.delete);
         done();
       });
-    });
-  });
-});
-
-describe('cloud storage cache', () => {
-  let sandbox;
-  let cache;
-  let fileStub;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    cache = new CloudStorageCache('my-storage-bucket')
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
-  describe('readFile', () => {
-    describe('when the file is in the cache', () => {
-      beforeEach(() => {
-        sandbox.stub(CloudStorage.prototype, 'download').returns(
-          'OWNERS file contents'
-        );
-      });
-
-      it('downloads and returns the file contents', async () => {
-        const contents = await cache.readFile('foo/OWNERS');
-
-        expect(contents).toEqual('OWNERS file contents');
-        sandbox.assert.calledWith(cache.storage.download, 'foo/OWNERS');
-      });
-    });
-
-    describe('when the file is not in the cache', () => {
-      const getContents = sinon.spy(() => 'OWNERS file contents');
-
-      beforeEach(() => {
-        sandbox.stub(CloudStorage.prototype, 'download').returns(
-          Promise.reject('Not found!')
-        );
-        sandbox.stub(CloudStorage.prototype, 'upload');
-      });
-
-      it('calls the provided method to get the file contents', async () => {
-        expect.assertions(1);
-        const contents = await cache.readFile('foo/OWNERS', getContents);
-
-        expect(contents).toEqual('OWNERS file contents');
-        sandbox.assert.calledOnce(getContents);
-      });
-
-      it('saves the contents to the cache', async done => {
-        await cache.readFile('foo/OWNERS', getContents);
-
-        sandbox.assert.calledWith(
-          cache.storage.upload,
-          'foo/OWNERS',
-          'OWNERS file contents',
-        );
-        done();
-      });
-    });
-  });
-
-  describe('invalidate', () => {
-    it('deletes the invalidated file cache from storage', async done => {
-      sinon.stub(CloudStorage.prototype, 'delete');
-      await cache.invalidate('foo/OWNERS');
-
-      sandbox.assert.calledWith(cache.storage.delete, 'foo/OWNERS');
-      done();
     });
   });
 });

--- a/owners/test/cloud_storage.test.js
+++ b/owners/test/cloud_storage.test.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2019 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const nock = require('nock');
+const sinon = require('sinon');
+
+const {CloudStorage} = require('../src/cloud_storage');
+
+describe('cloud storage', () => {
+  let sandbox;
+  let storage;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    storage = new CloudStorage('my-storage-bucket');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('file', () => {
+    it('provides a reference to a file in the storage bucket', () => {
+      const file = storage.file('foo/OWNERS');
+
+      expect(file.name).toEqual('foo/OWNERS');
+      expect(file.bucket.name).toEqual('my-storage-bucket');
+    });
+  });
+
+  describe('file operations', () => {
+    let fileStub;
+
+    beforeEach(() => {
+      fileStub = sinon.stub(storage.file('foo/OWNERS'));
+      sandbox.stub(CloudStorage.prototype, 'file').returns(fileStub);
+    });
+
+    describe('download', () => {
+      it('downloads the file contents as a string', async () => {
+        expect.assertions(1);
+        fileStub.download.returns(['OWNERS file contents']);
+        const contents = await storage.download('foo/OWNERS');
+
+        expect(contents).toEqual('OWNERS file contents');
+        sandbox.assert.calledWith(storage.file, 'foo/OWNERS');
+        sandbox.assert.calledOnce(fileStub.download);
+      });
+    });
+
+    describe('upload', () => {
+      it('saves the file contents', async done => {
+        await storage.upload('foo/OWNERS', 'OWNERS file contents');
+
+        sandbox.assert.calledWith(storage.file, 'foo/OWNERS');
+        sandbox.assert.calledWith(fileStub.save, 'OWNERS file contents', {
+          resumable: false,
+        });
+        done();
+      });
+    });
+
+    describe('delete', () => {
+      it('deletes the requested file', async done => {
+        await storage.delete('foo/OWNERS');
+
+        sandbox.assert.calledWith(storage.file, 'foo/OWNERS');
+        sandbox.assert.calledOnce(fileStub.delete);
+        done();
+      });
+    });
+  });
+});

--- a/owners/test/file_cache.test.js
+++ b/owners/test/file_cache.test.js
@@ -70,7 +70,7 @@ describe('file caches', () => {
         beforeEach(() => {
           sandbox
             .stub(CloudStorage.prototype, 'download')
-            .returns(Promise.reject('Not found!'));
+            .returns(Promise.reject(new Error('Not found!')));
           sandbox.stub(CloudStorage.prototype, 'upload');
         });
 
@@ -219,7 +219,7 @@ describe('file caches', () => {
             sandbox.stub(CloudStorage.prototype, 'upload');
             sandbox
               .stub(CloudStorage.prototype, 'download')
-              .returns(Promise.reject('Not found!'));
+              .returns(Promise.reject(new Error('Not found!')));
           });
 
           it('returns the file contents', async () => {

--- a/owners/test/file_cache.test.js
+++ b/owners/test/file_cache.test.js
@@ -39,15 +39,15 @@ describe('file caches', () => {
     let cache;
 
     beforeEach(() => {
-      cache = new CloudStorageCache('my-storage-bucket')
+      cache = new CloudStorageCache('my-storage-bucket');
     });
 
     describe('readFile', () => {
       describe('when the file is in the cache', () => {
         beforeEach(() => {
-          sandbox.stub(CloudStorage.prototype, 'download').returns(
-            'OWNERS file contents'
-          );
+          sandbox
+            .stub(CloudStorage.prototype, 'download')
+            .returns('OWNERS file contents');
         });
 
         it('downloads and returns the file contents', async () => {
@@ -68,9 +68,9 @@ describe('file caches', () => {
         const getContents = sinon.spy(async () => 'OWNERS file contents');
 
         beforeEach(() => {
-          sandbox.stub(CloudStorage.prototype, 'download').returns(
-            Promise.reject('Not found!')
-          );
+          sandbox
+            .stub(CloudStorage.prototype, 'download')
+            .returns(Promise.reject('Not found!'));
           sandbox.stub(CloudStorage.prototype, 'upload');
         });
 
@@ -88,7 +88,7 @@ describe('file caches', () => {
           sandbox.assert.calledWith(
             cache.storage.upload,
             'foo/OWNERS',
-            'OWNERS file contents',
+            'OWNERS file contents'
           );
           done();
         });
@@ -152,7 +152,7 @@ describe('file caches', () => {
     describe('invalidate', () => {
       it('deletes the invalidated file cache from memory', async () => {
         expect.assertions(1);
-        cache.files.set('foo/OWNERS', 'outdated file contents')
+        cache.files.set('foo/OWNERS', 'outdated file contents');
         await cache.invalidate('foo/OWNERS');
 
         expect(cache.files.has('foo/OWNERS')).toBe(false);
@@ -188,9 +188,9 @@ describe('file caches', () => {
       describe('when the file is not in the memory cache', () => {
         describe('when the file is in the Cloud Storage cache', async () => {
           beforeEach(() => {
-            sandbox.stub(CloudStorage.prototype, 'download').returns(
-              'OWNERS file contents'
-            );
+            sandbox
+              .stub(CloudStorage.prototype, 'download')
+              .returns('OWNERS file contents');
           });
 
           it('returns the file contents', async () => {
@@ -217,9 +217,9 @@ describe('file caches', () => {
         describe('when the file is not in the Cloud Storage cache', async () => {
           beforeEach(() => {
             sandbox.stub(CloudStorage.prototype, 'upload');
-            sandbox.stub(CloudStorage.prototype, 'download').returns(
-              Promise.reject('Not found!')
-            );
+            sandbox
+              .stub(CloudStorage.prototype, 'download')
+              .returns(Promise.reject('Not found!'));
           });
 
           it('returns the file contents', async () => {
@@ -248,7 +248,7 @@ describe('file caches', () => {
             sandbox.assert.calledWith(
               cache.cloudStorageCache.storage.upload,
               'foo/OWNERS',
-              'OWNERS file contents',
+              'OWNERS file contents'
             );
             done();
           });
@@ -266,7 +266,7 @@ describe('file caches', () => {
         await cache.invalidate('foo/OWNERS');
         sandbox.assert.calledWith(
           MemoryCache.prototype.invalidate,
-          'foo/OWNERS',
+          'foo/OWNERS'
         );
         done();
       });
@@ -275,7 +275,7 @@ describe('file caches', () => {
         await cache.invalidate('foo/OWNERS');
         sandbox.assert.calledWith(
           CloudStorageCache.prototype.invalidate,
-          'foo/OWNERS',
+          'foo/OWNERS'
         );
         done();
       });

--- a/owners/test/file_cache.test.js
+++ b/owners/test/file_cache.test.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2019 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const sinon = require('sinon');
+
+const {CloudStorage} = require('../src/cloud_storage');
+const {CloudStorageCache} = require('../src/file_cache');
+
+describe('cloud storage cache', () => {
+  let sandbox;
+  let cache;
+  let fileStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    cache = new CloudStorageCache('my-storage-bucket')
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('readFile', () => {
+    describe('when the file is in the cache', () => {
+      beforeEach(() => {
+        sandbox.stub(CloudStorage.prototype, 'download').returns(
+          'OWNERS file contents'
+        );
+      });
+
+      it('downloads and returns the file contents', async () => {
+        const contents = await cache.readFile('foo/OWNERS');
+
+        expect(contents).toEqual('OWNERS file contents');
+        sandbox.assert.calledWith(cache.storage.download, 'foo/OWNERS');
+      });
+    });
+
+    describe('when the file is not in the cache', () => {
+      const getContents = sinon.spy(() => 'OWNERS file contents');
+
+      beforeEach(() => {
+        sandbox.stub(CloudStorage.prototype, 'download').returns(
+          Promise.reject('Not found!')
+        );
+        sandbox.stub(CloudStorage.prototype, 'upload');
+      });
+
+      it('calls the provided method to get the file contents', async () => {
+        expect.assertions(1);
+        const contents = await cache.readFile('foo/OWNERS', getContents);
+
+        expect(contents).toEqual('OWNERS file contents');
+        sandbox.assert.calledOnce(getContents);
+      });
+
+      it('saves the contents to the cache', async done => {
+        await cache.readFile('foo/OWNERS', getContents);
+
+        sandbox.assert.calledWith(
+          cache.storage.upload,
+          'foo/OWNERS',
+          'OWNERS file contents',
+        );
+        done();
+      });
+    });
+  });
+
+  describe('invalidate', () => {
+    it('deletes the invalidated file cache from storage', async done => {
+      sinon.stub(CloudStorage.prototype, 'delete');
+      await cache.invalidate('foo/OWNERS');
+
+      sandbox.assert.calledWith(cache.storage.delete, 'foo/OWNERS');
+      done();
+    });
+  });
+});

--- a/owners/test/file_cache.test.js
+++ b/owners/test/file_cache.test.js
@@ -71,7 +71,7 @@ describe('file caches', () => {
           sandbox
             .stub(CloudStorage.prototype, 'download')
             .returns(Promise.reject(new Error('Not found!')));
-          sandbox.stub(CloudStorage.prototype, 'upload');
+          sandbox.stub(CloudStorage.prototype, 'upload').resolves();
         });
 
         it('calls the provided method to get the file contents', async () => {
@@ -216,7 +216,7 @@ describe('file caches', () => {
 
         describe('when the file is not in the Cloud Storage cache', async () => {
           beforeEach(() => {
-            sandbox.stub(CloudStorage.prototype, 'upload');
+            sandbox.stub(CloudStorage.prototype, 'upload').resolves();
             sandbox
               .stub(CloudStorage.prototype, 'download')
               .returns(Promise.reject(new Error('Not found!')));


### PR DESCRIPTION
This PR:
- adds a Cloud Storage API interface to upload, download, and delete files
- adds a Cloud Storage cache layer which tries to download from the cache before executing the provided function
- adds a memory cache which keeps a local copy of file contents
- adds a compound cache which first checks the memory cache, then the cloud storage cache
- includes tests

For a high-level view of what each class in this PR does, see the Jest output below:
```
 PASS  test/cloud_storage.test.js
  cloud storage
    file
      ✓ provides a reference to a file in the storage bucket (5ms)
    file operations
      download
        ✓ downloads the file contents as a string (17ms)
      upload
        ✓ saves the file contents (9ms)
      delete
        ✓ deletes the requested file (8ms)

 PASS  test/file_cache.test.js
  file caches
    Cloud Storage-backed
      readFile
        when the file is in the cache
          ✓ downloads and returns the file contents (10ms)
          ✓ does not get the contents from the provided method (1ms)
        when the file is not in the cache
          ✓ calls the provided method to get the file contents (3ms)
          ✓ saves the contents to the cache (1ms)
      invalidate
        ✓ deletes the invalidated file cache from storage (1ms)
    memory-backed
      readFile
        when the file is in the cache
          ✓ returns the file contents (1ms)
          ✓ does not get the contents from the provided method
        when the file is not in the cache
          ✓ calls the provided method to get the file contents (1ms)
          ✓ saves the contents to the cache
      invalidate
        ✓ deletes the invalidated file cache from memory (1ms)
    compound
      readFile
        when the file is in the memory cache
          ✓ returns the file contents (1ms)
          ✓ does not get the contents from the provided method
        when the file is not in the memory cache
          when the file is in the Cloud Storage cache
            ✓ returns the file contents (1ms)
            ✓ does not get the contents from the provided method
            ✓ saves the contents to the memory cache (1ms)
          when the file is not in the Cloud Storage cache
            ✓ returns the file contents (1ms)
            ✓ calls the provided method to get the file contents (1ms)
            ✓ saves the contents to the memory cache (4ms)
            ✓ saves the contents to the Cloud Storage cache (1ms)
      invalidate
        ✓ invalidates the memory cache (1ms)
        ✓ invalidates the Cloud Storage cache (1ms)
```

For #540 