### PR TITLE
[owners] Remove dependency on Probot when testing GitHub API

### DIFF
--- a/owners/src/github.js
+++ b/owners/src/github.js
@@ -139,10 +139,10 @@ class GitHub {
    *     https://probot.github.io/api/latest/interfaces/githubapi.html).
    * @param {string} owner GitHub repository owner.
    * @param {string} repository GitHub repository name.
-   * @param {!Logger} logger logging interface.
+   * @param {Logger=} [logger=console] logging interface.
    */
   constructor(client, owner, repository, logger) {
-    Object.assign(this, {client, owner, repository, logger});
+    Object.assign(this, {client, owner, repository, logger: logger || console});
   }
 
   /**

--- a/owners/test/github.test.js
+++ b/owners/test/github.test.js
@@ -116,7 +116,7 @@ describe('team', () => {
 describe('GitHub API', () => {
   let probot;
   let app;
-  let sandbox = sinon.createSandbox();
+  const sandbox = sinon.createSandbox();
   let githubClient;
   let github;
 
@@ -445,7 +445,8 @@ describe('GitHub API', () => {
       await github.createReviewRequests(24574, ['reviewer']);
     });
 
-    it('skips the API call if no usernames are provided', async done => {      // This will fail if it attempts to make an un-nocked network request.
+    it('skips the API call if no usernames are provided', async done => {
+      // This will fail if it attempts to make an un-nocked network request.
       await github.createReviewRequests(24574, []);
 
       done();

--- a/owners/test/github.test.js
+++ b/owners/test/github.test.js
@@ -279,12 +279,9 @@ describe('GitHub API', () => {
       nock('https://api.github.com')
         .get('/teams/1337/members?page=1&per_page=100')
         .reply(200, [{login: 'rcebulko'}, {login: 'erwinmombay'}]);
+      const members = await github.getTeamMembers(1337);
 
-      await withContext(async (context, github) => {
-        const members = await github.getTeamMembers(1337);
-
-        expect(members).toEqual(['rcebulko', 'erwinmombay']);
-      })();
+      expect(members).toEqual(['rcebulko', 'erwinmombay']);
     });
 
     it('pages automatically', async () => {
@@ -297,12 +294,9 @@ describe('GitHub API', () => {
       nock('https://api.github.com')
         .get('/teams/1337/members?page=2&per_page=100')
         .reply(200, manyTeamsResponsePage2);
+      const members = await github.getTeamMembers(1337);
 
-      await withContext(async (context, github) => {
-        const members = await github.getTeamMembers(1337);
-
-        expect(members.length).toEqual(40);
-      })();
+      expect(members.length).toEqual(40);
     });
   });
 
@@ -312,14 +306,11 @@ describe('GitHub API', () => {
       nock('https://api.github.com')
         .get('/repos/test_owner/test_repo/pulls/35')
         .reply(200, pullRequestResponse);
+      const pr = await github.getPullRequest(35);
 
-      await withContext(async (context, github) => {
-        const pr = await github.getPullRequest(35);
-
-        // Author pulled from pull_request.35.json
-        expect(pr.author).toEqual('ampprojectbot');
-        expect(pr.number).toEqual(35);
-      })();
+      // Author pulled from pull_request.35.json
+      expect(pr.author).toEqual('ampprojectbot');
+      expect(pr.number).toEqual(35);
     });
   });
 
@@ -329,14 +320,11 @@ describe('GitHub API', () => {
       nock('https://api.github.com')
         .get('/repos/test_owner/test_repo/pulls/35/reviews?page=1&per_page=100')
         .reply(200, reviewsApprovedResponse);
+      const [review] = await github.getReviews(35);
 
-      await withContext(async (context, github) => {
-        const [review] = await github.getReviews(35);
-
-        expect(review.reviewer).toEqual('erwinmombay');
-        expect(review.isApproved).toBe(true);
-        expect(review.submittedAt).toEqual(new Date('2019-02-26T20:39:13Z'));
-      })();
+      expect(review.reviewer).toEqual('erwinmombay');
+      expect(review.isApproved).toBe(true);
+      expect(review.submittedAt).toEqual(new Date('2019-02-26T20:39:13Z'));
     });
 
     it('pages automatically', async () => {
@@ -353,12 +341,9 @@ describe('GitHub API', () => {
           '/repos/test_owner/test_repo/pulls/23928/reviews?page=2&per_page=100'
         )
         .reply(200, manyReviewsPage2Response);
+      const reviews = await github.getReviews(23928);
 
-      await withContext(async (context, github) => {
-        const reviews = await github.getReviews(23928);
-
-        expect(reviews.length).toEqual(42);
-      })();
+      expect(reviews.length).toEqual(42);
     });
 
     it('returns approvals', async () => {
@@ -368,14 +353,11 @@ describe('GitHub API', () => {
           '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
         )
         .reply(200, commentReviewsResponse);
+      const reviews = await github.getReviews(24686);
+      const review = reviews[0];
 
-      await withContext(async (context, github) => {
-        const reviews = await github.getReviews(24686);
-        const review = reviews[0];
-
-        expect(review.reviewer).toEqual('rsimha');
-        expect(review.isApproved).toBe(true);
-      })();
+      expect(review.reviewer).toEqual('rsimha');
+      expect(review.isApproved).toBe(true);
     });
 
     it('returns post-review comments', async () => {
@@ -385,14 +367,11 @@ describe('GitHub API', () => {
           '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
         )
         .reply(200, commentReviewsResponse);
+      const reviews = await github.getReviews(24686);
+      const review = reviews[1];
 
-      await withContext(async (context, github) => {
-        const reviews = await github.getReviews(24686);
-        const review = reviews[1];
-
-        expect(review.reviewer).toEqual('rsimha');
-        expect(review.isComment).toBe(true);
-      })();
+      expect(review.reviewer).toEqual('rsimha');
+      expect(review.isComment).toBe(true);
     });
 
     it('returns pre-review comments', async () => {
@@ -402,14 +381,11 @@ describe('GitHub API', () => {
           '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
         )
         .reply(200, commentReviewsResponse);
+      const reviews = await github.getReviews(24686);
+      const review = reviews[2];
 
-      await withContext(async (context, github) => {
-        const reviews = await github.getReviews(24686);
-        const review = reviews[2];
-
-        expect(review.reviewer).toEqual('estherkim');
-        expect(review.isComment).toBe(true);
-      })();
+      expect(review.reviewer).toEqual('estherkim');
+      expect(review.isComment).toBe(true);
     });
 
     it('returns rejections', async () => {
@@ -419,14 +395,11 @@ describe('GitHub API', () => {
           '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
         )
         .reply(200, commentReviewsResponse);
+      const reviews = await github.getReviews(24686);
+      const review = reviews[3];
 
-      await withContext(async (context, github) => {
-        const reviews = await github.getReviews(24686);
-        const review = reviews[3];
-
-        expect(review.reviewer).toEqual('estherkim');
-        expect(review.isRejected).toBe(true);
-      })();
+      expect(review.reviewer).toEqual('estherkim');
+      expect(review.isRejected).toBe(true);
     });
 
     it('returns comment-only reviews', async () => {
@@ -436,14 +409,11 @@ describe('GitHub API', () => {
           '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
         )
         .reply(200, commentReviewsResponse);
+      const reviews = await github.getReviews(24686);
+      const review = reviews[4];
 
-      await withContext(async (context, github) => {
-        const reviews = await github.getReviews(24686);
-        const review = reviews[4];
-
-        expect(review.reviewer).toEqual('rcebulko');
-        expect(review.isComment).toBe(true);
-      })();
+      expect(review.reviewer).toEqual('rcebulko');
+      expect(review.isComment).toBe(true);
     });
 
     it('ignores irrelevant review states', async () => {
@@ -453,13 +423,10 @@ describe('GitHub API', () => {
           '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
         )
         .reply(200, commentReviewsResponse);
+      const reviews = await github.getReviews(24686);
+      const review = reviews[5];
 
-      await withContext(async (context, github) => {
-        const reviews = await github.getReviews(24686);
-        const review = reviews[5];
-
-        expect(review).toBeUndefined();
-      })();
+      expect(review).toBeUndefined();
     });
   });
 
@@ -475,19 +442,13 @@ describe('GitHub API', () => {
           }
         )
         .reply(200);
-
-      await withContext(async (context, github) => {
-        await github.createReviewRequests(24574, ['reviewer']);
-      })();
+      await github.createReviewRequests(24574, ['reviewer']);
     });
 
-    it('skips the API call if no usernames are provided', async done => {
-      await withContext(async (context, github) => {
-        // This will fail if it attempts to make an un-nocked network request.
-        await github.createReviewRequests(24574, []);
+    it('skips the API call if no usernames are provided', async done => {      // This will fail if it attempts to make an un-nocked network request.
+      await github.createReviewRequests(24574, []);
 
-        done();
-      })();
+      done();
     });
   });
 
@@ -497,12 +458,9 @@ describe('GitHub API', () => {
       nock('https://api.github.com')
         .get('/repos/test_owner/test_repo/pulls/24574/requested_reviewers')
         .reply(200, requestedReviewsResponse);
+      const reviewers = await github.getReviewRequests(24574);
 
-      await withContext(async (context, github) => {
-        const reviewers = await github.getReviewRequests(24574);
-
-        expect(reviewers).toEqual(['jridgewell', 'jpettitt', 'sparhami']);
-      })();
+      expect(reviewers).toEqual(['jridgewell', 'jpettitt', 'sparhami']);
     });
   });
 
@@ -515,17 +473,14 @@ describe('GitHub API', () => {
       nock('https://api.github.com')
         .get('/repos/test_owner/test_repo/issues/24574/comments')
         .reply(200, issueCommentsResponse);
+      const comments = await github.getBotComments(24574);
 
-      await withContext(async (context, github) => {
-        const comments = await github.getBotComments(24574);
-
-        expect(comments).toEqual([
-          {
-            id: 532484354,
-            body: 'Test comment by ampprojectbot',
-          },
-        ]);
-      })();
+      expect(comments).toEqual([
+        {
+          id: 532484354,
+          body: 'Test comment by ampprojectbot',
+        },
+      ]);
     });
   });
 
@@ -538,10 +493,7 @@ describe('GitHub API', () => {
           return true;
         })
         .reply(200);
-
-      await withContext(async (context, github) => {
-        await github.createBotComment(24574, 'test comment');
-      })();
+      await github.createBotComment(24574, 'test comment');
     });
   });
 
@@ -554,10 +506,7 @@ describe('GitHub API', () => {
           return true;
         })
         .reply(200);
-
-      await withContext(async (context, github) => {
-        await github.updateComment(24574, 'updated comment');
-      })();
+      await github.updateComment(24574, 'updated comment');
     });
   });
 
@@ -569,17 +518,14 @@ describe('GitHub API', () => {
           '/repos/test_owner/test_repo/git/blobs/eeae1593f4ecbae3f4453c9ceee2940a0e98ddca'
         )
         .reply(200, getFileResponse);
+      const contents = await github.getFileContents({
+        filename: 'third_party/subscriptions-project/OWNERS',
+        sha: 'eeae1593f4ecbae3f4453c9ceee2940a0e98ddca',
+      });
 
-      await withContext(async (context, github) => {
-        const contents = await github.getFileContents({
-          filename: 'third_party/subscriptions-project/OWNERS',
-          sha: 'eeae1593f4ecbae3f4453c9ceee2940a0e98ddca',
-        });
-
-        expect(contents).toEqual(
-          '- chenshay\n- chrisantaki\n- dparikh\n- dvoytenko\n- jpettitt\n'
-        );
-      })();
+      expect(contents).toEqual(
+        '- chenshay\n- chrisantaki\n- dparikh\n- dvoytenko\n- jpettitt\n'
+      );
     });
   });
 
@@ -589,12 +535,9 @@ describe('GitHub API', () => {
       nock('https://api.github.com')
         .get('/repos/test_owner/test_repo/pulls/35/files')
         .reply(200, listFilesResponse);
+      const [file] = await github.listFiles(35);
 
-      await withContext(async (context, github) => {
-        const [file] = await github.listFiles(35);
-
-        expect(file).toEqual('dir2/dir1/dir1/file.txt');
-      })();
+      expect(file).toEqual('dir2/dir1/dir1/file.txt');
     });
   });
 
@@ -606,11 +549,8 @@ describe('GitHub API', () => {
           '/search/code?q=filename%3AREADME.md%20repo%3Atest_owner%2Ftest_repo&page=1&per_page=100'
         )
         .reply(200, searchReadmeResponse);
-
-      await withContext(async (context, github) => {
-        const files = await github.searchFilename('README.md');
-        expect(files.length).toEqual(23);
-      })();
+      const files = await github.searchFilename('README.md');
+      expect(files.length).toEqual(23);
     });
 
     it('pages automatically', async () => {
@@ -627,11 +567,8 @@ describe('GitHub API', () => {
           '/search/code?q=filename%3AOWNERS%20repo%3Atest_owner%2Ftest_repo&page=2&per_page=100'
         )
         .reply(200, searchOwnersPage2Response);
-
-      await withContext(async (context, github) => {
-        const files = await github.searchFilename('OWNERS');
-        expect(files.length).toEqual(168);
-      })();
+      const files = await github.searchFilename('OWNERS');
+      expect(files.length).toEqual(168);
     });
 
     it('only includes exact file matches', async () => {
@@ -648,15 +585,12 @@ describe('GitHub API', () => {
             {name: 'exact-match', path: 'exact-match', sha: ''},
           ],
         });
+      const files = await github.searchFilename('exact-match');
+      const filenames = files.map(({filename}) => filename);
 
-      await withContext(async (context, github) => {
-        const files = await github.searchFilename('exact-match');
-        const filenames = files.map(({filename}) => filename);
-
-        expect(filenames).not.toContainEqual('foo/not-exact-match');
-        expect(filenames).toContainEqual('foo/exact-match');
-        expect(filenames).toContainEqual('exact-match');
-      })();
+      expect(filenames).not.toContainEqual('foo/not-exact-match');
+      expect(filenames).toContainEqual('foo/exact-match');
+      expect(filenames).toContainEqual('exact-match');
     });
   });
 
@@ -679,15 +613,12 @@ describe('GitHub API', () => {
           return true;
         })
         .reply(200);
-
-      await withContext(async (context, github) => {
-        const checkRun = new CheckRun(
-          CheckRunConclusion.NEUTRAL,
-          'Test summary',
-          'Test text'
-        );
-        await github.createCheckRun('_test_hash_', checkRun);
-      })();
+      const checkRun = new CheckRun(
+        CheckRunConclusion.NEUTRAL,
+        'Test summary',
+        'Test text'
+      );
+      await github.createCheckRun('_test_hash_', checkRun);
     });
   });
 
@@ -698,14 +629,11 @@ describe('GitHub API', () => {
       nock('https://api.github.com')
         .get(`/repos/test_owner/test_repo/commits/${sha}/check-runs`)
         .reply(200, checkRunsListResponse);
+      const checkRunIds = await github.getCheckRunIds(sha);
 
-      await withContext(async (context, github) => {
-        const checkRunIds = await github.getCheckRunIds(sha);
-
-        // ID pulled from check-runs.get.35.multiple
-        expect(checkRunIds['owners-check']).toEqual(53472315);
-        expect(checkRunIds['another-check']).toEqual(53472313);
-      })();
+      // ID pulled from check-runs.get.35.multiple
+      expect(checkRunIds['owners-check']).toEqual(53472315);
+      expect(checkRunIds['another-check']).toEqual(53472313);
     });
 
     it('returns null if the list has no matching check-run', async () => {
@@ -713,12 +641,9 @@ describe('GitHub API', () => {
       nock('https://api.github.com')
         .get('/repos/test_owner/test_repo/commits/_missing_hash_/check-runs')
         .reply(200, checkRunsListResponse);
+      const checkRunIds = await github.getCheckRunIds('_missing_hash_');
 
-      await withContext(async (context, github) => {
-        const checkRunIds = await github.getCheckRunIds('_missing_hash_');
-
-        expect(checkRunIds['owners-check']).toBeUndefined();
-      })();
+      expect(checkRunIds['owners-check']).toBeUndefined();
     });
 
     it('returns null if the list is empty', async () => {
@@ -726,12 +651,9 @@ describe('GitHub API', () => {
       nock('https://api.github.com')
         .get('/repos/test_owner/test_repo/commits/_test_hash_/check-runs')
         .reply(200, checkRunsEmptyResponse);
+      const checkRunIds = await github.getCheckRunIds('_test_hash_');
 
-      await withContext(async (context, github) => {
-        const checkRunIds = await github.getCheckRunIds('_test_hash_');
-
-        expect(checkRunIds['owners-check']).toBeUndefined();
-      })();
+      expect(checkRunIds['owners-check']).toBeUndefined();
     });
 
     it('returns null if there is an error querying GitHub', async () => {
@@ -742,12 +664,9 @@ describe('GitHub API', () => {
           message: 'Not found',
           code: 404,
         });
+      const checkRunIds = await github.getCheckRunIds('_test_hash_');
 
-      await withContext(async (context, github) => {
-        const checkRunIds = await github.getCheckRunIds('_test_hash_');
-
-        expect(checkRunIds['owners-check']).toBeUndefined();
-      })();
+      expect(checkRunIds['owners-check']).toBeUndefined();
     });
   });
 
@@ -769,15 +688,12 @@ describe('GitHub API', () => {
           return true;
         })
         .reply(200);
-
-      await withContext(async (context, github) => {
-        const checkRun = new CheckRun(
-          CheckRunConclusion.NEUTRAL,
-          'Test summary',
-          'Test text'
-        );
-        await github.updateCheckRun(1337, checkRun);
-      })();
+      const checkRun = new CheckRun(
+        CheckRunConclusion.NEUTRAL,
+        'Test summary',
+        'Test text'
+      );
+      await github.updateCheckRun(1337, checkRun);
     });
   });
 });

--- a/owners/test/github.test.js
+++ b/owners/test/github.test.js
@@ -115,10 +115,9 @@ describe('team', () => {
 describe('GitHub API', () => {
   let probot;
   let app;
-  let sandbox;
+  let sandbox = sinon.createSandbox();
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
     sandbox.stub(console);
     sandbox.stub(OwnersBot.prototype, 'initTeams').resolves();
     sandbox.stub(OwnersBot.prototype, 'refreshTree').resolves();
@@ -178,25 +177,21 @@ describe('GitHub API', () => {
   });
 
   describe('repo', () => {
-    it(
-      'returns the repo and owner',
-      withContext((context, github) => {
-        const repoInfo = github.repo();
+    const github = new GitHub({}, 'test_owner', 'test_repo');
 
-        expect(repoInfo.owner).toEqual('test_owner');
-        expect(repoInfo.repo).toEqual('test_repo');
-      })
-    );
+    it('returns the repo and owner', () => {
+      const repoInfo = github.repo();
 
-    it(
-      'sets the repo and owner on an object',
-      withContext((context, github) => {
-        const repoInfo = github.repo({key: 'value', owner: 'old_owner'});
+      expect(repoInfo.owner).toEqual('test_owner');
+      expect(repoInfo.repo).toEqual('test_repo');
+    });
 
-        expect(repoInfo.key).toEqual('value');
-        expect(repoInfo.owner).toEqual('test_owner');
-      })
-    );
+    it('sets the repo and owner on an object', () => {
+      const repoInfo = github.repo({key: 'value', owner: 'old_owner'});
+
+      expect(repoInfo.key).toEqual('value');
+      expect(repoInfo.owner).toEqual('test_owner');
+    });
   });
 
   describe('customRequest', () => {


### PR DESCRIPTION
When I originally wrote these tests, I wasn't familiar with Jest and I didn't know how to create a GitHub client instance without faking a Probot event and getting it from the context. Spinning up all those apps for each test made it pretty slow, especially as the class grew to contain many API methods (~6.5s to run all tests).

This PR swaps in an Octokit instance and removes the dependency on Probot, bringing the test runtime down to ~1.5s