### PR TITLE
[owners] Bring everything together for using the virtual repo

### DIFF
--- a/owners/app.yaml
+++ b/owners/app.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018, the AMP HTML authors
+# Copyright 2019, the AMP HTML authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/owners/app.yaml
+++ b/owners/app.yaml
@@ -1,6 +1,15 @@
-runtime: nodejs
-vm: true
+# Copyright 2018, the AMP HTML authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# Temporary setting to keep gcloud from uploading node_modules
-skip_files:
- - ^node_modules$
+runtime: nodejs
+env: flex

--- a/owners/bootstrap.js
+++ b/owners/bootstrap.js
@@ -62,12 +62,10 @@ function bootstrap(logger) {
     const initialized = Promise.all([
       ownersBot.initTeams(github).then(reparse),
       repo.warmCache().then(reparse),
-    ]).catch(
-      err => {
-        logger.error(err);
-        process.exit(1);
-      }
-    );
+    ]).catch(err => {
+      logger.error(err);
+      process.exit(1);
+    });
 
     components = {github, ownersBot, initialized};
   }

--- a/owners/bootstrap.js
+++ b/owners/bootstrap.js
@@ -36,10 +36,16 @@ function bootstrap(logger) {
 
     const Octokit = require('@octokit/rest');
     const {GitHub} = require('./src/api/github');
-    const LocalRepository = require('./src/repo/local_repo');
+    const VirtualRepository = require('./src/repo/virtual_repo');
+    const CompoundCache = require('./src/cache/compound_cache');
     const {OwnersBot} = require('./src/owners_bot');
 
-    const {GITHUB_REPO, GITHUB_REPO_DIR, GITHUB_ACCESS_TOKEN} = process.env;
+    const {
+      GITHUB_REPO,
+      GITHUB_REPO_DIR,
+      GITHUB_ACCESS_TOKEN,
+      CLOUD_STORAGE_BUCKET,
+    } = process.env;
     const [GITHUB_REPO_OWNER, GITHUB_REPO_NAME] = GITHUB_REPO.split('/');
 
     logger = logger || console;
@@ -51,7 +57,10 @@ function bootstrap(logger) {
       GITHUB_REPO_NAME,
       logger
     );
-    components.repo = new LocalRepository(GITHUB_REPO_DIR);
+    components.repo = new VirtualRepository(
+      components.github,
+      new CompoundCache(CLOUD_STORAGE_BUCKET),
+    );
     components.ownersBot = new OwnersBot(components.repo);
 
     const teamsInitialized = components.ownersBot.initTeams(components.github);

--- a/owners/bootstrap.js
+++ b/owners/bootstrap.js
@@ -41,7 +41,6 @@ function bootstrap(logger) {
 
     const {
       GITHUB_REPO,
-      GITHUB_REPO_DIR,
       GITHUB_ACCESS_TOKEN,
       CLOUD_STORAGE_BUCKET,
     } = process.env;
@@ -60,9 +59,10 @@ function bootstrap(logger) {
     const ownersBot = new OwnersBot(repo);
 
     const teamsInitialized = ownersBot.initTeams(github);
-    cacheWarmed = repo.findOwnersFiles().then(
-      ownersFiles => Promise.all(ownersFiles.map(repo.readFile, repo))
-    );
+    const cacheWarmed = repo
+      .findOwnersFiles()
+      .then(ownersFiles => Promise.all(ownersFiles.map(repo.readFile, repo)))
+      .then(() => ownersBot.reparseTree(logger));
     const initialized = Promise.all([teamsInitialized, cacheWarmed])
       .then(() => ownersBot.reparseTree(logger))
       .catch(err => {

--- a/owners/bootstrap.js
+++ b/owners/bootstrap.js
@@ -60,8 +60,11 @@ function bootstrap(logger) {
     const ownersBot = new OwnersBot(repo);
 
     const teamsInitialized = ownersBot.initTeams(github);
-    const initialized = teamsInitialized
-      .then(() => ownersBot.refreshTree(logger))
+    cacheWarmed = repo.findOwnersFiles().then(
+      ownersFiles => Promise.all(ownersFiles.map(repo.readFile, repo))
+    );
+    const initialized = Promise.all([teamsInitialized, cacheWarmed])
+      .then(() => ownersBot.reparseTree(logger))
       .catch(err => {
         logger.error(err);
         process.exit(1);

--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -16,9 +16,6 @@
 
 const express = require('express');
 
-const GITHUB_REPO = process.env.GITHUB_REPO || 'ampproject/amphtml';
-const [GITHUB_REPO_OWNER, GITHUB_REPO_NAME] = GITHUB_REPO.split('/');
-
 /**
  * Generic server wrapping express routing.
  */
@@ -130,7 +127,7 @@ class InfoServer extends Server {
   initRoutes() {
     this.get('/status', async req =>
       [
-        `The OWNERS bot is live and running on ${GITHUB_REPO}!`,
+        `The OWNERS bot is live and running on ${process.env.GITHUB_REPO}!`,
         '<a href="/tree">Owners Tree</a>',
         '<a href="/teams">Organization Teams</a>',
       ].join('<br>')
@@ -174,7 +171,6 @@ class InfoServer extends Server {
     });
   }
 }
-
 
 if (require.main === module) {
   const {github, ownersBot} = require('./bootstrap')(console);

--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -175,33 +175,12 @@ class InfoServer extends Server {
   }
 }
 
+
 if (require.main === module) {
-  require('dotenv').config();
+  const {github, ownersBot} = require('./bootstrap')(console);
 
-  const Octokit = require('@octokit/rest');
-  const {GitHub} = require('./src/api/github');
-  const {LocalRepository} = require('./src/repo');
-  const {OwnersBot} = require('./src/owners_bot');
-
-  const github = new GitHub(
-    new Octokit({auth: process.env.GITHUB_ACCESS_TOKEN}),
-    GITHUB_REPO_OWNER,
-    GITHUB_REPO_NAME,
-    console
-  );
-
-  const repo = new LocalRepository(process.env.GITHUB_REPO_DIR);
-  const ownersBot = new OwnersBot(repo);
   const infoServer = new InfoServer(ownersBot, github);
   infoServer.listen(process.env.INFO_SERVER_PORT);
-
-  const teamsInitialized = ownersBot.initTeams(github);
-  teamsInitialized
-    .then(() => ownersBot.refreshTree())
-    .catch(err => {
-      console.error(err);
-      process.exit(1);
-    });
 }
 
 module.exports = InfoServer;

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -57,7 +57,7 @@ class OwnersBot {
     const teamList = await github.getTeams();
     for (const team of teamList) {
       await this.syncTeam(team, github);
-      sleep(this.GITHUB_GET_MEMBERS_DELAY);
+      await sleep(this.GITHUB_GET_MEMBERS_DELAY);
     }
   }
 

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -81,6 +81,15 @@ class OwnersBot {
     logger.info(`Refreshing owners tree`);
 
     await this.repo.sync();
+    await this.reparseTree(logger);
+  }
+
+  /**
+   * Update the owners tree.
+   *
+   * @param {Logger} logger logging interface
+   */
+  async reparseTree(logger = console) {
     this.treeParse = await this.parser.parseOwnersTree();
     this.treeParse.errors.forEach(logger.warn, logger);
   }

--- a/owners/src/repo/virtual_repo.js
+++ b/owners/src/repo/virtual_repo.js
@@ -47,7 +47,7 @@ module.exports = class VirtualRepository extends Repository {
    */
   async warmCache() {
     const ownersFiles = await this.findOwnersFiles();
-    return await Promise.all(ownersFiles.map(this.readFile, this));
+    return await Promise.all(ownersFiles.map(file => this.readFile(file)));
   }
 
   /**

--- a/owners/src/repo/virtual_repo.js
+++ b/owners/src/repo/virtual_repo.js
@@ -43,6 +43,14 @@ module.exports = class VirtualRepository extends Repository {
   }
 
   /**
+   * Warms up the cache with all owners files.
+   */
+  async warmCache() {
+    const ownersFiles = await this.findOwnersFiles();
+    return await Promise.all(ownersFiles.map(this.readFile, this));
+  }
+
+  /**
    * Read the contents of a file from the repo.
    *
    * @param {string} relativePath file to read.

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -20,7 +20,6 @@ const owners = require('..');
 const {Probot} = require('probot');
 const sinon = require('sinon');
 
-const LocalRepository = require('../src/repo/local_repo');
 const {GitHub, Team} = require('../src/api/github');
 const {OwnersParser} = require('../src/parser');
 const {UserOwner} = require('../src/owner');
@@ -71,11 +70,11 @@ describe('owners bot', () => {
       NODE_ENV: 'test',
     });
     // Disabled execution of `git pull` for testing.
-    sandbox.stub(LocalRepository.prototype, 'checkout');
     sandbox.stub(OwnersBot.prototype, 'initTeams').resolves();
     sandbox.stub(GitHub.prototype, 'getBotComments').returns([]);
     sandbox.stub(GitHub.prototype, 'getReviewRequests').returns([]);
     sandbox.stub(GitHub.prototype, 'createReviewRequests').returns([]);
+    sandbox.stub(GitHub.prototype, 'searchFilename').returns([]);
     sandbox.stub(CheckRun.prototype, 'helpText').value('HELP TEXT');
     sandbox
       .stub(OwnersParser.prototype, 'parseAllOwnersRules')

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -131,6 +131,15 @@ describe('owners bot', () => {
     });
   });
 
+  describe('reparseTree', () => {
+    it('parses the owners tree', async () => {
+      expect.assertions(1);
+      ownersBot.treeParse = null;
+      await ownersBot.refreshTree(silentLogger);
+      expect(ownersBot.treeParse.result).toBeInstanceOf(OwnersTree);
+    });
+  });
+
   describe('initPr', () => {
     beforeEach(() => {
       const timestamp = new Date('2019-01-02T00:00:00Z');


### PR DESCRIPTION
This PR:
- uses the bootstrapping module in the info server
- migrates the botstrapper to use a virtual repo instead of a local repo
- warms up the in-memory cache during bot initialization
- adds a missing `await` before a promisified function
- updates `app.yaml` for GAE deployment