### PR TITLE
[owners] Don't read .env file during tests

### DIFF
--- a/owners/bootstrap.js
+++ b/owners/bootstrap.js
@@ -62,9 +62,11 @@ function bootstrap(logger) {
         logger.error(err);
         process.exit(1);
       });
+
+    components = {ownersBot, github, initialized};
   }
 
-  return {ownersBot, github, initialized};
+  return components;
 }
 
 module.exports = bootstrap;

--- a/owners/bootstrap.js
+++ b/owners/bootstrap.js
@@ -15,7 +15,7 @@
  */
 
 // Keep the components in scope so that, if multiple files include this, the
-// bootstrapping is only done once and all files share the components.
+// bootstrapping is only done once and all files share the
 let components = null;
 
 /**
@@ -45,27 +45,26 @@ function bootstrap(logger) {
     const [GITHUB_REPO_OWNER, GITHUB_REPO_NAME] = GITHUB_REPO.split('/');
 
     logger = logger || console;
-    components = {};
 
-    components.github = new GitHub(
+    const github = new GitHub(
       new Octokit({auth: GITHUB_ACCESS_TOKEN}),
       GITHUB_REPO_OWNER,
       GITHUB_REPO_NAME,
       logger
     );
-    components.repo = new LocalRepository(GITHUB_REPO_DIR);
-    components.ownersBot = new OwnersBot(components.repo);
+    const repo = new LocalRepository(GITHUB_REPO_DIR);
+    const ownersBot = new OwnersBot(repo);
 
-    const teamsInitialized = components.ownersBot.initTeams(components.github);
-    components.initialized = teamsInitialized
-      .then(() => components.ownersBot.refreshTree(logger))
+    const teamsInitialized = ownersBot.initTeams(github);
+    const initialized = teamsInitialized
+      .then(() => ownersBot.refreshTree(logger))
       .catch(err => {
         logger.error(err);
         process.exit(1);
       });
   }
 
-  return components;
+  return {ownersBot, github, initialized};
 }
 
 module.exports = bootstrap;

--- a/owners/bootstrap.js
+++ b/owners/bootstrap.js
@@ -15,7 +15,7 @@
  */
 
 // Keep the components in scope so that, if multiple files include this, the
-// bootstrapping is only done once and all files share the
+// bootstrapping is only done once and all files share the components.
 let components = null;
 
 /**

--- a/owners/bootstrap.js
+++ b/owners/bootstrap.js
@@ -32,7 +32,9 @@ let components = null;
  */
 function bootstrap(logger) {
   if (components === null) {
-    require('dotenv').config();
+    if (process.env.NODE_ENV !== 'test') {
+      require('dotenv').config();
+    }
 
     const Octokit = require('@octokit/rest');
     const {GitHub} = require('./src/api/github');


### PR DESCRIPTION
There have been a few cases where tests passed locally because they read from a `.env` file, but since those env vars weren't stubbed the tests failed on Travis. This PR gates the `require('dotenv').config()` call so it doesn't initialize the environment when `NODE_ENV` is `test`

Also cleans up bootstrap function.