### PR TITLE
[owners] Add callback for virtual repo cache misses

### DIFF
--- a/owners/scripts/warm_cache.js
+++ b/owners/scripts/warm_cache.js
@@ -32,9 +32,9 @@ require('dotenv').config();
 const sleep = require('sleep-promise');
 const Octokit = require('@octokit/rest');
 
-const {GitHub} = require('../src/github');
-const {VirtualRepository} = require('../src/repo');
-const {CompoundCache} = require('../src/file_cache');
+const {GitHub} = require('../src/api/github');
+const VirtualRepository = require('../src/repo/virtual_repo');
+const CompoundCache = require('../src//cache/compound_cache');
 const {OwnersParser} = require('../src/parser');
 
 const CLOUD_STORAGE_BUCKET = process.env.CLOUD_STORAGE_BUCKET;

--- a/owners/scripts/warm_cache.js
+++ b/owners/scripts/warm_cache.js
@@ -61,8 +61,7 @@ async function warmUp() {
   let i = 1;
   for (const file of ownersFiles) {
     console.log(`File #${i++} of ${ownersFiles.length}`);
-    await repo.readFile(file);
-    await sleep(CACHE_HIT_INTERVAL);
+    await repo.readFile(file, () => sleep(CACHE_HIT_INTERVAL));
   }
 }
 

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -57,7 +57,7 @@ class OwnersBot {
     const teamList = await github.getTeams();
     for (const team of teamList) {
       await this.syncTeam(team, github);
-      sleep(this.GITHUB_GET_MEMBERS_DELAY);
+      await sleep(this.GITHUB_GET_MEMBERS_DELAY);
     }
   }
 

--- a/owners/src/repo/virtual_repo.js
+++ b/owners/src/repo/virtual_repo.js
@@ -46,7 +46,7 @@ module.exports = class VirtualRepository extends Repository {
    * Read the contents of a file from the repo.
    *
    * @param {string} relativePath file to read.
-   * @param {?function} cacheHitCallback called when there is a cache miss.
+   * @param {?function} cacheMissCallback called when there is a cache miss.
    * @return {string} file contents.
    */
   async readFile(relativePath, cacheMissCallback) {

--- a/owners/src/repo/virtual_repo.js
+++ b/owners/src/repo/virtual_repo.js
@@ -46,9 +46,10 @@ module.exports = class VirtualRepository extends Repository {
    * Read the contents of a file from the repo.
    *
    * @param {string} relativePath file to read.
+   * @param {?function} cacheHitCallback called when there is a cache miss.
    * @return {string} file contents.
    */
-  async readFile(relativePath) {
+  async readFile(relativePath, cacheMissCallback) {
     const fileSha = this._fileRefs.get(relativePath);
     if (!fileSha) {
       throw new Error(
@@ -58,10 +59,16 @@ module.exports = class VirtualRepository extends Repository {
     }
 
     return await this.cache.readFile(relativePath, async () => {
-      return await this.github.getFileContents({
+      const contents = await this.github.getFileContents({
         filename: relativePath,
         sha: fileSha,
       });
+
+      if (cacheMissCallback) {
+        await cacheMissCallback();
+      }
+
+      return contents;
     });
   }
 

--- a/owners/test/repo/virtual_repo.test.js
+++ b/owners/test/repo/virtual_repo.test.js
@@ -118,6 +118,29 @@ describe('virtual repository', () => {
 
         expect(contents).toEqual('contents');
       });
+
+      it('executes the callback for cache misses', async () => {
+        expect.assertions(1);
+
+        const cacheMissCallback = sandbox.spy();
+        await repo.findOwnersFiles();
+        const contents = await repo.readFile('OWNERS', cacheMissCallback);
+
+        sandbox.assert.calledOnce(cacheMissCallback);
+        expect(contents).toEqual('contents');
+      });
+
+      it('ignores the callback for files in the cache', async () => {
+        expect.assertions(1);
+
+        const cacheMissCallback = sandbox.spy();
+        await repo.findOwnersFiles();
+        await repo.readFile('OWNERS');
+        const contents = await repo.readFile('OWNERS', cacheMissCallback);
+
+        sandbox.assert.notCalled(cacheMissCallback);
+        expect(contents).toEqual('contents');
+      });
     });
   });
 


### PR DESCRIPTION
This PR adds an optional callback to the virtual repo `readFile` method. This allows scripts like the cache warmup to sleep in between cache misses, but plow straight through cache hits.