### PR TITLE
[owners] Migrate from local repo to virtual repo

### DIFF
--- a/owners/bootstrap.js
+++ b/owners/bootstrap.js
@@ -22,15 +22,14 @@ let components = null;
  * Bootstraps the required components needed either for starting the full Probot
  * app or just running the info server.
  *
- * @param {Logger=} [logger=console] logging interface.
+ * @param {Logger} logger logging interface.
  * @return {{
  *   github: !GitHub,
- *   repo: !Repository,
  *   ownersBot: !OwnersBot,
  *   initialized: Promise,
  * }}
  */
-function bootstrap(logger) {
+function bootstrap(logger = console) {
   if (components === null) {
     if (process.env.NODE_ENV !== 'test') {
       require('dotenv').config();
@@ -38,13 +37,17 @@ function bootstrap(logger) {
 
     const Octokit = require('@octokit/rest');
     const {GitHub} = require('./src/api/github');
-    const LocalRepository = require('./src/repo/local_repo');
+    const VirtualRepository = require('./src/repo/virtual_repo');
+    const CompoundCache = require('./src/cache/compound_cache');
     const {OwnersBot} = require('./src/owners_bot');
 
-    const {GITHUB_REPO, GITHUB_REPO_DIR, GITHUB_ACCESS_TOKEN} = process.env;
+    const {
+      GITHUB_REPO,
+      GITHUB_REPO_DIR,
+      GITHUB_ACCESS_TOKEN,
+      CLOUD_STORAGE_BUCKET,
+    } = process.env;
     const [GITHUB_REPO_OWNER, GITHUB_REPO_NAME] = GITHUB_REPO.split('/');
-
-    logger = logger || console;
 
     const github = new GitHub(
       new Octokit({auth: GITHUB_ACCESS_TOKEN}),
@@ -52,11 +55,13 @@ function bootstrap(logger) {
       GITHUB_REPO_NAME,
       logger
     );
-    const repo = new LocalRepository(GITHUB_REPO_DIR);
+    const repo = new VirtualRepository(
+      github,
+      new CompoundCache(CLOUD_STORAGE_BUCKET),
+    );
     const ownersBot = new OwnersBot(repo);
 
-    const teamsInitialized = ownersBot.initTeams(github);
-    const initialized = teamsInitialized
+    const initialized = ownersBot.initTeams(github)
       .then(() => ownersBot.refreshTree(logger))
       .catch(err => {
         logger.error(err);

--- a/owners/bootstrap.js
+++ b/owners/bootstrap.js
@@ -45,7 +45,6 @@ function bootstrap(logger = console) {
 
     const {
       GITHUB_REPO,
-      GITHUB_REPO_DIR,
       GITHUB_ACCESS_TOKEN,
       CLOUD_STORAGE_BUCKET,
     } = process.env;
@@ -59,14 +58,15 @@ function bootstrap(logger = console) {
     );
     const repo = new VirtualRepository(
       github,
-      new CompoundCache(CLOUD_STORAGE_BUCKET),
+      new CompoundCache(CLOUD_STORAGE_BUCKET)
     );
     const ownersBot = new OwnersBot(repo);
 
     const initialized = Promise.all([
       ownersBot.initTeams(github),
       repo.warmCache(() => sleep(CACHE_WARM_INTERVAL)),
-    ]).then(() => ownersBot.reparseTree(logger))
+    ])
+      .then(() => ownersBot.reparseTree(logger))
       .catch(err => {
         logger.error(err);
         process.exit(1);

--- a/owners/index.js
+++ b/owners/index.js
@@ -20,8 +20,6 @@ const InfoServer = require('./info_server');
 const {GitHub, PullRequest, Team} = require('./src/api/github');
 const {OwnersCheck} = require('./src/owners_check');
 
-const INFO_SERVER_PORT = Number(process.env.INFO_SERVER_PORT || 8081);
-
 module.exports = app => {
   const {github, ownersBot, initialized} = bootstrap(app.log);
 
@@ -100,8 +98,7 @@ module.exports = app => {
   });
 
   if (process.env.NODE_ENV !== 'test') {
-    const infoServer = new InfoServer(ownersBot, github, null, app.log);
-    infoServer.listen(INFO_SERVER_PORT);
+    new InfoServer(ownersBot, github, app.route(), app.log);
   }
 
   // Since this endpoint triggers a ton of GitHub API requests, there is a risk

--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -28,9 +28,12 @@ class Server {
    * @param {function} initRoutes function adding routes.
    */
   constructor(app, logger = console) {
+    this.router = new express.Router();
     this.app = app || express();
     this.logger = logger;
+
     this.initRoutes();
+    this.app.use(this.router);
   }
 
   /**
@@ -51,7 +54,7 @@ class Server {
       throw new Error(`Method "${method}" not allowed as route`);
     }
 
-    this.app[method](uri, async (req, res, next) => {
+    this.router[method](uri, async (req, res, next) => {
       handler(req)
         .then(res.send.bind(res))
         .catch(next);
@@ -173,7 +176,7 @@ class InfoServer extends Server {
 }
 
 if (require.main === module) {
-  const {ownersBot, github} = require('bootstrap')(console);
+  const {ownersBot, github} = require('./bootstrap')(console);
   new InfoServer(ownersBot, github).listen(process.env.INFO_SERVER_PORT);
 }
 

--- a/owners/src/cache/cloud_storage_cache.js
+++ b/owners/src/cache/cloud_storage_cache.js
@@ -45,7 +45,7 @@ module.exports = class CloudStorageCache extends FileCache {
       this.logger.info(`Fetching "${filename}" from Cloud Storage cache`);
       return await this.storage.download(filename);
     } catch (e) {
-      this.logger.info(`Cache miss on "${filename}"`);
+      this.logger.info(`Memory cache miss on "${filename}"`);
       const contents = await getContents();
 
       this.logger.info(`Uploading "${filename}" to Cloud Storage cache`);

--- a/owners/src/cache/memory_cache.js
+++ b/owners/src/cache/memory_cache.js
@@ -44,7 +44,7 @@ module.exports = class MemoryCache extends FileCache {
       return this.files.get(filename);
     }
 
-    this.logger.debug(`Cache miss on "${filename}"`);
+    this.logger.debug(`Memory cache miss on "${filename}"`);
     const contents = await getContents();
 
     this.logger.debug(`Storing "${filename}" to in-memory cache`);

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -81,6 +81,15 @@ class OwnersBot {
     logger.info(`Refreshing owners tree`);
 
     await this.repo.sync();
+    await this.reparseTree(logger);
+  }
+
+  /**
+   * Update the owners tree.
+   *
+   * @param {Logger} logger logging interface
+   */
+  async reparseTree(logger = console) {
     this.treeParse = await this.parser.parseOwnersTree();
     this.treeParse.errors.forEach(logger.warn, logger);
   }

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -20,7 +20,7 @@ const owners = require('..');
 const {Probot} = require('probot');
 const sinon = require('sinon');
 
-const LocalRepository = require('../src/repo/local_repo');
+const VirtualRepository = require('../src/repo/virtual_repo');
 const {GitHub, Team} = require('../src/api/github');
 const {OwnersParser} = require('../src/parser');
 const {UserOwner} = require('../src/owner');
@@ -71,7 +71,8 @@ describe('owners bot', () => {
       NODE_ENV: 'test',
     });
     // Disabled execution of `git pull` for testing.
-    sandbox.stub(LocalRepository.prototype, 'checkout');
+    sandbox.stub(VirtualRepository.prototype, 'sync');
+    sandbox.stub(VirtualRepository.prototype, 'warmCache').resolves();
     sandbox.stub(OwnersBot.prototype, 'initTeams').resolves();
     sandbox.stub(GitHub.prototype, 'getBotComments').returns([]);
     sandbox.stub(GitHub.prototype, 'getReviewRequests').returns([]);

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -131,6 +131,15 @@ describe('owners bot', () => {
     });
   });
 
+  describe('reparseTree', () => {
+    it('parses the owners tree', async () => {
+      expect.assertions(1);
+      ownersBot.treeParse = null;
+      await ownersBot.refreshTree(silentLogger);
+      expect(ownersBot.treeParse.result).toBeInstanceOf(OwnersTree);
+    });
+  });
+
   describe('initPr', () => {
     beforeEach(() => {
       const timestamp = new Date('2019-01-02T00:00:00Z');


### PR DESCRIPTION
This PR:
- replaces the local repo with a virtual repo
- warms up the virtual repo cache during bootstrapping/initialization
- unifies the info server using the express instance owned by Probot