### PR TITLE
[owners] Make owners bot repository-agnostic

### DIFF
--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -177,7 +177,7 @@ class InfoServer extends Server {
 
 if (require.main === module) {
   const {ownersBot, github} = require('./bootstrap')(console);
-  new InfoServer(ownersBot, github).listen(process.env.INFO_SERVER_PORT);
+  new InfoServer(ownersBot, github).listen(process.env.PORT);
 }
 
 module.exports = InfoServer;

--- a/owners/test/repo/virtual_repo.test.js
+++ b/owners/test/repo/virtual_repo.test.js
@@ -22,7 +22,7 @@ const sinon = require('sinon');
 
 describe('virtual repository', () => {
   const sandbox = sinon.createSandbox();
-  const github = new GitHub({}, 'ampproject', 'amphtml', console);
+  const github = new GitHub({}, 'test_owner', 'test_repo', console);
   let repo;
 
   beforeEach(() => {
@@ -68,7 +68,7 @@ describe('virtual repository', () => {
   describe('readFile', () => {
     it('throws an error for unknown files', () => {
       expect(repo.readFile('OWNERS')).rejects.toThrowError(
-        'File "OWNERS" not found in virtual repository'
+        'File "test_repo/OWNERS" not found in virtual repository'
       );
     });
 
@@ -112,7 +112,7 @@ describe('virtual repository', () => {
           sha: 'sha_1',
         });
 
-        await repo.cache.invalidate('OWNERS');
+        await repo.cache.invalidate('test_repo/OWNERS');
         const contents = await repo.readFile('OWNERS');
         sandbox.assert.calledTwice(github.getFileContents);
 
@@ -155,8 +155,8 @@ describe('virtual repository', () => {
       expect.assertions(2);
       await repo.findOwnersFiles();
 
-      expect(repo._fileRefs.get('OWNERS')).toEqual('sha_1');
-      expect(repo._fileRefs.get('foo/OWNERS')).toEqual('sha_2');
+      expect(repo._fileRefs.get('test_repo/OWNERS')).toEqual('sha_1');
+      expect(repo._fileRefs.get('test_repo/foo/OWNERS')).toEqual('sha_2');
     });
 
     it('updates changed owners files', async () => {
@@ -164,12 +164,12 @@ describe('virtual repository', () => {
 
       await repo.findOwnersFiles();
       // Pretend the contents for the known files have been fetched
-      repo._fileRefs.get('OWNERS').contents = 'old root contents';
-      repo._fileRefs.get('foo/OWNERS').contents = 'old foo contents';
+      repo._fileRefs.get('test_repo/OWNERS').contents = 'old root contents';
+      repo._fileRefs.get('test_repo/foo/OWNERS').contents = 'old foo contents';
       await repo.findOwnersFiles();
 
-      expect(repo._fileRefs.get('OWNERS')).toEqual('sha_updated');
-      expect(repo._fileRefs.get('foo/OWNERS')).toEqual('sha_2');
+      expect(repo._fileRefs.get('test_repo/OWNERS')).toEqual('sha_updated');
+      expect(repo._fileRefs.get('test_repo/foo/OWNERS')).toEqual('sha_2');
     });
 
     it('invalidates the cache for changed owners files', async done => {
@@ -178,7 +178,7 @@ describe('virtual repository', () => {
       sandbox.assert.notCalled(repo.cache.invalidate);
 
       await repo.findOwnersFiles();
-      sandbox.assert.calledWith(repo.cache.invalidate, 'OWNERS');
+      sandbox.assert.calledWith(repo.cache.invalidate, 'test_repo/OWNERS');
       done();
     });
   });


### PR DESCRIPTION
This PR removes all repository-specific code for the owners bot, so it can work for any repo under a GitHub organization. It modifies the virtual repo to cache files using the repository name as the root directory. Since the GitHub interface is the only part of the bot that uses a repository, and since the app no longer requires checking out a copy of the repo onto the filesystem, this is all that's required on the implementation level to support other repos in the org. Since the bot instance currently holds the parsed owners tree, a few adjustments will need to be made to fully support additional repos.