### PR TITLE
[owners] Switch info server to template rendering and add OWNERS example file

### DIFF
--- a/owners/OWNERS.yaml
+++ b/owners/OWNERS.yaml
@@ -1,1 +1,0 @@
-- erwinmombay

--- a/owners/bootstrap.js
+++ b/owners/bootstrap.js
@@ -44,16 +44,16 @@ function bootstrap(logger = console) {
     const {OwnersBot} = require('./src/owners_bot');
 
     const {
-      GITHUB_REPO,
+      GITHUB_OWNER,
+      GITHUB_REPOSITORY,
       GITHUB_ACCESS_TOKEN,
       CLOUD_STORAGE_BUCKET,
     } = process.env;
-    const [GITHUB_REPO_OWNER, GITHUB_REPO_NAME] = GITHUB_REPO.split('/');
 
     const github = new GitHub(
       new Octokit({auth: GITHUB_ACCESS_TOKEN}),
-      GITHUB_REPO_OWNER,
-      GITHUB_REPO_NAME,
+      GITHUB_OWNER,
+      GITHUB_REPOSITORY,
       logger
     );
     const repo = new VirtualRepository(

--- a/owners/example.env
+++ b/owners/example.env
@@ -14,7 +14,7 @@ WEBHOOK_SECRET=secretsecretsecret
 PRIVATE_KEY=...
 GITHUB_ACCESS_TOKEN=0123456789abcdef0123456789abcdef01234567
 
-GITHUB_REPO=owner/repository
-GITHUB_REPO_DIR=/tmp/repository
+GITHUB_REPOSITORY=repository-name
+GITHUB_OWNER=organization-name
 GITHUB_BOT_USERNAME=owners-bot-username
 ADD_REVIEWERS_OPT_OUT=1

--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
+const fs = require('fs');
 const express = require('express');
+const _ = require('lodash');
+const hl = require('highlight').Highlight;
+
+const EXAMPLE_OWNERS_PATH = './OWNERS.example';
 
 /**
  * Generic server wrapping express routing.
@@ -85,6 +90,11 @@ class Server {
       });
     });
   }
+
+  render(view, ctx = {}) {
+    const template = fs.readFileSync(`./templates/${view}.template.html`);
+    return _.template(template)(ctx);
+  }
 }
 
 /**
@@ -138,17 +148,7 @@ class InfoServer extends Server {
 
     this.get('/tree', async req => {
       const {result, errors} = this.ownersBot.treeParse;
-      const treeHeader = '<h3>OWNERS tree</h3>';
-      const treeDisplay = `<pre>${result.toString()}</pre>`;
-
-      let output = `${treeHeader}${treeDisplay}`;
-      if (errors.length) {
-        const errorHeader = '<h3>Parser Errors</h3>';
-        const errorDisplay = errors.join('<br>');
-        output += `${errorHeader}<code>${errorDisplay}</code>`;
-      }
-
-      return output;
+      return this.render('tree', {ownersTree: result, errors});
     });
 
     this.get('/teams', async req => {

--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -19,8 +19,6 @@ const express = require('express');
 const _ = require('lodash');
 const hl = require('highlight').Highlight;
 
-const {GITHUB_OWNER, GITHUB_REPOSITORY, PORT} = process.env;
-
 const EXAMPLE_OWNERS_PATH = './OWNERS.example';
 
 /**
@@ -151,7 +149,7 @@ class InfoServer extends Server {
 
     this.get('/', async req =>
       this.render('status', {
-        repository: `${GITHUB_OWNER}/${GITHUB_REPOSITORY}`,
+        repository: `${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPOSITORY}`,
       })
     );
 
@@ -180,7 +178,7 @@ class InfoServer extends Server {
 
 if (require.main === module) {
   const {ownersBot, github} = require('./bootstrap')(console);
-  new InfoServer(ownersBot, github).listen(PORT);
+  new InfoServer(ownersBot, github).listen(process.env.PORT);
 }
 
 module.exports = InfoServer;

--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -138,7 +138,9 @@ class InfoServer extends Server {
    * Initialize route handlers.
    */
   initRoutes() {
-    this.get('/status', async req =>
+    const ownersFile = fs.readFileSync(EXAMPLE_OWNERS_PATH).toString('utf8');
+
+    this.get('/', async req =>
       this.render('status', {repository: process.env.GITHUB_REPO})
     );
 
@@ -149,6 +151,10 @@ class InfoServer extends Server {
 
     this.get('/teams', async req => {
       return this.render('teams', {teams: Object.values(this.ownersBot.teams)});
+    });
+
+    this.get('/example', async req => {
+      return this.render('example', {ownersFile: hl(ownersFile)});
     });
 
     this.cron('refreshTree', async req => {

--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -19,6 +19,8 @@ const express = require('express');
 const _ = require('lodash');
 const hl = require('highlight').Highlight;
 
+const {GITHUB_OWNER, GITHUB_REPOSITORY, PORT} = process.env;
+
 const EXAMPLE_OWNERS_PATH = './OWNERS.example';
 
 /**
@@ -140,8 +142,10 @@ class InfoServer extends Server {
   initRoutes() {
     const ownersFile = fs.readFileSync(EXAMPLE_OWNERS_PATH).toString('utf8');
 
-    this.get('/', async req =>
-      this.render('status', {repository: process.env.GITHUB_REPO})
+    this.get('/', async req => 
+      this.render('status', {
+        repository: `${GITHUB_OWNER}/${GITHUB_REPOSITORY}`
+      })
     );
 
     this.get('/tree', async req => {
@@ -169,7 +173,7 @@ class InfoServer extends Server {
 
 if (require.main === module) {
   const {ownersBot, github} = require('./bootstrap')(console);
-  new InfoServer(ownersBot, github).listen(process.env.PORT);
+  new InfoServer(ownersBot, github).listen(PORT);
 }
 
 module.exports = InfoServer;

--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -139,11 +139,7 @@ class InfoServer extends Server {
    */
   initRoutes() {
     this.get('/status', async req =>
-      [
-        `The OWNERS bot is live and running on ${process.env.GITHUB_REPO}!`,
-        '<a href="/tree">Owners Tree</a>',
-        '<a href="/teams">Organization Teams</a>',
-      ].join('<br>')
+      this.render('status', {repository: process.env.GITHUB_REPO})
     );
 
     this.get('/tree', async req => {

--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -93,6 +93,13 @@ class Server {
     });
   }
 
+  /**
+   * Render a `lodash` template.
+   *
+   * @param {string} view name of view template.
+   * @param {?object} ctx template context.
+   * @return {strintg} template rendered with context variables.
+   */
   render(view, ctx = {}) {
     const template = fs.readFileSync(`./templates/${view}.template.html`);
     return _.template(template)(ctx);
@@ -142,9 +149,9 @@ class InfoServer extends Server {
   initRoutes() {
     const ownersFile = fs.readFileSync(EXAMPLE_OWNERS_PATH).toString('utf8');
 
-    this.get('/', async req => 
+    this.get('/', async req =>
       this.render('status', {
-        repository: `${GITHUB_OWNER}/${GITHUB_REPOSITORY}`
+        repository: `${GITHUB_OWNER}/${GITHUB_REPOSITORY}`,
       })
     );
 

--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -152,17 +152,7 @@ class InfoServer extends Server {
     });
 
     this.get('/teams', async req => {
-      const teamSections = [];
-      Object.entries(this.ownersBot.teams).forEach(([name, team]) => {
-        teamSections.push(
-          [
-            `Team "${name}" (ID: ${team.id}):`,
-            ...team.members.map(username => `- ${username}`),
-          ].join('<br>')
-        );
-      });
-
-      return ['<h2>Teams</h2>', ...teamSections].join('<br><br>');
+      return this.render('teams', {teams: Object.values(this.ownersBot.teams)});
     });
 
     this.cron('refreshTree', async req => {

--- a/owners/package-lock.json
+++ b/owners/package-lock.json
@@ -2698,7 +2698,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2719,12 +2720,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2739,17 +2742,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2866,7 +2872,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2878,6 +2885,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2892,6 +2900,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2899,12 +2908,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2923,6 +2934,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3003,7 +3015,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3015,6 +3028,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3100,7 +3114,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3136,6 +3151,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3155,6 +3171,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3198,12 +3215,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3687,6 +3706,11 @@
           }
         }
       }
+    },
+    "highlight": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/highlight/-/highlight-0.2.4.tgz",
+      "integrity": "sha1-isAodbA/WTXgZ1hSt2z+H9WODf8="
     },
     "home-or-tmp": {
       "version": "2.0.0",

--- a/owners/package.json
+++ b/owners/package.json
@@ -21,6 +21,7 @@
     "express": "4.17.1",
     "highlight": "0.2.4",
     "json5": "2.1.1",
+    "lodash": "4.17.15",
     "minimatch": "3.0.4",
     "probot": "7.5.3",
     "sleep-promise": "8.0.1"

--- a/owners/package.json
+++ b/owners/package.json
@@ -19,6 +19,7 @@
     "@google-cloud/storage": "4.0.0",
     "@octokit/rest": "16.34.0",
     "express": "4.17.1",
+    "highlight": "0.2.4",
     "json5": "2.1.1",
     "minimatch": "3.0.4",
     "probot": "7.5.3",

--- a/owners/scripts/warm_cache.js
+++ b/owners/scripts/warm_cache.js
@@ -37,16 +37,18 @@ const VirtualRepository = require('../src/repo/virtual_repo');
 const CompoundCache = require('../src//cache/compound_cache');
 const {OwnersParser} = require('../src/parser');
 
-const CLOUD_STORAGE_BUCKET = process.env.CLOUD_STORAGE_BUCKET;
-const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
-const GITHUB_REPO = process.env.GITHUB_REPO || 'ampproject/amphtml';
-const [GITHUB_REPO_OWNER, GITHUB_REPO_NAME] = GITHUB_REPO.split('/');
+const {
+  CLOUD_STORAGE_BUCKET,
+  GITHUB_ACCESS_TOKEN,
+  GITHUB_OWNER,
+  GITHUB_REPOSITORY,
+} = process.env.CLOUD_STORAGE_BUCKET;
 const CACHE_HIT_INTERVAL = 3000;
 
 const github = new GitHub(
   new Octokit({auth: GITHUB_ACCESS_TOKEN}),
-  GITHUB_REPO_OWNER,
-  GITHUB_REPO_NAME,
+  GITHUB_OWNER,
+  GITHUB_REPOSITORY,
   console
 );
 const cache = new CompoundCache(CLOUD_STORAGE_BUCKET);

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -18,8 +18,7 @@ const {OWNER_MODIFIER} = require('./owner');
 const {ReviewerSelection} = require('./reviewer_selection');
 
 const GITHUB_CHECKRUN_NAME = 'ampproject/owners-check';
-const EXAMPLE_OWNERS_LINK =
-  'https://github.com/ampproject/amp-github-apps/blob/master/owners/OWNERS.example';
+const EXAMPLE_OWNERS_LINK = 'http://ampproject-owners-bot.appspot.com/example';
 
 const CheckRunConclusion = {
   SUCCESS: 'success',

--- a/owners/src/repo/virtual_repo.js
+++ b/owners/src/repo/virtual_repo.js
@@ -60,9 +60,7 @@ module.exports = class VirtualRepository extends Repository {
   async warmCache(cacheMissCallback) {
     const ownersFiles = await this.findOwnersFiles();
     return await Promise.all(
-      ownersFiles
-        .map(this.repoPath, this)
-        .map(filename => this.readFile(filename, cacheMissCallback))
+      ownersFiles.map(filename => this.readFile(filename, cacheMissCallback))
     );
   }
 

--- a/owners/templates/example.template.html
+++ b/owners/templates/example.template.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Owners File Syntax</title>
+
+  <style type="text/css">
+    /*
+      github.com style (c) Vasily Polovnyov <vast@whiteants.net>
+      Taken from `highlight/lib/vendor/highlight.js/styles/github.css`
+    */
+
+    pre code {
+      display: block; padding: 0.5em;
+      color: #000;
+      background: #f8f8ff
+    }
+
+    pre .comment,
+    pre .template_comment,
+    pre .diff .header,
+    pre .javadoc {
+      color: #998;
+      font-style: italic
+    }
+
+    pre .keyword,
+    pre .css .rule .keyword,
+    pre .winutils,
+    pre .javascript .title,
+    pre .lisp .title,
+    pre .subst {
+      color: #000;
+      font-weight: bold
+    }
+
+    pre .number,
+    pre .hexcolor {
+      color: #40a070
+    }
+
+    pre .string,
+    pre .tag .value,
+    pre .phpdoc,
+    pre .tex .formula {
+      color: #d14
+    }
+
+    pre .title,
+    pre .id {
+      color: #900;
+      font-weight: bold
+    }
+
+    pre .javascript .title,
+    pre .lisp .title,
+    pre .subst {
+      font-weight: normal
+    }
+
+    pre .class .title,
+    pre .haskell .label,
+    pre .tex .command {
+      color: #458;
+      font-weight: bold
+    }
+
+    pre .tag,
+    pre .tag .title,
+    pre .rules .property,
+    pre .django .tag .keyword {
+      color: #000080;
+      font-weight: normal
+    }
+
+    pre .attribute,
+    pre .variable,
+    pre .instancevar,
+    pre .lisp .body {
+      color: #008080
+    }
+
+    pre .regexp {
+      color: #009926
+    }
+
+    pre .class {
+      color: #458;
+      font-weight: bold
+    }
+
+    pre .symbol,
+    pre .ruby .symbol .string,
+    pre .ruby .symbol .keyword,
+    pre .ruby .symbol .keymethods,
+    pre .lisp .keyword,
+    pre .tex .special,
+    pre .input_number {
+      color: #990073
+    }
+
+    pre .builtin,
+    pre .built_in,
+    pre .lisp .title {
+      color: #0086b3
+    }
+
+    pre .preprocessor,
+    pre .pi,
+    pre .doctype,
+    pre .shebang,
+    pre .cdata {
+      color: #999;
+      font-weight: bold
+    }
+
+    pre .deletion {
+      background: #fdd
+    }
+
+    pre .addition {
+      background: #dfd
+    }
+
+    pre .diff .change {
+      background: #0086b3
+    }
+
+    pre .chunk {
+      color: #aaa
+    }
+
+    pre .tex .formula {
+      opacity: 0.5;
+    }
+  </style>
+</head>
+<body>
+  <pre><%= ownersFile %></pre>
+</body>
+</html>

--- a/owners/templates/status.template.html
+++ b/owners/templates/status.template.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Owners Bot Status</title>
+</head>
+<body>
+  <h3>
+    The Owners Bot is live and running on <code><%= repository %></code>
+  </h3>
+
+  <a href="/tree">Owners Tree</a>
+  <br>
+  <a href="/teams">Organization Teams</a>
+</body>
+</html>

--- a/owners/templates/status.template.html
+++ b/owners/templates/status.template.html
@@ -12,5 +12,7 @@
   <a href="/tree">Owners Tree</a>
   <br>
   <a href="/teams">Organization Teams</a>
+  <br>
+  <a href="/example">Owners File Syntax</a>
 </body>
 </html>

--- a/owners/templates/teams.template.html
+++ b/owners/templates/teams.template.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Organization Teams</title>
+</head>
+<body>
+  <h3>Teams</h3>
+
+  <% for (team of teams) { %>
+  <h4>Team <code>@<%= team %></code></h4>
+  <ul>
+    <% for (member of team.members) { %>
+    <li><code>@<%= member %></code></li>
+    <% } %>
+  </ul>  
+  <% } %>
+</body>
+</html>

--- a/owners/templates/tree.template.html
+++ b/owners/templates/tree.template.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Owners Tree</title>
+</head>
+<body>
+  <h3>Owners Tree</h3>
+  <pre><%= ownersTree.toString() %></pre>
+
+  <% if (errors.length) { %>
+  <h3>Parser Errors</h3>
+  <ul>
+    <% for (error of errors) { %>
+    <li><code><%= error.ownersPath %></code>: <%= error.message %></li>
+    <% } %>
+  </ul>  
+  <% } %>
+</body>
+</html>

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -49,8 +49,8 @@ const pullRequest35 = require('./fixtures/pulls/pull_request.35');
 nock.disableNetConnect();
 jest.setTimeout(30000);
 
-const GITHUB_REPO = 'erwinmombay/github-owners-bot-test-repo';
-const GITHUB_REPO_DIR = '/Users/erwinm/dev/github-owners-bot-test-repo';
+const GITHUB_OWNER = 'erwinmombay';
+const GITHUB_REPOSITORY = 'github-owners-bot-test-repo';
 const ownersRules = [
   new OwnersRule('OWNERS', [new UserOwner('donttrustthisbot')]),
   new OwnersRule('dir1/OWNERS', [new UserOwner('donttrustthisbot')]),
@@ -66,8 +66,8 @@ describe('owners bot', () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     sandbox.stub(process, 'env').value({
-      GITHUB_REPO,
-      GITHUB_REPO_DIR,
+      GITHUB_OWNER,
+      GITHUB_REPOSITORY,
       NODE_ENV: 'test',
     });
     // Disabled execution of `git pull` for testing.


### PR DESCRIPTION
This PR:
- replaces info server endpoints that concatenated HTML with `lodash` template rendering
  > Note that `lodash` is already a dependency of Probot
- Uses the OWNERS.example file as a syntax-highlighted documentation page
- Fixes a bug introduced by prefixing path names with the repository name
- Splits apart the repo owner and name in environment variables
- Removes the old OWNERS.yaml example