### PR TITLE
[owners] Fix GitHub Search and App Engine issues

### DIFF
--- a/owners/app.yaml
+++ b/owners/app.yaml
@@ -13,3 +13,7 @@
 
 runtime: nodejs
 env: flex
+
+automatic_scaling:
+  min_num_instances: 1
+  max_num_instances: 1

--- a/owners/src/api/github.js
+++ b/owners/src/api/github.js
@@ -445,31 +445,18 @@ class GitHub {
   async searchFilename(filename) {
     this.logger.info(`Searching repo for files named "${filename}"`);
 
-    const files = [];
-    let page = 1;
-    let isLastPage = false;
-    while (!isLastPage) {
-      this.logger.info(`Fetching page ${page}`);
-      const response = await this.client.search.code({
-        q: `filename:${filename} repo:${this.owner}/${this.repository}`,
-        per_page: MAX_PER_PAGE,
-        page,
-      });
+    const files = await this._paginate(
+      this.client.search.code,
+      {q: `filename:${filename} repo:${this.owner}/${this.repository}`},
+    );
 
-      const {items} = response.data;
-      const total = response.data.total_count;
-      this.logger.debug(`Received ${items.length} results out of ${total}`);
-      files.push(...items);
-
-      isLastPage = files.length >= total || !items.length;
-      page++;
-    }
-
-    return files
+    const ownersFiles = files
       .filter(({name}) => name === filename)
       .map(({path, sha}) => {
         return {filename: path, sha};
       });
+
+    return Array.from(new Set(ownersFiles));
   }
 
   /**

--- a/owners/src/api/github.js
+++ b/owners/src/api/github.js
@@ -445,10 +445,9 @@ class GitHub {
   async searchFilename(filename) {
     this.logger.info(`Searching repo for files named "${filename}"`);
 
-    const files = await this._paginate(
-      this.client.search.code,
-      {q: `filename:${filename} repo:${this.owner}/${this.repository}`},
-    );
+    const files = await this._paginate(this.client.search.code, {
+      q: `filename:${filename} repo:${this.owner}/${this.repository}`,
+    });
 
     const ownersFiles = files
       .filter(({name}) => name === filename)

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -21,7 +21,7 @@ const {OwnersTree} = require('./owners_tree');
 const {OwnersNotifier} = require('./notifier');
 
 const GITHUB_CHECKRUN_DELAY = 2000;
-const GITHUB_GET_MEMBERS_DELAY = 3000;
+const GITHUB_GET_MEMBERS_DELAY = 1000;
 const OWNERS_CHECKRUN_NAME = 'owners-check';
 
 /**

--- a/owners/test/api/github.test.js
+++ b/owners/test/api/github.test.js
@@ -559,7 +559,8 @@ describe('GitHub API', () => {
           '/search/code?q=filename%3AOWNERS%20repo%3Atest_owner%2Ftest_repo&per_page=100'
         )
         .reply(200, searchOwnersPage1Response, {
-          link: '</search/code?q=filename%3AOWNERS%20repo%3Atest_owner%2Ftest_repo&page=2&per_page=100>; rel="next"',
+          link:
+            '</search/code?q=filename%3AOWNERS%20repo%3Atest_owner%2Ftest_repo&page=2&per_page=100>; rel="next"',
         });
       nock('https://api.github.com')
         .get(

--- a/owners/test/api/github.test.js
+++ b/owners/test/api/github.test.js
@@ -545,7 +545,7 @@ describe('GitHub API', () => {
       expect.assertions(1);
       nock('https://api.github.com')
         .get(
-          '/search/code?q=filename%3AREADME.md%20repo%3Atest_owner%2Ftest_repo&page=1&per_page=100'
+          '/search/code?q=filename%3AREADME.md%20repo%3Atest_owner%2Ftest_repo&per_page=100'
         )
         .reply(200, searchReadmeResponse);
       const files = await github.searchFilename('README.md');
@@ -556,10 +556,10 @@ describe('GitHub API', () => {
       expect.assertions(1);
       nock('https://api.github.com')
         .get(
-          '/search/code?q=filename%3AOWNERS%20repo%3Atest_owner%2Ftest_repo&page=1&per_page=100'
+          '/search/code?q=filename%3AOWNERS%20repo%3Atest_owner%2Ftest_repo&per_page=100'
         )
         .reply(200, searchOwnersPage1Response, {
-          link: '<https://api.github.com/blah/blah?page=2>; rel="next"',
+          link: '</search/code?q=filename%3AOWNERS%20repo%3Atest_owner%2Ftest_repo&page=2&per_page=100>; rel="next"',
         });
       nock('https://api.github.com')
         .get(
@@ -574,7 +574,7 @@ describe('GitHub API', () => {
       expect.assertions(3);
       nock('https://api.github.com')
         .get(
-          '/search/code?q=filename%3Aexact-match%20repo%3Atest_owner%2Ftest_repo&page=1&per_page=100'
+          '/search/code?q=filename%3Aexact-match%20repo%3Atest_owner%2Ftest_repo&per_page=100'
         )
         .reply(200, {
           total_count: 3,


### PR DESCRIPTION
The GitHub Search API is the only available way to find OWNERS files in the repo through the GitHub API. It is, however, non-deterministic, and often responds missing a few results. This PR:
- separates syncing the virtual repo's OWNERS file list from returning a list of owners files, ensuring files can't "go missing"
- switches the search pagination to use Octokit's built-in pagination
- syncs the virtual repository's OWNERS file list during initialization
- disables App Engine automatic scaling