### PR TITLE
[owners] Update GitHub API calls to use Octokit's `paginate` method

### DIFF
--- a/owners/src/api/github.js
+++ b/owners/src/api/github.js
@@ -297,8 +297,9 @@ class GitHub {
   async getReviews(number) {
     this.logger.info(`Fetching reviews for PR #${number}`);
 
-    const reviewList = await this._autoPage(
-      `/repos/${this.owner}/${this.repository}/pulls/${number}/reviews`
+    const reviewList = await this._paginate(
+      this.client.pulls.listReviews,
+      this.repo({pull_number: number}),
     );
     this.logger.debug('[getReviews]', number, reviewList);
 

--- a/owners/src/api/github.js
+++ b/owners/src/api/github.js
@@ -429,12 +429,13 @@ class GitHub {
   async listFiles(number) {
     this.logger.info(`Fetching changed files for PR #${number}`);
 
-    const response = await this.client.pullRequests.listFiles(
-      this.repo({pull_number: number})
+    const files = await this._paginate(
+      this.client.pullRequests.listFiles,
+      this.repo({pull_number: number}),
     );
-    this.logger.debug('[listFiles]', number, response.data);
+    this.logger.debug('[listFiles]', number, files);
 
-    return response.data.map(({filename}) => filename);
+    return files.map(({filename}) => filename);
   }
 
   /**

--- a/owners/src/api/github.js
+++ b/owners/src/api/github.js
@@ -264,7 +264,10 @@ class GitHub {
   async getTeamMembers(teamId) {
     this.logger.info(`Fetching team members for team with ID ${teamId}`);
 
-    const memberList = await this._autoPage(`/teams/${teamId}/members`);
+    const memberList = await this._paginate(
+      this.client.teams.listMembers,
+      {team_id: teamId},
+    );
     this.logger.debug('[getTeamMembers]', teamId, memberList);
 
     return memberList.map(({login}) => login.toLowerCase());

--- a/owners/src/api/github.js
+++ b/owners/src/api/github.js
@@ -193,8 +193,6 @@ class GitHub {
     return await this.client.request(request);
   }
 
-  
-
   /**
    * Automatically fetch multiple pages from a GitHub endpoint
    *
@@ -216,10 +214,9 @@ class GitHub {
   async getTeams() {
     this.logger.info(`Fetching teams for organization '${this.owner}'`);
 
-    const teamsList = await this._paginate(
-      this.client.teams.list,
-      {org: this.owner}
-    );
+    const teamsList = await this._paginate(this.client.teams.list, {
+      org: this.owner,
+    });
     this.logger.debug('[getTeams]', teamsList);
 
     return teamsList.map(({id, slug}) => new Team(id, this.owner, slug));
@@ -234,10 +231,9 @@ class GitHub {
   async getTeamMembers(teamId) {
     this.logger.info(`Fetching team members for team with ID ${teamId}`);
 
-    const memberList = await this._paginate(
-      this.client.teams.listMembers,
-      {team_id: teamId},
-    );
+    const memberList = await this._paginate(this.client.teams.listMembers, {
+      team_id: teamId,
+    });
     this.logger.debug('[getTeamMembers]', teamId, memberList);
 
     return memberList.map(({login}) => login.toLowerCase());
@@ -269,7 +265,7 @@ class GitHub {
 
     const reviewList = await this._paginate(
       this.client.pulls.listReviews,
-      this.repo({pull_number: number}),
+      this.repo({pull_number: number})
     );
     this.logger.debug('[getReviews]', number, reviewList);
 
@@ -344,7 +340,7 @@ class GitHub {
 
     const comments = await this._paginate(
       this.client.issues.listComments,
-      this.repo({number}),
+      this.repo({number})
     );
     this.logger.debug('[getBotComments]', number, comments);
 
@@ -431,7 +427,7 @@ class GitHub {
 
     const files = await this._paginate(
       this.client.pullRequests.listFiles,
-      this.repo({pull_number: number}),
+      this.repo({pull_number: number})
     );
     this.logger.debug('[listFiles]', number, files);
 

--- a/owners/src/api/github.js
+++ b/owners/src/api/github.js
@@ -193,6 +193,21 @@ class GitHub {
     return await this.client.request(request);
   }
 
+  
+
+  /**
+   * Automatically fetch multiple pages from a GitHub endpoint
+   *
+   * @param {!object} target Octokit API target to call.
+   * @param {!object} options options to pass to Octokit's paginate function.
+   * @return {Array<*>} list of results.
+   */
+  async _paginate(target, options) {
+    return await this.client.paginate(
+      target.endpoint.merge(Object.assign({per_page: MAX_PER_PAGE}, options))
+    );
+  }
+
   /**
    * Automatically fetch multiple pages from a GitHub endpoint
    *
@@ -231,7 +246,10 @@ class GitHub {
   async getTeams() {
     this.logger.info(`Fetching teams for organization '${this.owner}'`);
 
-    const teamsList = await this._autoPage(`/orgs/${this.owner}/teams`);
+    const teamsList = await this._paginate(
+      this.client.teams.list,
+      {org: this.owner}
+    );
     this.logger.debug('[getTeams]', teamsList);
 
     return teamsList.map(({id, slug}) => new Team(id, this.owner, slug));

--- a/owners/test/api/github.test.js
+++ b/owners/test/api/github.test.js
@@ -233,7 +233,8 @@ describe('GitHub API', () => {
       nock('https://api.github.com')
         .get('/orgs/test_owner/teams?per_page=100')
         .reply(200, Array(30).fill([{id: 1337, slug: 'my_team'}]), {
-          link: '<https://api.github.com/orgs/test_owner/teams?page=2&per_page=100>; rel="next"',
+          link:
+            '<https://api.github.com/orgs/test_owner/teams?page=2&per_page=100>; rel="next"',
         });
       nock('https://api.github.com')
         .get('/orgs/test_owner/teams?page=2&per_page=100')
@@ -260,7 +261,8 @@ describe('GitHub API', () => {
       nock('https://api.github.com')
         .get('/teams/1337/members?per_page=100')
         .reply(200, manyTeamsResponsePage1, {
-          link: '<https://api.github.com/teams/1337/members?page=2&per_page=100>; rel="next"',
+          link:
+            '<https://api.github.com/teams/1337/members?page=2&per_page=100>; rel="next"',
         });
       nock('https://api.github.com')
         .get('/teams/1337/members?page=2&per_page=100')
@@ -301,11 +303,10 @@ describe('GitHub API', () => {
     it('pages automatically', async () => {
       expect.assertions(1);
       nock('https://api.github.com')
-        .get(
-          '/repos/test_owner/test_repo/pulls/23928/reviews?per_page=100'
-        )
+        .get('/repos/test_owner/test_repo/pulls/23928/reviews?per_page=100')
         .reply(200, manyReviewsPage1Response, {
-          link: '<https://api.github.com/repos/test_owner/test_repo/pulls/23928/reviews?page=2&per_page=100>; rel="next"',
+          link:
+            '<https://api.github.com/repos/test_owner/test_repo/pulls/23928/reviews?page=2&per_page=100>; rel="next"',
         });
       nock('https://api.github.com')
         .get(
@@ -320,9 +321,7 @@ describe('GitHub API', () => {
     it('returns approvals', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get(
-          '/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100'
-        )
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100')
         .reply(200, commentReviewsResponse);
       const reviews = await github.getReviews(24686);
       const review = reviews[0];
@@ -334,9 +333,7 @@ describe('GitHub API', () => {
     it('returns post-review comments', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get(
-          '/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100'
-        )
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100')
         .reply(200, commentReviewsResponse);
       const reviews = await github.getReviews(24686);
       const review = reviews[1];
@@ -348,9 +345,7 @@ describe('GitHub API', () => {
     it('returns pre-review comments', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get(
-          '/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100'
-        )
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100')
         .reply(200, commentReviewsResponse);
       const reviews = await github.getReviews(24686);
       const review = reviews[2];
@@ -362,9 +357,7 @@ describe('GitHub API', () => {
     it('returns rejections', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get(
-          '/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100'
-        )
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100')
         .reply(200, commentReviewsResponse);
       const reviews = await github.getReviews(24686);
       const review = reviews[3];
@@ -376,9 +369,7 @@ describe('GitHub API', () => {
     it('returns comment-only reviews', async () => {
       expect.assertions(2);
       nock('https://api.github.com')
-        .get(
-          '/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100'
-        )
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100')
         .reply(200, commentReviewsResponse);
       const reviews = await github.getReviews(24686);
       const review = reviews[4];
@@ -390,9 +381,7 @@ describe('GitHub API', () => {
     it('ignores irrelevant review states', async () => {
       expect.assertions(1);
       nock('https://api.github.com')
-        .get(
-          '/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100'
-        )
+        .get('/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100')
         .reply(200, commentReviewsResponse);
       const reviews = await github.getReviews(24686);
       const review = reviews[5];
@@ -463,10 +452,13 @@ describe('GitHub API', () => {
       nock('https://api.github.com')
         .get('/repos/test_owner/test_repo/issues/24574/comments?per_page=100')
         .reply(200, issueCommentsResponse, {
-          link: '<https://api.github.com/repos/test_owner/test_repo/issues/24574/comments?page=2&per_page=100>; rel="next"',
+          link:
+            '<https://api.github.com/repos/test_owner/test_repo/issues/24574/comments?page=2&per_page=100>; rel="next"',
         });
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/issues/24574/comments?page=2&per_page=100')
+        .get(
+          '/repos/test_owner/test_repo/issues/24574/comments?page=2&per_page=100'
+        )
         .reply(200, issueCommentsResponse);
       const comments = await github.getBotComments(24574);
 
@@ -536,7 +528,8 @@ describe('GitHub API', () => {
       nock('https://api.github.com')
         .get('/repos/test_owner/test_repo/pulls/35/files?per_page=100')
         .reply(200, listFilesResponsePage1, {
-          link: '<https://api.github.com/repos/test_owner/test_repo/pulls/35/files?per_page=100&page=2>; rel="next"',
+          link:
+            '<https://api.github.com/repos/test_owner/test_repo/pulls/35/files?per_page=100&page=2>; rel="next"',
         });
       nock('https://api.github.com')
         .get('/repos/test_owner/test_repo/pulls/35/files?per_page=100&page=2')

--- a/owners/test/api/github.test.js
+++ b/owners/test/api/github.test.js
@@ -218,7 +218,7 @@ describe('GitHub API', () => {
     it('returns a list of team objects', async () => {
       expect.assertions(3);
       nock('https://api.github.com')
-        .get('/orgs/test_owner/teams?page=1&per_page=100')
+        .get('/orgs/test_owner/teams?per_page=100')
         .reply(200, [{id: 1337, slug: 'my_team'}]);
       const teams = await github.getTeams();
 
@@ -230,9 +230,9 @@ describe('GitHub API', () => {
     it('pages automatically', async () => {
       expect.assertions(1);
       nock('https://api.github.com')
-        .get('/orgs/test_owner/teams?page=1&per_page=100')
+        .get('/orgs/test_owner/teams?per_page=100')
         .reply(200, Array(30).fill([{id: 1337, slug: 'my_team'}]), {
-          link: '<https://api.github.com/blah/blah?page=2>; rel="next"',
+          link: '<https://api.github.com/orgs/test_owner/teams?page=2&per_page=100>; rel="next"',
         });
       nock('https://api.github.com')
         .get('/orgs/test_owner/teams?page=2&per_page=100')

--- a/owners/test/api/github.test.js
+++ b/owners/test/api/github.test.js
@@ -247,7 +247,7 @@ describe('GitHub API', () => {
     it('returns a list of team objects', async () => {
       expect.assertions(1);
       nock('https://api.github.com')
-        .get('/teams/1337/members?page=1&per_page=100')
+        .get('/teams/1337/members?per_page=100')
         .reply(200, [{login: 'coder'}, {login: 'githubuser'}]);
       const members = await github.getTeamMembers(1337);
 
@@ -257,9 +257,9 @@ describe('GitHub API', () => {
     it('pages automatically', async () => {
       expect.assertions(1);
       nock('https://api.github.com')
-        .get('/teams/1337/members?page=1&per_page=100')
+        .get('/teams/1337/members?per_page=100')
         .reply(200, manyTeamsResponsePage1, {
-          link: '<https://api.github.com/blah/blah?page=2>; rel="next"',
+          link: '<https://api.github.com/teams/1337/members?page=2&per_page=100>; rel="next"',
         });
       nock('https://api.github.com')
         .get('/teams/1337/members?page=2&per_page=100')

--- a/owners/test/api/github.test.js
+++ b/owners/test/api/github.test.js
@@ -288,7 +288,7 @@ describe('GitHub API', () => {
     it('fetches a list of reviews', async () => {
       expect.assertions(3);
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/pulls/35/reviews?page=1&per_page=100')
+        .get('/repos/test_owner/test_repo/pulls/35/reviews?per_page=100')
         .reply(200, reviewsApprovedResponse);
       const [review] = await github.getReviews(35);
 
@@ -301,10 +301,10 @@ describe('GitHub API', () => {
       expect.assertions(1);
       nock('https://api.github.com')
         .get(
-          '/repos/test_owner/test_repo/pulls/23928/reviews?page=1&per_page=100'
+          '/repos/test_owner/test_repo/pulls/23928/reviews?per_page=100'
         )
         .reply(200, manyReviewsPage1Response, {
-          link: '<https://api.github.com/blah/blah?page=2>; rel="next"',
+          link: '<https://api.github.com/repos/test_owner/test_repo/pulls/23928/reviews?page=2&per_page=100>; rel="next"',
         });
       nock('https://api.github.com')
         .get(
@@ -320,7 +320,7 @@ describe('GitHub API', () => {
       expect.assertions(2);
       nock('https://api.github.com')
         .get(
-          '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
+          '/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100'
         )
         .reply(200, commentReviewsResponse);
       const reviews = await github.getReviews(24686);
@@ -334,7 +334,7 @@ describe('GitHub API', () => {
       expect.assertions(2);
       nock('https://api.github.com')
         .get(
-          '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
+          '/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100'
         )
         .reply(200, commentReviewsResponse);
       const reviews = await github.getReviews(24686);
@@ -348,7 +348,7 @@ describe('GitHub API', () => {
       expect.assertions(2);
       nock('https://api.github.com')
         .get(
-          '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
+          '/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100'
         )
         .reply(200, commentReviewsResponse);
       const reviews = await github.getReviews(24686);
@@ -362,7 +362,7 @@ describe('GitHub API', () => {
       expect.assertions(2);
       nock('https://api.github.com')
         .get(
-          '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
+          '/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100'
         )
         .reply(200, commentReviewsResponse);
       const reviews = await github.getReviews(24686);
@@ -376,7 +376,7 @@ describe('GitHub API', () => {
       expect.assertions(2);
       nock('https://api.github.com')
         .get(
-          '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
+          '/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100'
         )
         .reply(200, commentReviewsResponse);
       const reviews = await github.getReviews(24686);
@@ -390,7 +390,7 @@ describe('GitHub API', () => {
       expect.assertions(1);
       nock('https://api.github.com')
         .get(
-          '/repos/test_owner/test_repo/pulls/24686/reviews?page=1&per_page=100'
+          '/repos/test_owner/test_repo/pulls/24686/reviews?per_page=100'
         )
         .reply(200, commentReviewsResponse);
       const reviews = await github.getReviews(24686);

--- a/owners/test/api/github.test.js
+++ b/owners/test/api/github.test.js
@@ -442,7 +442,7 @@ describe('GitHub API', () => {
         GITHUB_BOT_USERNAME: 'amp-owners-bot',
       });
       nock('https://api.github.com')
-        .get('/repos/test_owner/test_repo/issues/24574/comments')
+        .get('/repos/test_owner/test_repo/issues/24574/comments?per_page=100')
         .reply(200, issueCommentsResponse);
       const comments = await github.getBotComments(24574);
 
@@ -452,6 +452,24 @@ describe('GitHub API', () => {
           body: 'Test comment by ampprojectbot',
         },
       ]);
+    });
+
+    it('pages automatically', async () => {
+      expect.assertions(1);
+      sandbox.stub(process, 'env').value({
+        GITHUB_BOT_USERNAME: 'amp-owners-bot',
+      });
+      nock('https://api.github.com')
+        .get('/repos/test_owner/test_repo/issues/24574/comments?per_page=100')
+        .reply(200, issueCommentsResponse, {
+          link: '<https://api.github.com/repos/test_owner/test_repo/issues/24574/comments?page=2&per_page=100>; rel="next"',
+        });
+      nock('https://api.github.com')
+        .get('/repos/test_owner/test_repo/issues/24574/comments?page=2&per_page=100')
+        .reply(200, issueCommentsResponse);
+      const comments = await github.getBotComments(24574);
+
+      expect(comments.length).toBe(2);
     });
   });
 

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -112,14 +112,14 @@ describe('owners bot', () => {
       // We need the list of files on a pull request to evaluate the required
       // reviewers.
       nock('https://api.github.com')
-        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files')
+        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
         .reply(200, files35);
 
       // We need the reviews to check if a pull request has been approved or
       // not.
       nock('https://api.github.com')
         .get(
-          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/reviews?page=1&per_page=100'
+          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/reviews?per_page=100'
         )
         .reply(200, reviews35);
 
@@ -173,14 +173,14 @@ describe('owners bot', () => {
       // We need the list of files on a pull request to evaluate the required
       // reviewers.
       nock('https://api.github.com')
-        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files')
+        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
         .reply(200, files35);
 
       // We need the reviews to check if a pull request has been approved or
       // not.
       nock('https://api.github.com')
         .get(
-          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/reviews?page=1&per_page=100'
+          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/reviews?per_page=100'
         )
         .reply(200, reviews35);
 
@@ -238,14 +238,14 @@ describe('owners bot', () => {
       // We need the list of files on a pull request to evaluate the required
       // reviewers.
       nock('https://api.github.com')
-        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files')
+        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
         .reply(200, files35);
 
       // We need the reviews to check if a pull request has been approved or
       // not.
       nock('https://api.github.com')
         .get(
-          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/reviews?page=1&per_page=100'
+          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/reviews?per_page=100'
         )
         .reply(200, reviews35);
 
@@ -297,14 +297,14 @@ describe('owners bot', () => {
       // We need the list of files on a pull request to evaluate the required
       // reviewers.
       nock('https://api.github.com')
-        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files')
+        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
         .reply(200, files35Multiple);
 
       // We need the reviews to check if a pull request has been approved or
       // not.
       nock('https://api.github.com')
         .get(
-          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/reviews?page=1&per_page=100'
+          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/reviews?per_page=100'
         )
         .reply(200, reviews35);
 
@@ -366,14 +366,14 @@ describe('owners bot', () => {
       // We need the list of files on a pull request to evaluate the required
       // reviewers.
       nock('https://api.github.com')
-        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files')
+        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
         .reply(200, files35);
 
       // We need the reviews to check if a pull request has been approved or
       // not.
       nock('https://api.github.com')
         .get(
-          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/reviews?page=1&per_page=100'
+          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/reviews?per_page=100'
         )
         .reply(200, reviews35);
 
@@ -430,14 +430,14 @@ describe('owners bot', () => {
       // We need the list of files on a pull request to evaluate the required
       // reviewers.
       nock('https://api.github.com')
-        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files')
+        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
         .reply(200, files35);
 
       // We need the reviews to check if a pull request has been approved or
       // not.
       nock('https://api.github.com')
         .get(
-          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/reviews?page=1&per_page=100'
+          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/reviews?per_page=100'
         )
         .reply(200, reviews35Approved);
 
@@ -486,14 +486,14 @@ describe('owners bot', () => {
       // We need the list of files on a pull request to evaluate the required
       // reviewers.
       nock('https://api.github.com')
-        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/36/files')
+        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/36/files?per_page=100')
         .reply(200, files36);
 
       // We need the reviews to check if a pull request has been approved or
       // not.
       nock('https://api.github.com')
         .get(
-          '/repos/githubuser/github-owners-bot-test-repo/pulls/36/reviews?page=1&per_page=100'
+          '/repos/githubuser/github-owners-bot-test-repo/pulls/36/reviews?per_page=100'
         )
         .reply(200, reviews35);
 
@@ -546,14 +546,14 @@ describe('owners bot', () => {
       // We need the list of files on a pull request to evaluate the required
       // reviewers.
       nock('https://api.github.com')
-        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files')
+        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
         .reply(200, files35);
 
       // We need the reviews to check if a pull request has been approved or
       // not.
       nock('https://api.github.com')
         .get(
-          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/reviews?page=1&per_page=100'
+          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/reviews?per_page=100'
         )
         .reply(200, reviews35Approved);
 
@@ -607,7 +607,7 @@ describe('owners bot', () => {
       ['membership.removed'],
     ])('updates the team members on event %p', async (name, done) => {
       nock('https://api.github.com')
-        .get('/teams/42/members?page=1&per_page=100')
+        .get('/teams/42/members?per_page=100')
         .reply(200, [{login: 'coder'}]);
 
       await probot.receive({
@@ -646,7 +646,7 @@ describe('owners bot', () => {
 
       it('does nothing for a PR without owners files', async done => {
         nock('https://api.github.com')
-          .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files')
+          .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
           .reply(200, [{filename: 'foo.txt', sha: ''}]);
         await probot.receive({name: 'pull_request.closed', payload});
 
@@ -656,7 +656,7 @@ describe('owners bot', () => {
 
       it('refreshes the owners tree for a PR with owners files', async done => {
         nock('https://api.github.com')
-          .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files')
+          .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
           .reply(200, [{filename: 'OWNERS', sha: ''}]);
         await probot.receive({name: 'pull_request.closed', payload});
 

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -112,7 +112,9 @@ describe('owners bot', () => {
       // We need the list of files on a pull request to evaluate the required
       // reviewers.
       nock('https://api.github.com')
-        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
+        .get(
+          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100'
+        )
         .reply(200, files35);
 
       // We need the reviews to check if a pull request has been approved or
@@ -173,7 +175,9 @@ describe('owners bot', () => {
       // We need the list of files on a pull request to evaluate the required
       // reviewers.
       nock('https://api.github.com')
-        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
+        .get(
+          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100'
+        )
         .reply(200, files35);
 
       // We need the reviews to check if a pull request has been approved or
@@ -238,7 +242,9 @@ describe('owners bot', () => {
       // We need the list of files on a pull request to evaluate the required
       // reviewers.
       nock('https://api.github.com')
-        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
+        .get(
+          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100'
+        )
         .reply(200, files35);
 
       // We need the reviews to check if a pull request has been approved or
@@ -297,7 +303,9 @@ describe('owners bot', () => {
       // We need the list of files on a pull request to evaluate the required
       // reviewers.
       nock('https://api.github.com')
-        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
+        .get(
+          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100'
+        )
         .reply(200, files35Multiple);
 
       // We need the reviews to check if a pull request has been approved or
@@ -366,7 +374,9 @@ describe('owners bot', () => {
       // We need the list of files on a pull request to evaluate the required
       // reviewers.
       nock('https://api.github.com')
-        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
+        .get(
+          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100'
+        )
         .reply(200, files35);
 
       // We need the reviews to check if a pull request has been approved or
@@ -430,7 +440,9 @@ describe('owners bot', () => {
       // We need the list of files on a pull request to evaluate the required
       // reviewers.
       nock('https://api.github.com')
-        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
+        .get(
+          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100'
+        )
         .reply(200, files35);
 
       // We need the reviews to check if a pull request has been approved or
@@ -486,7 +498,9 @@ describe('owners bot', () => {
       // We need the list of files on a pull request to evaluate the required
       // reviewers.
       nock('https://api.github.com')
-        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/36/files?per_page=100')
+        .get(
+          '/repos/githubuser/github-owners-bot-test-repo/pulls/36/files?per_page=100'
+        )
         .reply(200, files36);
 
       // We need the reviews to check if a pull request has been approved or
@@ -546,7 +560,9 @@ describe('owners bot', () => {
       // We need the list of files on a pull request to evaluate the required
       // reviewers.
       nock('https://api.github.com')
-        .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
+        .get(
+          '/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100'
+        )
         .reply(200, files35);
 
       // We need the reviews to check if a pull request has been approved or
@@ -646,7 +662,9 @@ describe('owners bot', () => {
 
       it('does nothing for a PR without owners files', async done => {
         nock('https://api.github.com')
-          .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
+          .get(
+            '/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100'
+          )
           .reply(200, [{filename: 'foo.txt', sha: ''}]);
         await probot.receive({name: 'pull_request.closed', payload});
 
@@ -656,7 +674,9 @@ describe('owners bot', () => {
 
       it('refreshes the owners tree for a PR with owners files', async done => {
         nock('https://api.github.com')
-          .get('/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100')
+          .get(
+            '/repos/githubuser/github-owners-bot-test-repo/pulls/35/files?per_page=100'
+          )
           .reply(200, [{filename: 'OWNERS', sha: ''}]);
         await probot.receive({name: 'pull_request.closed', payload});
 


### PR DESCRIPTION
This wasn't used previously because the outdated Octokit in the outdated Probot package used to cause breakages.