### PR TITLE
[owners] Add "in progress" as a possible check-run status

### DIFF
--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -164,7 +164,7 @@ class OwnersCheck {
       // If anything goes wrong, report a failing check.
       return {
         checkRun: new CheckRun(
-          CheckRunConclusion.FAILURE,
+          CheckRunState.FAILURE,
           'The check encountered an error!',
           'OWNERS check encountered an error:\n' + error
         ),

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -20,7 +20,7 @@ const {ReviewerSelection} = require('./reviewer_selection');
 const GITHUB_CHECKRUN_NAME = 'ampproject/owners-check';
 const EXAMPLE_OWNERS_LINK = 'http://ampproject-owners-bot.appspot.com/example';
 
-const CheckRunConclusion = {
+const CheckRunState = {
   SUCCESS: 'success',
   FAILURE: 'failure',
   NEUTRAL: 'neutral',
@@ -34,7 +34,7 @@ class CheckRun {
   /**
    * Constructor.
    *
-   * @param {!CheckRunConclusion} conclusion result of the check-run.
+   * @param {!CheckRunState} conclusion result of the check-run.
    * @param {string} summary check-run summary text to show in PR.
    * @param {string} text description of check-run results.
    */
@@ -108,7 +108,7 @@ class OwnersCheck {
       if (prHasFullOwnersCoverage && prHasReviewerSetApproval) {
         return {
           checkRun: new CheckRun(
-            CheckRunConclusion.SUCCESS,
+            CheckRunState.SUCCESS,
             'All files in this PR have OWNERS approval',
             coverageText
           ),
@@ -121,7 +121,7 @@ class OwnersCheck {
 
         return {
           checkRun: new CheckRun(
-            CheckRunConclusion.ACTION_REQUIRED,
+            CheckRunState.ACTION_REQUIRED,
             'Missing review from a member of the reviewer set',
             `${reviewerSetText}\n\n${coverageText}`
           ),
@@ -143,7 +143,7 @@ class OwnersCheck {
       );
       return {
         checkRun: new CheckRun(
-          CheckRunConclusion.ACTION_REQUIRED,
+          CheckRunState.ACTION_REQUIRED,
           'Missing required OWNERS approvals! ' +
             `Suggested reviewers: ${reviewers.join(', ')}`,
           `${coverageText}\n\n${suggestionsText}`
@@ -154,7 +154,7 @@ class OwnersCheck {
       // If anything goes wrong, report a failing check.
       return {
         checkRun: new CheckRun(
-          CheckRunConclusion.NEUTRAL,
+          CheckRunState.NEUTRAL,
           'The check encountered an error!',
           'OWNERS check encountered an error:\n' + error
         ),
@@ -338,5 +338,5 @@ class OwnersCheck {
 module.exports = {
   OwnersCheck,
   CheckRun,
-  CheckRunConclusion,
+  CheckRunState,
 };

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -22,6 +22,7 @@ const EXAMPLE_OWNERS_LINK = 'http://ampproject-owners-bot.appspot.com/example';
 
 const CheckRunState = {
   SUCCESS: 'success',
+  IN_PROGRESS: 'in_progress',
   FAILURE: 'failure',
   NEUTRAL: 'neutral',
   ACTION_REQUIRED: 'action_required',
@@ -48,17 +49,26 @@ class CheckRun {
    * @return {!object} JSON object describing check-run.
    */
   get json() {
-    return {
+    const checkRun = {
       name: GITHUB_CHECKRUN_NAME,
-      status: 'completed',
-      conclusion: this.state,
-      completed_at: new Date(),
       output: {
         title: this.summary,
         summary: this.summary,
         text: `${this.text}\n\n${this.helpText}`,
       },
     };
+
+    if (this.state === CheckRunState.IN_PROGRESS) {
+      checkRun.status = this.state;
+    } else {
+      Object.assign(checkRun, {
+        status: 'completed',
+        conclusion: this.state,
+        completed_at: new Date(),
+      });
+    }
+
+    return checkRun;
   }
 }
 CheckRun.prototype.helpText =

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -131,7 +131,7 @@ class OwnersCheck {
 
         return {
           checkRun: new CheckRun(
-            CheckRunState.ACTION_REQUIRED,
+            CheckRunState.IN_PROGRESS,
             'Missing review from a member of the reviewer set',
             `${reviewerSetText}\n\n${coverageText}`
           ),

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -34,12 +34,12 @@ class CheckRun {
   /**
    * Constructor.
    *
-   * @param {!CheckRunState} conclusion result of the check-run.
+   * @param {!CheckRunState} state result of the check-run.
    * @param {string} summary check-run summary text to show in PR.
    * @param {string} text description of check-run results.
    */
-  constructor(conclusion, summary, text) {
-    Object.assign(this, {conclusion, summary, text});
+  constructor(state, summary, text) {
+    Object.assign(this, {state, summary, text});
   }
 
   /**
@@ -51,7 +51,7 @@ class CheckRun {
     return {
       name: GITHUB_CHECKRUN_NAME,
       status: 'completed',
-      conclusion: this.conclusion,
+      conclusion: this.state,
       completed_at: new Date(),
       output: {
         title: this.summary,

--- a/owners/test/api/github.test.js
+++ b/owners/test/api/github.test.js
@@ -18,7 +18,7 @@ const nock = require('nock');
 const sinon = require('sinon');
 const Octokit = require('@octokit/rest');
 
-const {CheckRun, CheckRunConclusion} = require('../../src/owners_check');
+const {CheckRun, CheckRunState} = require('../../src/owners_check');
 const {GitHub, PullRequest, Review, Team} = require('../../src/api/github');
 
 const reviewsApprovedResponse = require('../fixtures/reviews/reviews.35.approved.json');
@@ -585,7 +585,7 @@ describe('GitHub API', () => {
         })
         .reply(200);
       const checkRun = new CheckRun(
-        CheckRunConclusion.NEUTRAL,
+        CheckRunState.NEUTRAL,
         'Test summary',
         'Test text'
       );
@@ -660,7 +660,7 @@ describe('GitHub API', () => {
         })
         .reply(200);
       const checkRun = new CheckRun(
-        CheckRunConclusion.NEUTRAL,
+        CheckRunState.NEUTRAL,
         'Test summary',
         'Test text'
       );

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -22,7 +22,7 @@ const {OwnersNotifier} = require('../src/notifier');
 const {OwnersTree} = require('../src/owners_tree');
 const {
   CheckRun,
-  CheckRunConclusion,
+  CheckRunState,
   OwnersCheck,
 } = require('../src/owners_check');
 
@@ -185,7 +185,7 @@ describe('owners bot', () => {
 
   describe('runOwnersCheck', () => {
     const checkRun = new CheckRun(
-      CheckRunConclusion.SUCCESS,
+      CheckRunState.SUCCESS,
       'Success!',
       'The owners check passed.'
     );

--- a/owners/test/owners_bot.test.js
+++ b/owners/test/owners_bot.test.js
@@ -20,11 +20,7 @@ const LocalRepository = require('../src/repo/local_repo');
 const {OwnersBot} = require('../src/owners_bot');
 const {OwnersNotifier} = require('../src/notifier');
 const {OwnersTree} = require('../src/owners_tree');
-const {
-  CheckRun,
-  CheckRunState,
-  OwnersCheck,
-} = require('../src/owners_check');
+const {CheckRun, CheckRunState, OwnersCheck} = require('../src/owners_check');
 
 describe('owners bot', () => {
   const silentLogger = {

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -17,7 +17,7 @@
 const sinon = require('sinon');
 const {
   CheckRun,
-  CheckRunConclusion,
+  CheckRunState,
   OwnersCheck,
 } = require('../src/owners_check');
 const {UserOwner, TeamOwner, OWNER_MODIFIER} = require('../src/owner');
@@ -37,7 +37,7 @@ describe('check run', () => {
     it('produces a JSON object in the GitHub API format', () => {
       sandbox.stub(CheckRun.prototype, 'helpText').value('HELP TEXT');
       const checkRun = new CheckRun(
-        CheckRunConclusion.NEUTRAL,
+        CheckRunState.NEUTRAL,
         'Test summary',
         'Test text'
       );

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -15,11 +15,7 @@
  */
 
 const sinon = require('sinon');
-const {
-  CheckRun,
-  CheckRunState,
-  OwnersCheck,
-} = require('../src/owners_check');
+const {CheckRun, CheckRunState, OwnersCheck} = require('../src/owners_check');
 const {UserOwner, TeamOwner, OWNER_MODIFIER} = require('../src/owner');
 const {Team} = require('../src/api/github');
 const {OwnersTree} = require('../src/owners_tree');
@@ -57,23 +53,30 @@ describe('check run', () => {
       [CheckRunState.FAILURE, 'failure'],
       [CheckRunState.NEUTRAL, 'neutral'],
       [CheckRunState.ACTION_REQUIRED, 'action_required'],
-    ])('with state %p has conclusion %p and "completed_at"', (state, conclusion) => {
-      const checkRun = new CheckRun(state, 'Test summary', 'Test text');
-      const checkRunJson = checkRun.json;
-      
-      expect(checkRunJson.status).toEqual('completed');
-      expect(checkRunJson.conclusion).toEqual(conclusion);
-      expect(checkRunJson.completed_at).not.toBeUndefined();
-    });
+    ])(
+      'with state %p has conclusion %p and "completed_at"',
+      (state, conclusion) => {
+        const checkRun = new CheckRun(state, 'Test summary', 'Test text');
+        const checkRunJson = checkRun.json;
+
+        expect(checkRunJson.status).toEqual('completed');
+        expect(checkRunJson.conclusion).toEqual(conclusion);
+        expect(checkRunJson.completed_at).not.toBeUndefined();
+      }
+    );
 
     it('with state "in_progress" has no conclusion or completed_at', () => {
-      const checkRun = new CheckRun(CheckRunState.IN_PROGRESS, 'Test summary', 'Test text');
+      const checkRun = new CheckRun(
+        CheckRunState.IN_PROGRESS,
+        'Test summary',
+        'Test text'
+      );
       const checkRunJson = checkRun.json;
-      
+
       expect(checkRunJson.status).toEqual('in_progress');
       expect(checkRunJson.conclusion).toBeUndefined();
       expect(checkRunJson.completed_at).toBeUndefined();
-    })
+    });
   });
 });
 

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -34,8 +34,11 @@ describe('check run', () => {
   });
 
   describe('json', () => {
-    it('produces a JSON object in the GitHub API format', () => {
+    beforeEach(() => {
       sandbox.stub(CheckRun.prototype, 'helpText').value('HELP TEXT');
+    });
+
+    it('produces a JSON object in the GitHub API format', () => {
       const checkRun = new CheckRun(
         CheckRunState.NEUTRAL,
         'Test summary',
@@ -44,11 +47,22 @@ describe('check run', () => {
       const checkRunJson = checkRun.json;
 
       expect(checkRunJson.name).toEqual('ampproject/owners-check');
-      expect(checkRunJson.status).toEqual('completed');
-      expect(checkRunJson.conclusion).toEqual('neutral');
       expect(checkRunJson.output.title).toEqual('Test summary');
       expect(checkRunJson.output.summary).toEqual('Test summary');
       expect(checkRunJson.output.text).toEqual('Test text\n\nHELP TEXT');
+    });
+
+    it.each([
+      [CheckRunState.SUCCESS, 'success'],
+      [CheckRunState.FAILURE, 'failure'],
+      [CheckRunState.NEUTRAL, 'neutral'],
+      [CheckRunState.ACTION_REQUIRED, 'action_required'],
+    ])('with state %p has conclusion %p and "completed_at"', (state, conclusion) => {
+      const checkRun = new CheckRun(state, 'Test summary', 'Test text');
+      const checkRunJson = checkRun.json;
+      
+      expect(checkRunJson.conclusion).toEqual(conclusion);
+      expect(checkRunJson.completed_at).not.toBeUndefined();
     });
   });
 });

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -184,9 +184,9 @@ describe('owners check', () => {
             ownersTree.addRule(reviewerSetRule);
           });
 
-          it('has an action-required conclusion', () => {
+          it('has an in-progress status', () => {
             const {checkRun} = ownersCheck.run();
-            expect(checkRun.json.conclusion).toEqual('action_required');
+            expect(checkRun.json.status).toEqual('in_progress');
           });
 
           it('has a failing summary', () => {

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -61,9 +61,19 @@ describe('check run', () => {
       const checkRun = new CheckRun(state, 'Test summary', 'Test text');
       const checkRunJson = checkRun.json;
       
+      expect(checkRunJson.status).toEqual('completed');
       expect(checkRunJson.conclusion).toEqual(conclusion);
       expect(checkRunJson.completed_at).not.toBeUndefined();
     });
+
+    it('with state "in_progress" has no conclusion or completed_at', () => {
+      const checkRun = new CheckRun(CheckRunState.IN_PROGRESS, 'Test summary', 'Test text');
+      const checkRunJson = checkRun.json;
+      
+      expect(checkRunJson.status).toEqual('in_progress');
+      expect(checkRunJson.conclusion).toBeUndefined();
+      expect(checkRunJson.completed_at).toBeUndefined();
+    })
   });
 });
 


### PR DESCRIPTION
Closes #596 

Adds support for check-runs to have an "in progress" status. If a PR has reviews requested from enough OWNERS but they have not yet given approval, it will report an "in progress" status