### PR TITLE
[owners] Better handling for `requestReviews: false`

### DIFF
--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -104,22 +104,35 @@ class OwnersNotifier {
   }
 
   /**
+   * Checks if a reviewer should be requested.
+   *
+   * If there is any file for which the reviewer is a non-silent owner, this
+   * should be true.
+   *
+   * @param {string} reviewer reviewer username.
+   * @return {boolean} if the reviewer is a non-silent owner of a changed file.
+   */
+  _shouldRequestReview(reviewer) {
+    return Object.entries(this.fileTreeMap)
+      .map(([filename, subtree]) => subtree.fileOwners(filename))
+      .some(fileOwners => {
+        for (const owner of fileOwners) {
+          if (owner.includes(reviewer)) {
+            return owner.modifier !== OWNER_MODIFIER.SILENT;
+          }
+        }
+      });
+  }
+
+  /**
    * Determine the set of users to request reviews from.
    *
    * @param {!Array<string>} suggestedReviewers list of suggested reviewer usernames.
    * @return {!Array<string>} list of usernames.
    */
   getReviewersToRequest(suggestedReviewers) {
-    const reviewers = new Set(suggestedReviewers);
-    Object.entries(this.fileTreeMap).forEach(([filename, subtree]) => {
-      subtree
-        .getModifiedFileOwners(filename, OWNER_MODIFIER.SILENT)
-        .map(owner => owner.allUsernames)
-        .reduce((left, right) => left.concat(right), [])
-        .forEach(reviewers.delete, reviewers);
-    });
-
-    return Array.from(reviewers);
+    return Array.from(new Set(suggestedReviewers))
+      .filter(this._shouldRequestReview, this);
   }
 
   /**

--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -131,8 +131,10 @@ class OwnersNotifier {
    * @return {!Array<string>} list of usernames.
    */
   getReviewersToRequest(suggestedReviewers) {
-    return Array.from(new Set(suggestedReviewers))
-      .filter(this._shouldRequestReview, this);
+    return Array.from(new Set(suggestedReviewers)).filter(
+      this._shouldRequestReview,
+      this
+    );
   }
 
   /**

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -25,6 +25,7 @@ describe('notifier', () => {
   const sandbox = sinon.createSandbox();
   const loggerStub = sinon.stub();
   const github = new GitHub(sinon.stub(), 'ampproject', 'amphtml', loggerStub);
+  let tree;
   let pr;
 
   beforeEach(() => {
@@ -35,6 +36,9 @@ describe('notifier', () => {
       'description',
       'open'
     );
+
+    tree = new OwnersTree();
+    tree.addRule(new OwnersRule('OWNERS', [new UserOwner('auser')]));
   });
 
   afterEach(() => {
@@ -45,7 +49,7 @@ describe('notifier', () => {
     let notifier;
 
     beforeEach(() => {
-      notifier = new OwnersNotifier(pr, {}, new OwnersTree(), []);
+      notifier = new OwnersNotifier(pr, {}, tree, ['script.js']);
       sandbox.stub(GitHub.prototype, 'createReviewRequests');
       sandbox.stub(OwnersNotifier.prototype, 'createNotificationComment');
     });
@@ -265,7 +269,6 @@ describe('notifier', () => {
   });
 
   describe('getReviewersToRequest', () => {
-    let tree;
     const busyTeam = new Team(42, 'ampproject', 'busy_team');
     busyTeam.members = ['busy_member'];
     let notifier;
@@ -276,14 +279,9 @@ describe('notifier', () => {
         .withArgs(sinon.match.string, OWNER_MODIFIER.SILENT)
         .returns([new UserOwner('busy_user'), new TeamOwner(busyTeam)]);
 
-      tree = new OwnersTree();
       tree.addRule(
         new OwnersRule('foo/OWNERS', [
           new UserOwner('busy_user', OWNER_MODIFIER.SILENT),
-        ])
-      );
-      tree.addRule(
-        new OwnersRule('foo/OWNERS', [
           new TeamOwner(busyTeam, OWNER_MODIFIER.SILENT),
         ])
       );
@@ -305,23 +303,94 @@ describe('notifier', () => {
       const reviewRequests = notifier.getReviewersToRequest(['busy_member']);
       expect(reviewRequests).not.toContain('busy_member');
     });
+
+    describe('nested directory rules', () => {
+      it('includes non-silent owners in deeper OWNERS files', () => {
+        tree.addRule(
+          new OwnersRule('foo/foobar/OWNERS', [
+            new UserOwner('busy_user'),
+            new TeamOwner(busyTeam),
+          ])
+        );
+        notifier = new OwnersNotifier(pr, {}, tree, [
+          'foo/script.js',
+          'foo/foobar/style.css'
+        ]);
+
+        const reviewRequests = notifier.getReviewersToRequest([
+          'busy_user',
+          'busy_member',
+        ]);
+
+        expect(reviewRequests).toContain('busy_user');
+        expect(reviewRequests).toContain('busy_member');
+      });
+
+      it('excludes non-silent owners in higher OWNERS files', () => {
+        tree.addRule(
+          new OwnersRule('OWNERS', [
+            new UserOwner('busy_user'),
+            new TeamOwner(busyTeam),
+          ])
+        );
+        notifier = new OwnersNotifier(pr, {}, tree, [
+          'foo/script.js',
+          'foo/foobar/style.css'
+        ]);
+   
+        const reviewRequests = notifier.getReviewersToRequest([
+          'busy_user',
+          'busy_member',
+        ]);
+
+        expect(reviewRequests).not.toContain('busy_user');
+        expect(reviewRequests).not.toContain('busy_member');
+      });
+    });
+
+    describe('adjacent directory rules', () => {
+      beforeEach(() => {
+        tree.addRule(
+          new OwnersRule('bar/OWNERS', [
+            new UserOwner('busy_user'),
+            new TeamOwner(busyTeam),
+          ])
+        );
+        notifier = new OwnersNotifier(pr, {}, tree, [
+          'foo/script.js',
+          'bar/style.css'
+        ]);
+      });
+
+      it('includes non-silent owners in other branches\' OWNERS files', () => {
+        const reviewRequests = notifier.getReviewersToRequest([
+          'busy_user',
+          'busy_member',
+        ]);
+
+        expect(reviewRequests).toContain('busy_user');
+        expect(reviewRequests).toContain('busy_member');
+      });
+    });
   });
 
   describe('getOwnersToNotify', () => {
-    const tree = new OwnersTree();
     const relevantTeam = new Team(42, 'ampproject', 'relevant_team');
     relevantTeam.members = ['relevant_member'];
-    tree.addRule(
-      new OwnersRule('foo/OWNERS', [
-        new UserOwner('relevant_user', OWNER_MODIFIER.NOTIFY),
-      ])
-    );
-    tree.addRule(
-      new OwnersRule('bar/OWNERS', [
-        new TeamOwner(relevantTeam, OWNER_MODIFIER.NOTIFY),
-      ])
-    );
-    tree.addRule(new OwnersRule('baz/OWNERS', [new UserOwner('rando')]));
+
+    beforeEach(() => {
+      tree.addRule(
+        new OwnersRule('foo/OWNERS', [
+          new UserOwner('relevant_user', OWNER_MODIFIER.NOTIFY),
+        ])
+      );
+      tree.addRule(
+        new OwnersRule('bar/OWNERS', [
+          new TeamOwner(relevantTeam, OWNER_MODIFIER.NOTIFY),
+        ])
+      );
+      tree.addRule(new OwnersRule('baz/OWNERS', [new UserOwner('rando')]));
+    });
 
     it('includes user owners with the always-notify modifier', () => {
       const notifier = new OwnersNotifier(pr, {}, tree, [

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -314,7 +314,7 @@ describe('notifier', () => {
         );
         notifier = new OwnersNotifier(pr, {}, tree, [
           'foo/script.js',
-          'foo/foobar/style.css'
+          'foo/foobar/style.css',
         ]);
 
         const reviewRequests = notifier.getReviewersToRequest([
@@ -335,9 +335,9 @@ describe('notifier', () => {
         );
         notifier = new OwnersNotifier(pr, {}, tree, [
           'foo/script.js',
-          'foo/foobar/style.css'
+          'foo/foobar/style.css',
         ]);
-   
+
         const reviewRequests = notifier.getReviewersToRequest([
           'busy_user',
           'busy_member',
@@ -358,11 +358,11 @@ describe('notifier', () => {
         );
         notifier = new OwnersNotifier(pr, {}, tree, [
           'foo/script.js',
-          'bar/style.css'
+          'bar/style.css',
         ]);
       });
 
-      it('includes non-silent owners in other branches\' OWNERS files', () => {
+      it("includes non-silent owners in other branches' OWNERS files", () => {
         const reviewRequests = notifier.getReviewersToRequest([
           'busy_user',
           'busy_member',


### PR DESCRIPTION
Currently, the owners bot handles the `requestReviews: false` modifier by determining the set of reviewers to request, then removing any with the silent modifier in any owners path. This has the following odd effect:

If I am an owner in `foo/OWNERS` with `requestReviews: false` as well as an owner in `bar/OWNERS` with no modifier, a PR touching both directories will not request me as a reviewer, even though I should be assigned because of my ownership of `bar`.

Likewise, if I am an owner in `OWNERS` with `requestReviews: false` as well as an owner in `bar/OWNERS` with no modifier, a PR touching `bar/foo.js` will not request me as a reviewer, even though I have not explicitly opted out of review requests in `bar`.

Both of these cases are counterintuitive. This PR first adds tests for each, then rewrites the notifier code which determines who to send review requests to.