### PR TITLE
[owners] Fetch and save the set of known file refs through the cache

### DIFF
--- a/owners/info_server.js
+++ b/owners/info_server.js
@@ -145,7 +145,7 @@ class InfoServer extends Server {
     this.get(`/_cron/${taskName}`, async req => {
       // This header is set by App Engine when running cron tasks, and is
       // stripped out of external requests.
-      if (!req.header('X-Appengine-Cron')) {
+      if (!req.header('X-Appengine-Cron') && process.env.NODE_ENV !== 'dev') {
         throw new Error('Attempted external request to a cron endpoint');
       }
 

--- a/owners/src/cache/cloud_storage_cache.js
+++ b/owners/src/cache/cloud_storage_cache.js
@@ -45,7 +45,7 @@ module.exports = class CloudStorageCache extends FileCache {
       this.logger.info(`Fetching "${filename}" from Cloud Storage cache`);
       return await this.storage.download(filename);
     } catch (e) {
-      this.logger.info(`Memory cache miss on "${filename}"`);
+      this.logger.info(`Cloud Storage cache miss on "${filename}"`);
       const contents = await getContents();
 
       this.logger.info(`Uploading "${filename}" to Cloud Storage cache`);

--- a/owners/src/owners_bot.js
+++ b/owners/src/owners_bot.js
@@ -78,7 +78,7 @@ class OwnersBot {
    * @param {Logger} logger logging interface
    */
   async refreshTree(logger = console) {
-    logger.info(`Refreshing owners tree`);
+    logger.info('Refreshing owners tree');
 
     await this.repo.sync();
     await this.reparseTree(logger);
@@ -90,6 +90,8 @@ class OwnersBot {
    * @param {Logger} logger logging interface
    */
   async reparseTree(logger = console) {
+    logger.info('Re-parsing owners tree');
+
     this.treeParse = await this.parser.parseOwnersTree();
     this.treeParse.errors.forEach(logger.warn, logger);
   }

--- a/owners/src/repo/virtual_repo.js
+++ b/owners/src/repo/virtual_repo.js
@@ -69,9 +69,8 @@ module.exports = class VirtualRepository extends Repository {
     if (fileChanged) {
       const fileRefsPath = this.repoPath('__fileRefs__');
       await this.cache.invalidate(fileRefsPath);
-      await this.cache.readFile(
-        fileRefsPath,
-        () => JSON.stringify(Array.from(this._fileRefs))
+      await this.cache.readFile(fileRefsPath, () =>
+        JSON.stringify(Array.from(this._fileRefs))
       );
     }
   }

--- a/owners/src/repo/virtual_repo.js
+++ b/owners/src/repo/virtual_repo.js
@@ -30,7 +30,7 @@ module.exports = class VirtualRepository extends Repository {
     super();
     this.github = github;
     this.logger = github.logger;
-    /** @type {?Map<string, string>} */
+    /** @type {!Map<string, string>} */
     this._fileRefs = new Map();
     this.cache = cache;
   }

--- a/owners/src/repo/virtual_repo.js
+++ b/owners/src/repo/virtual_repo.js
@@ -39,7 +39,29 @@ module.exports = class VirtualRepository extends Repository {
    * Fetch the latest versions of all OWNERS files.
    */
   async sync() {
-    await this.findOwnersFiles();
+    const ownersFiles = await this.github.searchFilename('OWNERS');
+
+    for (const {filename, sha} of ownersFiles) {
+      const repoPath = this.repoPath(filename);
+      const fileSha = this._fileRefs.get(repoPath);
+
+      if (!fileSha) {
+        // File has never been fetched and should be added to the cache.
+        this.logger.info(`Recording SHA for file "${repoPath}"`);
+
+        this._fileRefs.set(repoPath, sha);
+      } else if (fileSha !== sha) {
+        // File has been updated and needs to be re-fetched.
+        this.logger.info(
+          `Updating SHA and clearing cache for file "${repoPath}"`
+        );
+
+        this._fileRefs.set(repoPath, sha);
+        await this.cache.invalidate(repoPath);
+      } else {
+        this.logger.debug(`Ignoring unchanged file "${repoPath}"`);
+      }
+    }
   }
 
   /**
@@ -58,8 +80,9 @@ module.exports = class VirtualRepository extends Repository {
    * @param {?function} cacheMissCallback called when there is a cache miss.
    */
   async warmCache(cacheMissCallback) {
+    await this.sync();
     const ownersFiles = await this.findOwnersFiles();
-    return await Promise.all(
+    await Promise.all(
       ownersFiles.map(filename => this.readFile(filename, cacheMissCallback))
     );
   }
@@ -101,27 +124,9 @@ module.exports = class VirtualRepository extends Repository {
    * @return {!Array<string>} a list of relative OWNERS file paths.
    */
   async findOwnersFiles() {
-    const ownersFiles = await this.github.searchFilename('OWNERS');
-
-    ownersFiles.forEach(({filename, sha}) => {
-      const repoPath = this.repoPath(filename);
-      const fileSha = this._fileRefs.get(repoPath);
-      if (!fileSha) {
-        // File has never been fetched and should be added to the cache.
-        this.logger.info(`Recording SHA for file "${repoPath}"`);
-        this._fileRefs.set(repoPath, sha);
-      } else if (fileSha !== sha) {
-        // File has been updated and needs to be re-fetched.
-        this.logger.info(
-          `Updating SHA and clearing cache for file "${repoPath}"`
-        );
-        this._fileRefs.set(repoPath, sha);
-        this.cache.invalidate(repoPath);
-      } else {
-        this.logger.debug(`Ignoring unchanged file "${repoPath}"`);
-      }
-    });
-
-    return ownersFiles.map(({filename}) => filename);
+    const repoPrefix = this.repoPath('');
+    return Array.from(this._fileRefs.keys())
+      .filter(filename => filename.startsWith(repoPrefix))
+      .map(filename => filename.substr(repoPrefix.length));
   }
 };

--- a/owners/test/repo/virtual_repo.test.js
+++ b/owners/test/repo/virtual_repo.test.js
@@ -158,14 +158,14 @@ describe('virtual repository', () => {
     it('fetches file refs from GitHub', async () => {
       await repo.warmCache();
 
-      sandbox.assert.calledWith(
-        github.getFileContents.getCall(0),
-        {filename: 'OWNERS', sha: 'sha_1'},
-      );
-      sandbox.assert.calledWith(
-        github.getFileContents.getCall(1),
-        {filename: 'foo/OWNERS', sha: 'sha_2'},
-      );
+      sandbox.assert.calledWith(github.getFileContents.getCall(0), {
+        filename: 'OWNERS',
+        sha: 'sha_1',
+      });
+      sandbox.assert.calledWith(github.getFileContents.getCall(1), {
+        filename: 'foo/OWNERS',
+        sha: 'sha_2',
+      });
     });
 
     describe('when file refs are in the cache', () => {
@@ -209,17 +209,17 @@ describe('virtual repository', () => {
         sandbox.assert.calledWith(
           repo.cache.readFile,
           'test_repo/__fileRefs__',
-          sinon.match.any,
+          sinon.match.any
         );
         sandbox.assert.calledWith(
           repo.cache.readFile,
           'test_repo/OWNERS',
-          sinon.match.any,
+          sinon.match.any
         );
         sandbox.assert.calledWith(
           repo.cache.readFile,
           'test_repo/foo/OWNERS',
-          sinon.match.any,
+          sinon.match.any
         );
         done();
       });


### PR DESCRIPTION
The GitHub Search API is the only available API method by which the virtual repo can determine the list of OWNERS files. Since this API is non-deterministic and often leaves out results, it's useful to keep a copy of the file ref list available, rather than fetching it from the API each time the tree is parsed. This PR updates the virtual repo to fetch the list of file refs through the cache, and updates the cache whenever it sees that a file ref sha has changed.

This means that even if the first request during warm-up doesn't catch all the owners files, each subsequent attempt will improve coverage, and the combination will be available going forward (even on system start-up, as it's cached in Cloud Storage).