### PR TITLE
Set up build targets for amp-github-apps

### DIFF
--- a/build-system/build-targets.js
+++ b/build-system/build-targets.js
@@ -31,10 +31,6 @@ const ALL_TARGETS = ['bundle-size', 'owners', 'pr-deploy', 'test-status'];
  */
 const targetMatchers = [
   {
-    targets: ALL_TARGETS,
-    func: file => file.startsWith('build-system') || path.dirname(file) === '.',
-  },
-  {
     targets: ['bundle-size'],
     func: file => file.startsWith('bundle-size/'),
   },
@@ -68,6 +64,11 @@ function determineBuildTargets(fileName = 'build-targets.js') {
     .map(matcher => matcher.targets)
     .reduce((left, right) => left.concat(right), [])
     .forEach(buildTargets.add, buildTargets);
+  
+  if (buildTargets.size === 0) {
+    // Default to running all test targets if no other targets are matched.
+    ALL_TARGETS.forEach(buildTargets.add, buildTargets)
+  }
 
   const targetList = Array.from(buildTargets)
     .sort()

--- a/build-system/build-targets.js
+++ b/build-system/build-targets.js
@@ -23,29 +23,24 @@
 const {bold, cyan, yellow} = require('ansi-colors');
 const {gitDiffNameOnlyMaster} = require('./git');
 
-const ALL_TARGETS = ['bundle-size', 'owners', 'pr-deploy', 'test-status'];
+const APP_TARGETS = {
+  'BUNDLE_SIZE': 'bundle-size',
+  'OWNERS': 'owners',
+  'PR_DEPLOY': 'pr-deploy',
+  'TEST_STATUS': 'test-status',
+};
+const ALL_TARGETS = [...Object.keys(APP_TARGETS)];
 
 /**
  * A mapping of functions that match a given file to one or more build targets.
  */
-const targetMatchers = [
-  {
-    targets: ['bundle-size'],
-    func: file => file.startsWith('bundle-size/'),
-  },
-  {
-    targets: ['owners'],
-    func: file => file.startsWith('owners/'),
-  },
-  {
-    targets: ['pr-deploy'],
-    func: file => file.startsWith('pr-deploy/'),
-  },
-  {
-    targets: ['test-status'],
-    func: file => file.startsWith('test-status/'),
-  },
-];
+const appTargetMatchers = Object.entries(APP_TARGETS).map((target, appName) => {
+  return {
+    targets: [target],
+    func: file => file.startsWith(appName),
+  };
+});
+const targetMatchers = [...appTargetMatchers];
 
 /**
  * Populates buildTargets with a set of build targets contained in a PR after
@@ -82,5 +77,7 @@ function determineBuildTargets(fileName = 'build-targets.js') {
 }
 
 module.exports = {
+  ALL_TARGETS,
+  APP_TARGETS,
   determineBuildTargets,
 };

--- a/build-system/build-targets.js
+++ b/build-system/build-targets.js
@@ -21,7 +21,6 @@
  * determine which tasks are required to run for pull request builds.
  */
 const {bold, cyan, yellow} = require('ansi-colors');
-const path = require('path');
 const {gitDiffNameOnlyMaster} = require('./git');
 
 const ALL_TARGETS = ['bundle-size', 'owners', 'pr-deploy', 'test-status'];
@@ -64,10 +63,10 @@ function determineBuildTargets(fileName = 'build-targets.js') {
     .map(matcher => matcher.targets)
     .reduce((left, right) => left.concat(right), [])
     .forEach(buildTargets.add, buildTargets);
-  
+
   if (buildTargets.size === 0) {
     // Default to running all test targets if no other targets are matched.
-    ALL_TARGETS.forEach(buildTargets.add, buildTargets)
+    ALL_TARGETS.forEach(buildTargets.add, buildTargets);
   }
 
   const targetList = Array.from(buildTargets)

--- a/build-system/build-targets.js
+++ b/build-system/build-targets.js
@@ -24,22 +24,7 @@ const {bold, cyan, yellow} = require('ansi-colors');
 const path = require('path');
 const {gitDiffNameOnlyMaster} = require('./git');
 
-const ALL_TARGETS = ['BUNDLE_SIZE', 'OWNERS', 'PR_DEPLOY', 'TEST_STATUS'];
-
-/**
- * Determines if a file is a filetype containing code.
- *
- * @param {string} filePath
- * @return {boolean}
- */
-function isCode(filePath) {
-  const fileName = path.basename(filePath);
-  return !(
-    fileName.startsWith('.') ||
-    fileName.endsWith('.md') ||
-    fileName === 'LICENSE'
-  );
-}
+const ALL_TARGETS = ['bundle-size', 'owners', 'pr-deploy', 'test-status'];
 
 /**
  * A mapping of functions that match a given file to one or more build targets.
@@ -47,26 +32,23 @@ function isCode(filePath) {
 const targetMatchers = [
   {
     targets: ALL_TARGETS,
-    func: file =>
-      (isCode(file) && file.startsWith('build-system') ||
-      file === 'package.json' ||
-      file === 'package-lock.json'),
+    func: file => file.startsWith('build-system') || path.dirname(file) === '.',
   },
   {
-    targets: ['BUNDLE_SIZE'],
-    func: file => isCode(file) && file.startsWith('bundle-size/'),
+    targets: ['bundle-size'],
+    func: file => file.startsWith('bundle-size/'),
   },
   {
-    targets: ['OWNERS'],
-    func: file => isCode(file) && file.startsWith('owners/'),
+    targets: ['owners'],
+    func: file => file.startsWith('owners/'),
   },
   {
-    targets: ['PR_DEPLOY'],
-    func: file => isCode(file) && file.startsWith('pr-deploy/'),
+    targets: ['pr-deploy'],
+    func: file => file.startsWith('pr-deploy/'),
   },
   {
-    targets: ['TEST_STATUS'],
-    func: file => isCode(file) && file.startsWith('test-status/'),
+    targets: ['test-status'],
+    func: file => file.startsWith('test-status/'),
   },
 ];
 

--- a/build-system/build-targets.js
+++ b/build-system/build-targets.js
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview
+ * This script sets the build targets for our PR check, where the build targets
+ * determine which tasks are required to run for pull request builds.
+ */
+const {bold, cyan, yellow} = require('ansi-colors');
+const minimatch = require('minimatch');
+const path = require('path');
+const {gitDiffNameOnlyMaster} = require('./git');
+
+const ALL_TARGETS = ['BUNDLE_SIZE', 'OWNERS', 'PR_DEPLOY', 'TEST_STATUS'];
+
+function isCode(filePath) {
+  const fileName = path.basename(filePath);
+  return !(
+    fileName.startsWith('.') ||
+    fileName.endsWith('.md') ||
+    fileName === 'LICENSE'
+  );
+}
+
+/**
+ * A mapping of functions that match a given file to one or more build targets.
+ */
+const targetMatchers = [
+  {
+    targets: ALL_TARGETS,
+    func: file =>
+      isCode(file) &&
+      (file.startsWith('build-system') ||
+        file === 'package.json' ||
+        file === 'package-lock.json'),
+  },
+  {
+    targets: ['BUNDLE_SIZE'],
+    func: file => isCode(file) && file.startsWith('bundle-size/'),
+  },
+  {
+    targets: ['OWNERS'],
+    func: file => isCode(file) && file.startsWith('owners/'),
+  },
+  {
+    targets: ['PR_DEPLOY'],
+    func: file => isCode(file) && file.startsWith('pr-deploy/'),
+  },
+  {
+    targets: ['TEST_STATUS'],
+    func: file => isCode(file) && file.startsWith('test-status/'),
+  },
+];
+
+/**
+ * Populates buildTargets with a set of build targets contained in a PR after
+ * making sure they are valid. Used to determine which checks to perform / tests
+ * to run during PR builds.
+ * @param {string} fileName
+ * @return {Set<string>}
+ */
+function determineBuildTargets(fileName = 'build-targets.js') {
+  const filesChanged = gitDiffNameOnlyMaster();
+  const buildTargets = new Set();
+
+  targetMatchers
+    .filter(matcher => filesChanged.some(matcher.func))
+    .map(matcher => matcher.targets)
+    .reduce((left, right) => left.concat(right), [])
+    .forEach(buildTargets.add, buildTargets);
+
+  const targetList = Array.from(buildTargets)
+    .sort()
+    .join(', ');
+  console.log(
+    bold(yellow(`${fileName}:`)),
+    'Detected build targets:',
+    cyan(targetList)
+  );
+
+  return buildTargets;
+}
+
+module.exports = {
+  determineBuildTargets,
+};

--- a/build-system/build-targets.js
+++ b/build-system/build-targets.js
@@ -48,10 +48,9 @@ const targetMatchers = [
   {
     targets: ALL_TARGETS,
     func: file =>
-      isCode(file) &&
-      (file.startsWith('build-system') ||
-        file === 'package.json' ||
-        file === 'package-lock.json'),
+      (isCode(file) && file.startsWith('build-system') ||
+      file === 'package.json' ||
+      file === 'package-lock.json'),
   },
   {
     targets: ['BUNDLE_SIZE'],

--- a/build-system/build-targets.js
+++ b/build-system/build-targets.js
@@ -23,24 +23,29 @@
 const {bold, cyan, yellow} = require('ansi-colors');
 const {gitDiffNameOnlyMaster} = require('./git');
 
-const APP_TARGETS = {
-  'BUNDLE_SIZE': 'bundle-size',
-  'OWNERS': 'owners',
-  'PR_DEPLOY': 'pr-deploy',
-  'TEST_STATUS': 'test-status',
-};
-const ALL_TARGETS = [...Object.keys(APP_TARGETS)];
+const ALL_TARGETS = ['BUNDLE_SIZE', 'OWNERS', 'PR_DEPLOY', 'TEST_STATUS'];
 
 /**
  * A mapping of functions that match a given file to one or more build targets.
  */
-const appTargetMatchers = Object.entries(APP_TARGETS).map((target, appName) => {
-  return {
-    targets: [target],
-    func: file => file.startsWith(appName),
-  };
-});
-const targetMatchers = [...appTargetMatchers];
+const targetMatchers = [
+  {
+    targets: ['BUNDLE_SIZE'],
+    func: file => file.startsWith('bundle-size/'),
+  },
+  {
+    targets: ['OWNERS'],
+    func: file => file.startsWith('owners/'),
+  },
+  {
+    targets: ['PR_DEPLOY'],
+    func: file => file.startsWith('pr-deploy/'),
+  },
+  {
+    targets: ['TEST_STATUS'],
+    func: file => file.startsWith('test-status/'),
+  },
+];
 
 /**
  * Populates buildTargets with a set of build targets contained in a PR after
@@ -78,6 +83,5 @@ function determineBuildTargets(fileName = 'build-targets.js') {
 
 module.exports = {
   ALL_TARGETS,
-  APP_TARGETS,
   determineBuildTargets,
 };

--- a/build-system/build-targets.js
+++ b/build-system/build-targets.js
@@ -21,12 +21,17 @@
  * determine which tasks are required to run for pull request builds.
  */
 const {bold, cyan, yellow} = require('ansi-colors');
-const minimatch = require('minimatch');
 const path = require('path');
 const {gitDiffNameOnlyMaster} = require('./git');
 
 const ALL_TARGETS = ['BUNDLE_SIZE', 'OWNERS', 'PR_DEPLOY', 'TEST_STATUS'];
 
+/**
+ * Determines if a file is a filetype containing code.
+ *
+ * @param {string} filePath
+ * @return {boolean}
+ */
 function isCode(filePath) {
   const fileName = path.basename(filePath);
   return !(

--- a/build-system/exec.js
+++ b/build-system/exec.js
@@ -43,7 +43,7 @@ function spawnProcess(cmd, options) {
  * @param {object} options
  * @return {object} Process info.
  */
-exec = function(cmd, options) {
+function exec(cmd, options) {
   options = options || {'stdio': 'inherit'};
   return spawnProcess(cmd, options);
 };
@@ -54,7 +54,7 @@ exec = function(cmd, options) {
  * @param {string} cmd Command line to execute.
  * @param {object} options Extra options to send to the process.
  */
-execOrDie = function(cmd, options) {
+function execOrDie(cmd, options) {
   const p = exec(cmd, options);
   if (p.status != 0) {
     process.exit(p.status);

--- a/build-system/exec.js
+++ b/build-system/exec.js
@@ -46,7 +46,7 @@ function spawnProcess(cmd, options) {
 function exec(cmd, options) {
   options = options || {'stdio': 'inherit'};
   return spawnProcess(cmd, options);
-};
+}
 
 /**
  * Executes the provided command, and terminates the program in case of failure.
@@ -59,7 +59,7 @@ function execOrDie(cmd, options) {
   if (p.status != 0) {
     process.exit(p.status);
   }
-};
+}
 
 /**
  * Executes the provided command, returning the process object.

--- a/build-system/exec.js
+++ b/build-system/exec.js
@@ -43,7 +43,7 @@ function spawnProcess(cmd, options) {
  * @param {object} options
  * @return {object} Process info.
  */
-exports.exec = function(cmd, options) {
+exec = function(cmd, options) {
   options = options || {'stdio': 'inherit'};
   return spawnProcess(cmd, options);
 };
@@ -54,9 +54,52 @@ exports.exec = function(cmd, options) {
  * @param {string} cmd Command line to execute.
  * @param {object} options Extra options to send to the process.
  */
-exports.execOrDie = function(cmd, options) {
-  const p = exports.exec(cmd, options);
+execOrDie = function(cmd, options) {
+  const p = exec(cmd, options);
   if (p.status != 0) {
     process.exit(p.status);
   }
+};
+
+/**
+ * Executes the provided command, returning the process object.
+ * @param {string} cmd
+ * @param {?Object} options
+ * @return {!Object}
+ */
+function getOutput(cmd, options = {}) {
+  return spawnProcess(cmd, {
+    'cwd': options.cwd || process.cwd(),
+    'env': options.env || process.env,
+    'stdio': options.stdio || 'pipe',
+    'encoding': options.encoding || 'utf-8',
+  });
+}
+
+/**
+ * Executes the provided command, returning its stdout.
+ * @param {string} cmd
+ * @param {?Object} options
+ * @return {string}
+ */
+function getStdout(cmd, options) {
+  return getOutput(cmd, options).stdout;
+}
+
+/**
+ * Executes the provided command, returning its stderr.
+ * @param {string} cmd
+ * @param {?Object} options
+ * @return {string}
+ */
+function getStderr(cmd, options) {
+  return getOutput(cmd, options).stderr;
+}
+
+module.exports = {
+  exec,
+  execOrDie,
+  getOutput,
+  getStderr,
+  getStdout,
 };

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -74,4 +74,6 @@ function gitDiffNameOnlyMaster() {
     .split('\n');
 }
 
-module.exports = {gitDiffNameOnlyMaster};
+module.exports = {
+  gitDiffNameOnlyMaster,
+};

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview Provides functions for executing various git commands.
+ */
+
+const {isTravisBuild} = require('./travis');
+const {getStdout} = require('./exec');
+
+/**
+ * Returns the merge base of HEAD off of a given ref.
+ *
+ * @param {string} ref
+ * @return {string}
+ */
+function gitMergeBase(ref) {
+  return getStdout(`git merge-base ${ref} HEAD`).trim();
+}
+
+/**
+ * Returns the `master` parent of the merge commit (current HEAD) on Travis.
+ * Note: This is not the same as origin/master (a moving target), since new
+ * commits can be merged while a Travis build is in progress.
+ * See https://travis-ci.community/t/origin-master-moving-forward-between-build-stages/4189/6
+ * @return {string}
+ */
+function gitTravisMasterBaseline() {
+  return gitMergeBase('origin/master');
+}
+
+/**
+ * Returns the merge base of the current branch off of master when running on
+ * a local workspace.
+ * @return {string}
+ */
+function gitMergeBaseLocalMaster() {
+  return gitMergeBase('master');
+}
+
+/**
+ * Returns the master baseline commit, regardless of running environment.
+ * @return {string}
+ */
+function gitMasterBaseline() {
+  return isTravisBuild()
+    ? gitTravisMasterBaseline()
+    : gitMergeBaseLocalMaster();
+}
+
+/**
+ * Returns the list of files changed relative to the branch point off of master,
+ * one on each line.
+ * @return {!Array<string>}
+ */
+function gitDiffNameOnlyMaster() {
+  const masterBaseline = gitMasterBaseline();
+  return getStdout(`git diff --name-only ${masterBaseline}`)
+    .trim()
+    .split('\n');
+}
+
+module.exports = {gitDiffNameOnlyMaster};

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -40,8 +40,8 @@ function timedExecOrDie(cmd) {
 /**
  * Set up and execute tests for an app.
  *
- * TODO(rcebulko): Replace this with gulp tasks.
- * TODO(rcebulko): Adopt same logging standards as `amphtml`.
+ * TODO(#608): Replace this with gulp tasks.
+ * TODO(#607): Adopt same logging standards as `amphtml`.
  *
  * @param {string} appName
  */

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -60,23 +60,10 @@ function main() {
     ['bundle-size', 'owners', 'pr-deploy', 'test-status'].forEach(runAppTests);
   } else {
     const buildTargets = determineBuildTargets(FILENAME);
+    ['bundle-size', 'owners', 'pr-deploy', 'test-status']
+      .filter(buildTargets.has, buildTargets)
+      .forEach(runAppTests);
     log.info(`Detected build targets: ${Array.from(buildTargets).join(', ')}`);
-
-    if (buildTargets.has('BUNDLE_SIZE')) {
-      runAppTests('bundle-size');
-    }
-
-    if (buildTargets.has('OWNERS')) {
-      runAppTests('owners');
-    }
-
-    if (buildTargets.has('PR_DEPLOY')) {
-      runAppTests('pr-deploy');
-    }
-
-    if (buildTargets.has('TEST_STATUS')) {
-      runAppTests('test-status');
-    }
   }
 
   return 0;

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -37,6 +37,7 @@ function timedExecOrDie(cmd) {
  * Set up and execute tests for an app.
  *
  * TODO(rcebulko): Replace this with gulp tasks.
+ * TODO(rcebulko): Adopt same logging standards as `amphtml`.
  *
  * @param {string} appName
  */

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -16,7 +16,11 @@
 
 const colors = require('ansi-colors');
 const {execOrDie} = require('./exec');
+const {isTravisPushBuild} = require('./travis');
+const {determineBuildTargets} = require('./build-targets');
 const log = require('fancy-log');
+
+const FILENAME = 'pr-check.js';
 
 /**
  * Execute a command, surrounded by start/end time logs.
@@ -30,17 +34,50 @@ function timedExecOrDie(cmd) {
 }
 
 /**
+ * Set up and execute tests for an app.
+ *
+ * TODO(rcebulko): Replace this with gulp tasks.
+ *
+ * @param {string} appName
+ */
+function runAppTests(appName) {
+  log.info(`Running tests for "${appName}" app`);
+  timedExecOrDie(`cd ${appName} && npm ci`);
+  timedExecOrDie(`cd ${appName} && npm test -u`);
+  log.info(`Done running "${appName}" tests`);
+}
+
+/**
  * Runs the checks.
  *
  * @return {number} process exit code.
  */
 function main() {
-  // TODO(danielrozenberg): conditional test running
   timedExecOrDie('eslint .');
-  ['bundle-size', 'test-status', 'pr-deploy', 'owners'].forEach(appName => {
-    timedExecOrDie(`cd ${appName} && npm ci`);
-    timedExecOrDie(`cd ${appName} && npm test -u`);
-  });
+
+  if (isTravisPushBuild()) {
+    log.info('Travis push build; running all tests');
+    ['bundle-size', 'owners', 'pr-deploy', 'test-status'].forEach(runAppTests);
+  } else {
+    const buildTargets = determineBuildTargets(FILENAME);
+    log.info(`Detected build targets: ${Array.from(buildTargets).join(', ')}`);
+
+    if (buildTargets.has('BUNDLE_SIZE')) {
+      runAppTests('bundle-size');
+    }
+
+    if (buildTargets.has('OWNERS')) {
+      runAppTests('owners');
+    }
+
+    if (buildTargets.has('PR_DEPLOY')) {
+      runAppTests('pr-deploy');
+    }
+
+    if (buildTargets.has('TEST_STATUS')) {
+      runAppTests('test-status');
+    }
+  }
 
   return 0;
 }

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -17,11 +17,7 @@
 const colors = require('ansi-colors');
 const {execOrDie} = require('./exec');
 const {isTravisPushBuild} = require('./travis');
-const {
-  ALL_TARGETS,
-  APP_TARGETS,
-  determineBuildTargets,
-} = require('./build-targets');
+const {ALL_TARGETS, determineBuildTargets} = require('./build-targets');
 const log = require('fancy-log');
 
 const FILENAME = 'pr-check.js';
@@ -68,10 +64,17 @@ function main() {
     log.info(`Detected build targets: ${Array.from(buildTargets).join(', ')}`);
   }
 
-  for (const [target, appName] of Object.entries(APP_TARGETS)) {
-    if (buildTargets.has(target)) {
-      runAppTests(appName);
-    }
+  if (buildTargets.has('BUNDLE_SIZE')) {
+    runAppTests('bundle-size');
+  }
+  if (buildTargets.has('OWNERS')) {
+    runAppTests('owners');
+  }
+  if (buildTargets.has('PR_DEPLOY')) {
+    runAppTests('pr-deploy');
+  }
+  if (buildTargets.has('TEST_STATUS')) {
+    runAppTests('test-status');
   }
 
   return 0;

--- a/build-system/travis.js
+++ b/build-system/travis.js
@@ -43,4 +43,8 @@ function isTravisPushBuild() {
   return isTravisBuild() && process.env.TRAVIS_EVENT_TYPE === 'push';
 }
 
-module.exports = {isTravisBuild, isTravisPullRequestBuild, isTravisPushBuild};
+module.exports = {
+  isTravisBuild,
+  isTravisPullRequestBuild,
+  isTravisPushBuild,
+};

--- a/build-system/travis.js
+++ b/build-system/travis.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview Provides functions that extract various kinds of Travis state.
+ */
+
+/**
+ * Returns true if this is a Travis build.
+ * @return {boolean}
+ */
+function isTravisBuild() {
+  return !!process.env.TRAVIS;
+}
+
+module.exports = {isTravisBuild};

--- a/build-system/travis.js
+++ b/build-system/travis.js
@@ -27,4 +27,20 @@ function isTravisBuild() {
   return !!process.env.TRAVIS;
 }
 
-module.exports = {isTravisBuild};
+/**
+ * Returns true if this is a Travis PR build.
+ * @return {boolean}
+ */
+function isTravisPullRequestBuild() {
+  return isTravisBuild() && process.env.TRAVIS_EVENT_TYPE === 'pull_request';
+}
+
+/**
+ * Returns true if this is a Travis Push build.
+ * @return {boolean}
+ */
+function isTravisPushBuild() {
+  return isTravisBuild() && process.env.TRAVIS_EVENT_TYPE === 'push';
+}
+
+module.exports = {isTravisBuild, isTravisPullRequestBuild, isTravisPushBuild};


### PR DESCRIPTION
- Transfers a lot of the helper functions for Git, Travis, and  `exec` directly from `ampproject/amphtml`
- Mimics the core logic/structure of build targets from `ampproject/amphtml`
- Defines build targets for each app

Closes #605 