### PR TITLE
[owners] Add hellcat preview to Octokit initialization

### DIFF
--- a/owners/bootstrap.js
+++ b/owners/bootstrap.js
@@ -53,6 +53,7 @@ function bootstrap(logger = console) {
     const github = new GitHub(
       new Octokit({
         auth: GITHUB_ACCESS_TOKEN,
+        // hellcat-preview allows team member listings to include nested teams.
         previews: ['hellcat-preview'],
       }),
       GITHUB_OWNER,

--- a/owners/bootstrap.js
+++ b/owners/bootstrap.js
@@ -51,7 +51,10 @@ function bootstrap(logger = console) {
     } = process.env;
 
     const github = new GitHub(
-      new Octokit({auth: GITHUB_ACCESS_TOKEN}),
+      new Octokit({
+        auth: GITHUB_ACCESS_TOKEN,
+        previews: ['hellcat-preview'],
+      }),
       GITHUB_OWNER,
       GITHUB_REPOSITORY,
       logger


### PR DESCRIPTION
The hellcat preview allows the GitHub API's team members API to include nested teams. Originally this was set in code I'd written that manually ran custom requests, required for the outdated version of Octokit that shipped with the outdated version of Probot. The update to Probot 9 resulted in the update of Octokit, and the custom code was no longer needed. The header was never replaced, however, so nested teams broke.