### PR TITLE
[owners] Don't report failure on reviewer selection errors

### DIFF
--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -146,16 +146,27 @@ class OwnersCheck {
       });
 
       // TODO(#516): Include missing required reviewers.
-      const reviewSuggestions = ReviewerSelection.pickReviews(fileTreeMap);
+      let reviewSuggestions = [];
+      let reviewerSelectionErrors = '';
+      try {
+        reviewSuggestions = ReviewerSelection.pickReviews(fileTreeMap);
+      } catch (e) {
+        reviewerSelectionErrors =
+          'Encountered an error during reviewer ' +
+          `selection: \n${e}\nSkipping reviewer assignment.`;
+      }
+
       const reviewers = reviewSuggestions.map(([reviewer, files]) => reviewer);
-      const suggestionsText = this.buildReviewSuggestionsText(
-        reviewSuggestions
-      );
+      const suggestionsText = reviewSuggestions.length
+        ? this.buildReviewSuggestionsText(reviewSuggestions)
+        : reviewerSelectionErrors;
+      const suggestedReviewersText = reviewers.length ?
+        ` Suggested reviewers: ${reviewers.join(', ')}` : '';
+
       return {
         checkRun: new CheckRun(
           CheckRunState.ACTION_REQUIRED,
-          'Missing required OWNERS approvals! ' +
-            `Suggested reviewers: ${reviewers.join(', ')}`,
+          `Missing required OWNERS approvals!${suggestedReviewersText}`,
           `${coverageText}\n\n${suggestionsText}`
         ),
         reviewers,

--- a/owners/src/owners_check.js
+++ b/owners/src/owners_check.js
@@ -160,8 +160,9 @@ class OwnersCheck {
       const suggestionsText = reviewSuggestions.length
         ? this.buildReviewSuggestionsText(reviewSuggestions)
         : reviewerSelectionErrors;
-      const suggestedReviewersText = reviewers.length ?
-        ` Suggested reviewers: ${reviewers.join(', ')}` : '';
+      const suggestedReviewersText = reviewers.length
+        ? ` Suggested reviewers: ${reviewers.join(', ')}`
+        : '';
 
       return {
         checkRun: new CheckRun(

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -329,8 +329,8 @@ describe('owners check', () => {
 
           expect(checkRun.text).toContain(
             'Encountered an error during reviewer selection: \n' +
-            'Error: Something is wrong\n' +
-            'Skipping reviewer assignment.'
+              'Error: Something is wrong\n' +
+              'Skipping reviewer assignment.'
           );
         });
       });

--- a/owners/test/owners_check.test.js
+++ b/owners/test/owners_check.test.js
@@ -302,6 +302,38 @@ describe('owners check', () => {
           );
         });
       });
+
+      describe('if an error occurs in reviewer selection', () => {
+        beforeEach(() => {
+          sandbox
+            .stub(ReviewerSelection, 'pickReviews')
+            .throws(new Error('Something is wrong'));
+        });
+
+        it('has an action-required conclusion', () => {
+          const {checkRun} = ownersCheck.run();
+
+          expect(checkRun.json.conclusion).toEqual('action_required');
+        });
+
+        it('has a failing summary', () => {
+          const {checkRun} = ownersCheck.run();
+
+          expect(checkRun.summary).toContain(
+            'Missing required OWNERS approvals!'
+          );
+        });
+
+        it('contains error details in the output', () => {
+          const {checkRun} = ownersCheck.run();
+
+          expect(checkRun.text).toContain(
+            'Encountered an error during reviewer selection: \n' +
+            'Error: Something is wrong\n' +
+            'Skipping reviewer assignment.'
+          );
+        });
+      });
     });
   });
 


### PR DESCRIPTION
A recent combination of owners rules let to an error thrown in reviewer selection for certain files, blocking PRs like https://github.com/ampproject/amphtml/pull/25639 and https://github.com/ampproject/amphtml/pull/25521 .

The underlying bug has been identified, but will take a bit longer to fix and test. This PR ensures that errors in reviewer selection do not report failed owners checks, and instead just give up on suggesting reviewers