### PR TITLE
[owners] Fix reviewer selection bug for non-matching rules

### DIFF
--- a/owners/src/owners_tree.js
+++ b/owners/src/owners_tree.js
@@ -198,9 +198,16 @@ class OwnersTree {
    */
   buildFileTreeMap(filenames) {
     const fileTreeMap = {};
+
     filenames.forEach(filename => {
-      fileTreeMap[filename] = this.atPath(filename);
+      let subtree = this.atPath(filename);
+      // Walk up the tree until reaching a node with at least one matching rule.
+      while (!subtree.rules.some(rule => rule.matchesFile(filename))) {
+        subtree = subtree.parent;
+      }
+      fileTreeMap[filename] = subtree;
     });
+
     return fileTreeMap;
   }
 

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -196,7 +196,9 @@ describe('notifier', () => {
       getCommentsStub = sandbox.stub(GitHub.prototype, 'getBotComments');
       getCommentsStub.returns([]);
 
-      notifier = new OwnersNotifier(pr, {}, new OwnersTree(), ['main.js']);
+      const tree = new OwnersTree();
+      tree.addRule(new OwnersRule('OWNERS', ['root_owner']));
+      notifier = new OwnersNotifier(pr, {}, tree, ['main.js']);
     });
 
     it('gets users and teams to notify', async done => {

--- a/owners/test/owners_tree.test.js
+++ b/owners/test/owners_tree.test.js
@@ -381,7 +381,7 @@ describe('owners tree', () => {
     });
 
     it('maps to the deepest subtree with a matching rule', () => {
-      tree.addRule(rootDirRule),
+      tree.addRule(rootDirRule);
       tree.addRule(
         new PatternOwnersRule(
           'foo/OWNERS',

--- a/owners/test/owners_tree.test.js
+++ b/owners/test/owners_tree.test.js
@@ -356,8 +356,8 @@ describe('owners tree', () => {
     it('builds a map from filenames to subtrees', () => {
       const dirTrees = {
         '/': tree.addRule(rootDirRule),
-        '/foo': tree.addRule(rootDirRule),
-        '/biz': tree.addRule(rootDirRule),
+        '/foo': tree.addRule(childDirRule),
+        '/biz': tree.addRule(otherChildDirRule),
       };
       const fileTreeMap = tree.buildFileTreeMap([
         './main.js',
@@ -378,6 +378,20 @@ describe('owners tree', () => {
         'buzz/info.txt': dirTrees['/'],
         'buzz/code.js': dirTrees['/'],
       });
+    });
+
+    it('maps to the deepest subtree with a matching rule', () => {
+      tree.addRule(rootDirRule),
+      tree.addRule(
+        new PatternOwnersRule(
+          'foo/OWNERS',
+          [new UserOwner('person')],
+          'not_a_file_pattern'
+        )
+      );
+      const fileTreeMap = tree.buildFileTreeMap(['foo/file.js']);
+
+      expect(fileTreeMap).toEqual({'foo/file.js': tree});
     });
   });
 

--- a/owners/test/reviewer_selection.test.js
+++ b/owners/test/reviewer_selection.test.js
@@ -104,6 +104,20 @@ describe('reviewer selection', () => {
 
       expect(deepestRules).toEqual([dirRules['/foo']]);
     });
+
+    it('tries less-deep rules when the deepest rules do not apply', () => {
+      const deeperRule = new SameDirPatternOwnersRule(
+        'foo/bar/OWNERS',
+        [new UserOwner('person')],
+        'not_the_file.txt'
+      );
+      ownersTree.addRule(deeperRule);
+      const fileTreeMap = ownersTree.buildFileTreeMap(['foo/bar/file.js']);
+      const deepestRules = ReviewerSelection._deepestOwnersRules(fileTreeMap);
+
+      expect(deepestRules).not.toContain(deeperRule);
+      expect(deepestRules).toContain(dirRules['/foo']);
+    });
   });
 
   describe('reviewersForRules', () => {


### PR DESCRIPTION
There is a bug in reviewer selection (sort of). It looks at the deepest OWNERS file rules for each file, and tries to look for reviewers in them. There are cases, however, where only pattern-based rules exist in `foo/OWNERS`, but those patterns may not apply to some files under `foo/`. Previously, this would cause reviewer selection to break, since it would think there were no reviewers available.

This was caused by a broken contract between what the reviewer selection algorithm is expecting in its input `fileTreeMap`. The `fileTreeMap` it was given mapped files to the closest OWNERS file, but did not care if that OWNERS file contained any rules that actually applied to the file.

This PR adds failing tests for reviewer selection and fileTreeMap construction, then patches the method on `OwnersTree` to respect that expectation.