### PR TITLE
[bundle-size] Fetch `APPROVERS.json` file from `ampproject/amphtml` and process bundle-size deltas with it

### DIFF
--- a/bundle-size/.env.example
+++ b/bundle-size/.env.example
@@ -1,19 +1,41 @@
 # The ID of your GitHub App
 APP_ID=12345
+
+# From the GitHub App settings page
 WEBHOOK_SECRET=0123456789abcdef0123456789abcdef01234567
-WEBHOOK_PROXY_URL=https://smee.io/0123456789abcdef  # For local development only
-PRIVATE_KEY=0123456789abcdefghijklmnopqrstuvwxyz  # Base64 encoded private key from GitHub
-TRAVIS_IP_ADDRESSES=1.1.1.1,8.8.8.8  # Remove this line for local development, update based on https://docs.travis-ci.com/user/ip-addresses/ otherwise
-TRAVIS_PUSH_BUILD_TOKEN=0123456789abcdefghijklmnopqrstuvwxyz  # Generate a unique token here in any way you want, see README.md for details
-FALLBACK_APPROVER_TEAMS=ampproject/wg-runtime,ampproject/wg-performance  # List of GitHub teams whose members can approve bundle-size changes involving multiple files changed
-SUPER_USER_TEAMS=ampproject/wg-runtime,ampproject/wg-performance,ampproject/wg-infra  # List of GitHub teams whose members can approve all bundle-size changes
-APPROVER_TEAMS=123,234,345  # List of GitHub team IDs whose members can approve bundle-size changes; legacy, to be removed with #617
-REVIEWER_TEAMS=123  # List of GitHub team IDs from which a random member will be assigned as a reviewer. SHOULD be a subset of APPROVER_TEAMS (this is not verified in runtime); legacy, to be removed with #617
-REVIEWER_TEAM_NAMES=@ampproject/wg-runtime  # As-is text to add to the message on who can be tagged to get a reviewer; legacy, to be removed with #617
-ACCESS_TOKEN=0123456789abcdef0123456789abcdef01234567  # A user access token that can read team members
+
+# Proxy is used for local development only
+WEBHOOK_PROXY_URL=https://smee.io/0123456789abcdef
+
+# Base64 encoded private key from GitHub
+PRIVATE_KEY=0123456789abcdefghijklmnopqrstuvwxyz
+
+# Remove the Travis IP addresses listing for local development, update based on https://docs.travis-ci.com/user/ip-addresses/ otherwise
+TRAVIS_IP_ADDRESSES=1.1.1.1,8.8.8.8
+
+# Generate a unique token here in any way you want, see README.md for details
+TRAVIS_PUSH_BUILD_TOKEN=0123456789abcdefghijklmnopqrstuvwxyz
+
+# List of GitHub teams whose members can approve bundle-size changes involving multiple files changed
+FALLBACK_APPROVER_TEAMS=ampproject/wg-runtime,ampproject/wg-performance
+
+# List of GitHub teams whose members can approve all bundle-size changes
+SUPER_USER_TEAMS=ampproject/wg-runtime,ampproject/wg-performance,ampproject/wg-infra
+
+# List of GitHub team IDs whose members can approve bundle-size changes; legacy, to be removed with #617
+APPROVER_TEAMS=123,234,345
+
+# List of GitHub team IDs from which a random member will be assigned as a reviewer. SHOULD be a subset of APPROVER_TEAMS (this is not verified in runtime); legacy, to be removed with #617
+REVIEWER_TEAMS=123
+
+# As-is text to add to the message on who can be tagged to get a reviewer; legacy, to be removed with #617
+REVIEWER_TEAM_NAMES=@ampproject/wg-runtime
+
+# A GitHub user access token that can read team members
+ACCESS_TOKEN=0123456789abcdef0123456789abcdef01234567
 
 # Use `trace` to get verbose logging or `info` to show less
 LOG_LEVEL=trace
 
-# Required flag for the GitHub App
+# Size in KB that v0.js is allowed to increase without requiring special approval; legacy, to be removed with #617
 MAX_ALLOWED_INCREASE=0.1

--- a/bundle-size/.env.example
+++ b/bundle-size/.env.example
@@ -5,9 +5,11 @@ WEBHOOK_PROXY_URL=https://smee.io/0123456789abcdef  # For local development only
 PRIVATE_KEY=0123456789abcdefghijklmnopqrstuvwxyz  # Base64 encoded private key from GitHub
 TRAVIS_IP_ADDRESSES=1.1.1.1,8.8.8.8  # Remove this line for local development, update based on https://docs.travis-ci.com/user/ip-addresses/ otherwise
 TRAVIS_PUSH_BUILD_TOKEN=0123456789abcdefghijklmnopqrstuvwxyz  # Generate a unique token here in any way you want, see README.md for details
-APPROVER_TEAMS=123,234,345  # List of GitHub team IDs whose members can approve bundle-size changes
-REVIEWER_TEAMS=123  # List of GitHub team IDs from which a random member will be assigned as a reviewer. SHOULD be a subset of APPROVER_TEAMS (this is not verified in runtime)
-REVIEWER_TEAM_NAMES=@ampproject/wg-runtime  # As-is text to add to the message on who can be tagged to get a reviewer
+FALLBACK_APPROVER_TEAMS=ampproject/wg-runtime,ampproject/wg-performance  # List of GitHub teams whose members can approve bundle-size changes involving multiple files changed
+SUPER_USER_TEAMS=ampproject/wg-runtime,ampproject/wg-performance,ampproject/wg-infra  # List of GitHub teams whose members can approve all bundle-size changes
+APPROVER_TEAMS=123,234,345  # List of GitHub team IDs whose members can approve bundle-size changes; legacy, to be removed with #617
+REVIEWER_TEAMS=123  # List of GitHub team IDs from which a random member will be assigned as a reviewer. SHOULD be a subset of APPROVER_TEAMS (this is not verified in runtime); legacy, to be removed with #617
+REVIEWER_TEAM_NAMES=@ampproject/wg-runtime  # As-is text to add to the message on who can be tagged to get a reviewer; legacy, to be removed with #617
 ACCESS_TOKEN=0123456789abcdef0123456789abcdef01234567  # A user access token that can read team members
 
 # Use `trace` to get verbose logging or `info` to show less

--- a/bundle-size/README.md
+++ b/bundle-size/README.md
@@ -71,7 +71,7 @@ Follow these setup instructions to start developing for this App locally:
 6. After creating the application, generate and download a private key. Also
    take note of the App ID
 7. Create a personal access token belonging to a GitHub _user_ with the
-   `public_repo` and `read:org` permissions and nore its access token.
+   `public_repo` and `read:org` permissions and note its access token.
 8. Install the application on a GitHub repository that you want to use for
    testing. You might want to create a new repository for this purpose.
 9. Copy the `.env.example` file to `.env` and modify the fields based on the

--- a/bundle-size/api.js
+++ b/bundle-size/api.js
@@ -82,14 +82,14 @@ async function storeBuildArtifactsFile(github, filename, contents) {
 }
 
 /**
- * Get the dictionary of compiled files to their approvers and thresholds.
+ * Get the mapping of compiled files to their approvers and thresholds.
  * @param {!github} github an authenticated GitHub API object.
  * @param {Logger} log logging function/object.
  * @return {Map<string, {approvers: string[], thresholds: number}>} mapping of
  *   compiled files to the teams that can approve an increase, and the threshold
  *   in KB that requires an approval.
  */
-async function getFileApprovalsDictionary(github, log) {
+async function getFileApprovalsMapping(github, log) {
   let approvers = cache.get(CACHE_APPROVERS_KEY);
   if (!approvers) {
     log(`Cache miss for ${CACHE_APPROVERS_KEY}. Fetching from GitHub...`);
@@ -303,7 +303,7 @@ exports.installApiRouter = (app, db, userBasedGithub) => {
         'Fetching mapping of file approvers and thresholds for pull request ' +
           `#${check.pull_request_id}`
       );
-      const fileApprovers = await getFileApprovalsDictionary(github, app.log);
+      const fileApprovers = await getFileApprovalsMapping(github, app.log);
 
       // Calculate and collect all (non-zero) bundle size deltas and list all
       // dist files that are missing either from master or from this pull

--- a/bundle-size/api.js
+++ b/bundle-size/api.js
@@ -19,6 +19,7 @@ const {
   getCheckFromDatabase,
   isBundleSizeApprover,
 } = require('./common');
+const NodeCache = require('node-cache');
 const path = require('path');
 const sleep = require('sleep-promise');
 
@@ -26,6 +27,15 @@ const RETRY_MILLIS = 60000;
 const RETRY_TIMES = 60;
 
 const HUMAN_ENCOURAGEMENT_MAX_DELTA = -0.03;
+
+const CACHE_TTL_SECONDS = 900;
+const CACHE_CHECK_SECONDS = 60;
+const CACHE_APPROVERS_KEY = 'approvers';
+
+const cache = new NodeCache({
+  'stdTTL': CACHE_TTL_SECONDS,
+  'checkperiod': CACHE_CHECK_SECONDS,
+});
 
 /**
  * Get GitHub API parameters for bundle-size file actions.
@@ -52,9 +62,7 @@ function getBuildArtifactsFileParams(filename) {
 async function getBuildArtifactsFile(github, filename) {
   return await github.repos
     .getContents(getBuildArtifactsFileParams(filename))
-    .then(result => {
-      return Buffer.from(result.data.content, 'base64').toString();
-    });
+    .then(result => Buffer.from(result.data.content, 'base64').toString());
 }
 
 /**
@@ -64,14 +72,43 @@ async function getBuildArtifactsFile(github, filename) {
  * @param {!github} github an authenticated GitHub API object.
  * @param {string} filename the name of the file to store into.
  * @param {string} contents text contents of the file.
- * @return {object} to ignore.
  */
 async function storeBuildArtifactsFile(github, filename, contents) {
-  return await github.repos.createOrUpdateFile({
+  await github.repos.createOrUpdateFile({
     ...getBuildArtifactsFileParams(filename),
     message: `bundle-size: ${filename}`,
     content: Buffer.from(contents).toString('base64'),
   });
+}
+
+/**
+ * Get the dictionary of compiled files to their approvers and thresholds.
+ * @param {!github} github an authenticated GitHub API object.
+ * @param {Logger} log logging function/object.
+ * @return {Map<string, {approvers: string[], thresholds: number}>} mapping of
+ *   compiled files to the teams that can approve an increase, and the threshold
+ *   in KB that requires an approval.
+ */
+async function getFileApprovalsDictionary(github, log) {
+  let approvers = cache.get(CACHE_APPROVERS_KEY);
+  if (!approvers) {
+    log(`Cache miss for ${CACHE_APPROVERS_KEY}. Fetching from GitHub...`);
+    approvers = await github.repos
+      .getContents({
+        owner: 'ampproject',
+        repo: 'amphtml',
+        path: 'build-system/tasks/bundle-size/APPROVERS.json',
+      })
+      .then(result => Buffer.from(result.data.content, 'base64').toString())
+      .then(JSON.parse);
+    log(
+      `Fetched ${CACHE_APPROVERS_KEY} from GitHub with ` +
+        `${Object.keys(approvers).length} entries. Caching for ` +
+        `${CACHE_TTL_SECONDS} seconds.`
+    );
+    cache.set(CACHE_APPROVERS_KEY, approvers);
+  }
+  return approvers;
 }
 
 /**
@@ -181,6 +218,54 @@ function extraBundleSizesSummary(otherBundleSizeDeltas, missingBundleSizes) {
   );
 }
 
+/**
+ * Choose the set of all the potential approver teams into a single team.
+ *
+ * Could end up choosing the fallback set defined in the `.env` file, even if
+ * the fallback set is not in the input.
+ *
+ * @param {Array<Array<string>>} allPotentialApproverTeams all the potential
+ *   teams that can approve this pull request.
+ * @param {Logger} log logging function/object.
+ * @param {number} pullRequestId the pull request ID.
+ * @return {Array<string>} the selected subset of all potential approver teams
+ *   that can approve this bundle-size change.
+ */
+function choosePotentialApproverTeams(
+  allPotentialApproverTeams,
+  log,
+  pullRequestId
+) {
+  let potentialApproverTeams;
+  switch (allPotentialApproverTeams.length) {
+    case 0:
+      potentialApproverTeams = [];
+      log(
+        `Pull request #${pullRequestId} does not require ` +
+          'bundle-size approval'
+      );
+      break;
+
+    case 1:
+      potentialApproverTeams = allPotentialApproverTeams[0];
+      log(
+        `Pull request #${pullRequestId} requires approval ` +
+          `from members of one of: ${potentialApproverTeams.join(', ')}`
+      );
+      break;
+
+    default:
+      potentialApproverTeams = process.env.FALLBACK_APPROVER_TEAMS.split(',');
+      log(
+        `Pull request #${pullRequestId} requires approval from ` +
+          'multiple sets of teams, so we fall back to the default set ' +
+          `of: ${potentialApproverTeams.join(', ')}`
+      );
+      break;
+  }
+  return potentialApproverTeams;
+}
+
 exports.installApiRouter = (app, db, userBasedGithub) => {
   /**
    * Try to report the bundle size of a pull request to the GitHub check.
@@ -206,21 +291,28 @@ exports.installApiRouter = (app, db, userBasedGithub) => {
     };
 
     try {
+      app.log(
+        `Fetching master bundle-sizes on base commit ${baseSha} for pull ` +
+          `request #${check.pull_request_id}`
+      );
       const masterBundleSizes = JSON.parse(
         await getBuildArtifactsFile(github, `${baseSha}.json`)
       );
 
+      app.log(
+        'Fetching mapping of file approvers and thresholds for pull request ' +
+          `#${check.pull_request_id}`
+      );
+      const fileApprovers = await getFileApprovalsDictionary(github, app.log);
+
       // Calculate and collect all (non-zero) bundle size deltas and list all
       // dist files that are missing either from master or from this pull
-      // request.
-      const otherBundleSizeDeltas = [];
+      // request, and all the potential teams that can approve above-threshold
+      // deltas.
+      const bundleSizeDeltas = [];
       const missingBundleSizes = [];
+      const allPotentialApproverTeams = new Set();
       for (const [file, baseBundleSize] of Object.entries(masterBundleSizes)) {
-        if (file === 'dist/v0.js') {
-          // For now, skip dist/v0.js because it gets special handling.
-          continue;
-        }
-
         if (!(file in prBundleSizes)) {
           missingBundleSizes.push(`* \`${file}\`: missing in pull request`);
           continue;
@@ -228,8 +320,19 @@ exports.installApiRouter = (app, db, userBasedGithub) => {
 
         const bundleSizeDelta = prBundleSizes[file] - baseBundleSize;
         if (bundleSizeDelta !== 0) {
-          otherBundleSizeDeltas.push(
+          bundleSizeDeltas.push(
             `* \`${file}\`: ${formatBundleSizeDelta(bundleSizeDelta)}`
+          );
+        }
+
+        if (
+          file in fileApprovers &&
+          bundleSizeDelta >= fileApprovers[file].threshold
+        ) {
+          // Since `.approvers` is an array, it must be stringified to maintain
+          // the Set uniqueness property.
+          allPotentialApproverTeams.add(
+            JSON.stringify(fileApprovers[file].approvers)
           );
         }
       }
@@ -242,13 +345,29 @@ exports.installApiRouter = (app, db, userBasedGithub) => {
         }
       }
 
-      if (otherBundleSizeDeltas.length === 0) {
-        otherBundleSizeDeltas.push(
-          '* No other bundle sizes reported in this pull request'
+      // TODO(#617, danielrozenberg): replace the legacy logic below with logic
+      // that uses the chosen approvers team list.
+      // eslint-disable-next-line no-unused-vars
+      const chosenApproverTeams = choosePotentialApproverTeams(
+        Array.from(allPotentialApproverTeams).map(JSON.parse),
+        app.log,
+        check.pull_request_id
+      );
+
+      if (bundleSizeDeltas.length === 0) {
+        bundleSizeDeltas.push(
+          '* No bundle size changes reported in this pull request'
         );
       }
 
-      // TODO(#271, danielrozenberg): this is a transitionary solution. This API
+      app.log(
+        'Done pre-processing bundle-size changes for pull request ' +
+          `#${check.pull_request_id}:`
+      );
+      app.log(`Deltas:\n${bundleSizeDeltas.join('\n')}`);
+      app.log(`Missing:\n${missingBundleSizes.join('\n')}`);
+
+      // TODO(#617, danielrozenberg): this is a transitionary solution. This API
       // endpoint accepts a JSON with multiple bundle sizes, but for now it only
       // blocks on size changes in dist/v0.js. Later we determine how we want to
       // report and block PRs based on bundle sizes of other dist files.
@@ -267,7 +386,7 @@ exports.installApiRouter = (app, db, userBasedGithub) => {
           conclusion: 'action_required',
           output: failedCheckOutput(
             baseRuntimeBundleSizeDelta,
-            otherBundleSizeDeltas,
+            bundleSizeDeltas,
             missingBundleSizes
           ),
         });
@@ -276,7 +395,7 @@ exports.installApiRouter = (app, db, userBasedGithub) => {
           conclusion: 'success',
           output: successfulCheckOutput(
             baseRuntimeBundleSizeDelta,
-            otherBundleSizeDeltas,
+            bundleSizeDeltas,
             missingBundleSizes
           ),
         });
@@ -297,7 +416,8 @@ exports.installApiRouter = (app, db, userBasedGithub) => {
       app.log.error(
         'ERROR: Failed to retrieve the bundle size of ' +
           `${partialHeadSha} (PR #${check.pull_request_id}) with branch ` +
-          `point ${partialBaseSha} from GitHub: ${error}`
+          `point ${partialBaseSha} from GitHub:\n`,
+        error
       );
       if (lastAttempt) {
         app.log.warn('No more retries left. Reporting failure');
@@ -372,7 +492,7 @@ exports.installApiRouter = (app, db, userBasedGithub) => {
         'ERROR: Failed to add a reviewer to pull request ' +
           `${pullRequest.pull_number}. Skipping...`
       );
-      app.log.error(`Error message: ${error}`);
+      app.log.error(`Error message:\n`, error);
       throw error;
     }
   }
@@ -525,10 +645,9 @@ exports.installApiRouter = (app, db, userBasedGithub) => {
     } catch (error) {
       const errorMessage =
         `ERROR: Failed to create the bundle-size/${jsonBundleSizeFile} file ` +
-        'in the build artifacts repository on GitHub!\n' +
-        `Error message was: ${error}`;
-      app.log.error(errorMessage);
-      return response.status(500).end(errorMessage);
+        'in the build artifacts repository on GitHub! Error message was:';
+      app.log.error(`${errorMessage}\n`, error);
+      return response.status(500).end(`${errorMessage}\n${error}`);
     }
 
     response.end();

--- a/bundle-size/api.js
+++ b/bundle-size/api.js
@@ -85,9 +85,9 @@ async function storeBuildArtifactsFile(github, filename, contents) {
  * Get the mapping of compiled files to their approvers and thresholds.
  * @param {!github} github an authenticated GitHub API object.
  * @param {Logger} log logging function/object.
- * @return {Map<string, {approvers: string[], thresholds: number}>} mapping of
- *   compiled files to the teams that can approve an increase, and the threshold
- *   in KB that requires an approval.
+ * @return {!Map<string, {approvers: !Array<string>, threshold: number}>}
+ *   mapping of compiled files to the teams that can approve an increase, and
+ *   the threshold in KB that requires an approval.
  */
 async function getFileApprovalsMapping(github, log) {
   let approvers = cache.get(CACHE_APPROVERS_KEY);
@@ -224,11 +224,11 @@ function extraBundleSizesSummary(otherBundleSizeDeltas, missingBundleSizes) {
  * Could end up choosing the fallback set defined in the `.env` file, even if
  * the fallback set is not in the input.
  *
- * @param {Array<Array<string>>} allPotentialApproverTeams all the potential
+ * @param {!Array<!Array<string>>} allPotentialApproverTeams all the potential
  *   teams that can approve this pull request.
- * @param {Logger} log logging function/object.
+ * @param {!Logger} log logging function/object.
  * @param {number} pullRequestId the pull request ID.
- * @return {Array<string>} the selected subset of all potential approver teams
+ * @return {!Array<string>} the selected subset of all potential approver teams
  *   that can approve this bundle-size change.
  */
 function choosePotentialApproverTeams(

--- a/bundle-size/package-lock.json
+++ b/bundle-size/package-lock.json
@@ -1549,6 +1549,11 @@
         }
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
     "cluster-key-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
@@ -5258,6 +5263,14 @@
             "ms": "^2.1.1"
           }
         }
+      }
+    },
+    "node-cache": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.0.2.tgz",
+      "integrity": "sha512-wqJIYqBbOaYycAHNXgWx7fYJA5S3KcwpJqwuDuHWGKzzG8vIvj80eN47+/FTioUdE96AuiTHoAtsiTVOBLrM9A==",
+      "requires": {
+        "clone": "2.x"
       }
     },
     "node-fetch": {

--- a/bundle-size/package.json
+++ b/bundle-size/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@octokit/rest": "16.35.0",
     "knex": "0.20.2",
+    "node-cache": "5.0.2",
     "pg": "7.14.0",
     "probot": "9.6.6",
     "sleep-promise": "8.0.1"

--- a/bundle-size/test/api.test.js
+++ b/bundle-size/test/api.test.js
@@ -70,7 +70,11 @@ describe('bundle-size api', () => {
       .get('/teams/123/members')
       .reply(200, getFixture('teams.123.members'))
       .get('/teams/234/members')
-      .reply(200, getFixture('teams.234.members'));
+      .reply(200, getFixture('teams.234.members'))
+      .get(
+        '/repos/ampproject/amphtml/contents/build-system/tasks/bundle-size/APPROVERS.json'
+      )
+      .reply(200, getFixture('APPROVERS.json'));
   });
 
   afterEach(async () => {

--- a/bundle-size/test/fixtures/APPROVERS.json.json
+++ b/bundle-size/test/fixtures/APPROVERS.json.json
@@ -1,0 +1,18 @@
+{
+  "name": "APPROVERS.json",
+  "path": "build-system/tasks/bundle-size/APPROVERS.json",
+  "sha": "a533db2ed2dea345943998219b61e3ae9a2bac58",
+  "size": 416,
+  "url": "https://api.github.com/repos/ampproject/amphtml/contents/build-system/tasks/bundle-size/APPROVERS.json?ref=master",
+  "html_url": "https://github.com/ampproject/amphtml/blob/master/build-system/tasks/bundle-size/APPROVERS.json",
+  "git_url": "https://api.github.com/repos/ampproject/amphtml/git/blobs/a533db2ed2dea345943998219b61e3ae9a2bac58",
+  "download_url": "https://raw.githubusercontent.com/ampproject/amphtml/master/build-system/tasks/bundle-size/APPROVERS.json",
+  "type": "file",
+  "content": "ewogICJkaXN0L3YwLmpzIjogewogICAgImFwcHJvdmVycyI6IFsiYW1wcHJv\namVjdC93Zy1wZXJmb3JtYW5jZSIsICJhbXBwcm9qZWN0L3dnLXJ1bnRpbWUi\nXSwKICAgICJ0aHJlc2hvbGQiOiAwLjEKICB9LAogICJkaXN0L2FtcDRhZHMt\ndjAuanMiOiB7CiAgICAiYXBwcm92ZXJzIjogWyJhbXBwcm9qZWN0L3dnLWFk\ncyJdLAogICAgInRocmVzaG9sZCI6IDAuMQogIH0sCiAgImRpc3QvdjAvYW1w\nLXN0b3J5LTAuMS5qcyI6IHsKICAgICJhcHByb3ZlcnMiOiBbImFtcHByb2pl\nY3Qvd2ctc3RvcmllcyJdLAogICAgInRocmVzaG9sZCI6IDAuNQogIH0sCiAg\nImRpc3QvdjAvYW1wLXN0b3J5LTEuMC5qcyI6IHsKICAgICJhcHByb3ZlcnMi\nOiBbImFtcHByb2plY3Qvd2ctc3RvcmllcyJdLAogICAgInRocmVzaG9sZCI6\nIDAuNQogIH0KfQo=\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/ampproject/amphtml/contents/build-system/tasks/bundle-size/APPROVERS.json?ref=master",
+    "git": "https://api.github.com/repos/ampproject/amphtml/git/blobs/a533db2ed2dea345943998219b61e3ae9a2bac58",
+    "html": "https://github.com/ampproject/amphtml/blob/master/build-system/tasks/bundle-size/APPROVERS.json"
+  }
+}


### PR DESCRIPTION
Related to #617

Does the pre-processing, but doesn't actually do anything with it yet.

Tag-along changes:
* Better error messages in the log (`app.log(error)` gives a stack trace, ```app.log(`${error}`)``` does not)
* More log statements
* Fix a type in README.md