### PR TITLE
[bundle-size] Prevent preemptive approvals for bundle-size changes

### DIFF
--- a/bundle-size/setup-db.js
+++ b/bundle-size/setup-db.js
@@ -32,7 +32,9 @@ function setupDb(db) {
       table.integer('pull_request_id');
       table.integer('installation_id');
       table.integer('check_run_id');
-      table.decimal('delta', 6, 2);
+      table
+        .decimal('delta', 6, 2)
+        .comment('Legacy column, should be removed with #617');
     })
     .createTable('merges', table => {
       table.string('merge_commit_sha', 40).primary();

--- a/bundle-size/test/webhooks.test.js
+++ b/bundle-size/test/webhooks.test.js
@@ -256,7 +256,7 @@ describe('bundle-size webhooks', () => {
       nocks.done();
     });
 
-    test('mark a check as successful when a capable user approves the PR with missing size delta', async () => {
+    test('ignore a preemptive approval', async () => {
       const payload = getFixture('pull_request_review.submitted');
 
       await db('checks').insert({
@@ -269,20 +269,7 @@ describe('bundle-size webhooks', () => {
         delta: null,
       });
 
-      const nocks = nock('https://api.github.com')
-        .patch('/repos/ampproject/amphtml/check-runs/555555', body => {
-          expect(body).toMatchObject({
-            conclusion: 'success',
-            output: {
-              title: 'Δ ±?.??KB | approved by @aghassemi',
-            },
-          });
-          return true;
-        })
-        .reply(200);
-
       await probot.receive({name: 'pull_request_review', payload});
-      nocks.done();
     });
 
     test('ignore an approved review by a non-capable reviewer', async () => {

--- a/bundle-size/webhooks.js
+++ b/bundle-size/webhooks.js
@@ -103,7 +103,11 @@ exports.installGitHubWebhooks = (app, db, userBasedGithub) => {
 
       let approvalMessagePrefix;
       if (check.delta === null) {
-        approvalMessagePrefix = 'Δ ±?.??KB';
+        context.log(
+          'Pull requests can no longer be preemptively approved for ' +
+            'bundle-size changes'
+        );
+        return;
       } else {
         const bundleSizeDelta = parseFloat(check.delta);
         if (bundleSizeDelta <= process.env['MAX_ALLOWED_INCREASE']) {


### PR DESCRIPTION
This preemption was necessary in the past, when the bundle-size checks were unstable. Eventually I'll return that ability only for `ampproject/wg-infra` so that we can still have somebody override it, but for #617 to work correctly this needs to go away