### PR TITLE
Let renovate-bot upgrade node version to latest LTS

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,9 @@
   "extends": [
     "config:base"
   ],
+  "node": {
+    "supportPolicy": ["lts_latest"]
+  },
   "packageRules": [{
     "packagePatterns": [".*"],
     "groupName": "packages",


### PR DESCRIPTION
Relevant docs: https://docs.renovatebot.com/node/#configuring-support-policy

We use `lts_active` in `ampproject/amphtml`, but for `amp-github-apps` I think it makes sense to ride the front of the wave with `lts_latest`