### PR TITLE
[bundle-size] Store the chosen approving teams in the database

### DIFF
--- a/bundle-size/api.js
+++ b/bundle-size/api.js
@@ -336,7 +336,10 @@ exports.installApiRouter = (app, db, githubUtils) => {
       prBundleSizes['dist/v0.js'] - baseRuntimeBundleSize;
 
     await db('checks')
-      .update({delta: baseRuntimeBundleSizeDelta})
+      .update({
+        delta: baseRuntimeBundleSizeDelta,
+        approving_teams: chosenApproverTeams.join(','),
+      })
       .where({head_sha: check.head_sha});
 
     const requiresApproval =

--- a/bundle-size/common.js
+++ b/bundle-size/common.js
@@ -30,7 +30,8 @@ exports.getCheckFromDatabase = async (db, headSha) => {
       'owner',
       'repo',
       'check_run_id',
-      'delta'
+      'delta',
+      'approving_teams'
     )
     .where('head_sha', headSha);
   if (results.length > 0) {

--- a/bundle-size/github-utils.js
+++ b/bundle-size/github-utils.js
@@ -229,7 +229,7 @@ class GitHubUtils {
     );
     this.log(
       `Reviewer for pull request ${pullRequestId} will be chosen from ` +
-        `[${potentialApproverTeams.join(', ')}] (team ids are` +
+        `[${potentialApproverTeams.join(', ')}] (team ids are ` +
         `[${teamIds.join(', ')}])`
     );
     const potentialReviewers = await this.getTeamMembers_(teamIds);

--- a/bundle-size/setup-db.js
+++ b/bundle-size/setup-db.js
@@ -35,6 +35,11 @@ function setupDb(db) {
       table
         .decimal('delta', 6, 2)
         .comment('Legacy column, should be removed with #617');
+      table
+        .string('approving_teams')
+        .comment(
+          'Comma separated list of teams to that can approve a bundle-size increase, in the format `ampproject/wg-runtime,ampproject/wg-performance`'
+        );
     })
     .createTable('merges', table => {
       table.string('merge_commit_sha', 40).primary();

--- a/bundle-size/test/api.test.js
+++ b/bundle-size/test/api.test.js
@@ -106,6 +106,7 @@ describe('bundle-size api', () => {
         installation_id: 123456,
         check_run_id: 555555,
         delta: null,
+        approving_teams: null,
       });
 
       const nocks = nock('https://api.github.com')
@@ -163,6 +164,7 @@ describe('bundle-size api', () => {
           installation_id: 123456,
           check_run_id: 555555,
           delta: null,
+          approving_teams: null,
         });
 
         const baseBundleSizeFixture = getFixture(
@@ -207,6 +209,7 @@ describe('bundle-size api', () => {
         installation_id: 123456,
         check_run_id: 555555,
         delta: null,
+        approving_teams: null,
       });
 
       const baseBundleSizeFixture = getFixture(
@@ -258,6 +261,7 @@ describe('bundle-size api', () => {
           installation_id: 123456,
           check_run_id: 555555,
           delta: null,
+          approving_teams: null,
         });
 
         const baseBundleSizeFixture = getFixture(
@@ -319,6 +323,7 @@ describe('bundle-size api', () => {
           installation_id: 123456,
           check_run_id: 555555,
           delta: null,
+          approving_teams: null,
         });
 
         const baseBundleSizeFixture = getFixture(
@@ -380,6 +385,7 @@ describe('bundle-size api', () => {
           installation_id: 123456,
           check_run_id: 555555,
           delta: null,
+          approving_teams: null,
         });
 
         const baseBundleSizeFixture = getFixture(
@@ -433,6 +439,7 @@ describe('bundle-size api', () => {
           installation_id: 123456,
           check_run_id: 555555,
           delta: null,
+          approving_teams: null,
         });
 
         const baseBundleSizeFixture = getFixture(
@@ -493,6 +500,7 @@ describe('bundle-size api', () => {
           installation_id: 123456,
           check_run_id: 555555,
           delta: null,
+          approving_teams: null,
         });
 
         const baseBundleSizeFixture = getFixture(
@@ -564,6 +572,7 @@ describe('bundle-size api', () => {
         installation_id: 123456,
         check_run_id: 555555,
         delta: null,
+        approving_teams: null,
       });
 
       const lastNetworkRequest = new Promise(resolve => {

--- a/bundle-size/test/webhooks.test.js
+++ b/bundle-size/test/webhooks.test.js
@@ -106,7 +106,7 @@ describe('bundle-size webhooks', () => {
       await probot.receive({name: 'pull_request', payload});
       nocks.done();
 
-      expect(await db('checks').select('*')).toMatchObject([
+      expect(await db('checks').select('*')).toEqual([
         {
           head_sha: '39f787c8132f9ccc956ed465c0af8bc33f641404',
           owner: 'ampproject',
@@ -115,6 +115,7 @@ describe('bundle-size webhooks', () => {
           installation_id: 123456,
           check_run_id: 555555,
           delta: null,
+          approving_teams: null,
         },
       ]);
     });
@@ -128,6 +129,7 @@ describe('bundle-size webhooks', () => {
         installation_id: 123456,
         check_run_id: 444444,
         delta: null,
+        approving_teams: null,
       });
 
       const payload = getFixture('pull_request.opened');
@@ -148,7 +150,7 @@ describe('bundle-size webhooks', () => {
       await probot.receive({name: 'pull_request', payload});
       nocks.done();
 
-      expect(await db('checks').select('*')).toMatchObject([
+      expect(await db('checks').select('*')).toEqual([
         {
           head_sha: '39f787c8132f9ccc956ed465c0af8bc33f641404',
           owner: 'ampproject',
@@ -157,6 +159,7 @@ describe('bundle-size webhooks', () => {
           installation_id: 123456,
           check_run_id: 555555,
           delta: null,
+          approving_teams: null,
         },
       ]);
     });
@@ -169,7 +172,7 @@ describe('bundle-size webhooks', () => {
         name: 'pull_request',
         payload: pullRequestPayload,
       });
-      expect(await db('merges').select('*')).toMatchObject([]);
+      expect(await db('merges').select('*')).toEqual([]);
 
       const checkRunPayload = getFixture('check_run.created');
 
@@ -187,7 +190,7 @@ describe('bundle-size webhooks', () => {
         name: 'pull_request',
         payload: pullRequestPayload,
       });
-      expect(await db('merges').select('*')).toMatchObject([
+      expect(await db('merges').select('*')).toEqual([
         {merge_commit_sha: '4ba02c691d1a3014f70a7521c07d775dc6a1e355'},
       ]);
 
@@ -206,7 +209,7 @@ describe('bundle-size webhooks', () => {
         .reply(200);
 
       await probot.receive({name: 'check_run', payload: checkRunPayload});
-      expect(await db('merges').select('*')).toMatchObject([]);
+      expect(await db('merges').select('*')).toEqual([]);
       nocks.done();
     });
 
@@ -244,6 +247,7 @@ describe('bundle-size webhooks', () => {
         installation_id: 123456,
         check_run_id: 555555,
         delta: 0.2,
+        approving_teams: 'ampproject/wg-performance,ampproject/wg-runtime',
       });
 
       const nocks = nock('https://api.github.com')
@@ -273,6 +277,7 @@ describe('bundle-size webhooks', () => {
         installation_id: 123456,
         check_run_id: 555555,
         delta: null,
+        approving_teams: null,
       });
 
       await probot.receive({name: 'pull_request_review', payload});
@@ -302,6 +307,7 @@ describe('bundle-size webhooks', () => {
         installation_id: 123456,
         check_run_id: 555555,
         delta: 0.05,
+        approving_teams: 'ampproject/wg-performance,ampproject/wg-runtime',
       });
 
       await probot.receive({name: 'pull_request_review', payload});


### PR DESCRIPTION
Related to #617

Adds a new DB column and updates that column when the teams needed for approval are determined in the `/report` API endpoint. This data will be used in a followup-PR in the review webhook

Tag-along changes:
* Make tests more strict by switching db row comparisons from `toMatchObject` to `toEqual`, which fails on missing fields
* Fixed logging typo