### PR TITLE
Show all JS files in default view of bundle-size chart

### DIFF
--- a/bundle-size-chart/static/index.html
+++ b/bundle-size-chart/static/index.html
@@ -30,7 +30,7 @@
 <body>
   <h1><a href="https://github.com/ampproject/amphtml">AMPHTML</a> bundle-size history</h1>
   <div id="chart"></div>
-  <label for="filter">Filter</label> <input type="text" id="filter" value="v0.js">
+  <label for="filter">Filter (for example, "v0.js")</label> <input type="text" id="filter" value="">
   <script src="https://d3js.org/d3.v5.min.js" charset="utf-8"></script>
   <script src="/index.js"></script>
 </body>


### PR DESCRIPTION
This PR removes the filter so that all JS files are shown in the default view, and instead, adds a suggestion for how to use the filter field.