### PR TITLE
[bundle-size] Move new reviewer selection logic into the `addBundleSizeReviewer` and move that method into `GitHubUtils`

### DIFF
--- a/bundle-size/.env.example
+++ b/bundle-size/.env.example
@@ -20,7 +20,7 @@ TRAVIS_PUSH_BUILD_TOKEN=0123456789abcdefghijklmnopqrstuvwxyz
 FALLBACK_APPROVER_TEAMS=ampproject/wg-runtime,ampproject/wg-performance
 
 # List of GitHub teams whose members can approve all bundle-size changes
-SUPER_USER_TEAMS=ampproject/wg-runtime,ampproject/wg-performance,ampproject/wg-infra
+SUPER_USER_TEAMS=ampproject/wg-infra
 
 # List of GitHub team IDs whose members can approve bundle-size changes; legacy, to be removed with #617
 APPROVER_TEAMS=123,234,345

--- a/bundle-size/api.js
+++ b/bundle-size/api.js
@@ -249,10 +249,13 @@ exports.installApiRouter = (app, db, githubUtils) => {
           output: erroredCheckOutput(partialBaseSha),
         });
         await github.checks.update(updatedCheckOptions);
-        await githubUtils.addBundleSizeReviewer({
-          pull_number: check.pull_request_id,
-          ...githubOptions,
-        });
+        await githubUtils.addBundleSizeReviewer(
+          {
+            pull_number: check.pull_request_id,
+            ...githubOptions,
+          },
+          process.env.SUPER_USER_TEAMS.split(',')
+        );
       }
       return false;
     }
@@ -309,10 +312,6 @@ exports.installApiRouter = (app, db, githubUtils) => {
       app.log,
       check.pull_request_id
     );
-    if (chosenApproverTeams.length) {
-      // eslint-disable-next-line no-unused-vars
-      githubUtils.getRandomReviewer(chosenApproverTeams, check.pull_request_id);
-    }
 
     if (bundleSizeDeltas.length === 0) {
       bundleSizeDeltas.push(
@@ -366,10 +365,13 @@ exports.installApiRouter = (app, db, githubUtils) => {
     await github.checks.update(updatedCheckOptions);
 
     if (requiresApproval) {
-      await githubUtils.addBundleSizeReviewer({
-        pull_number: check.pull_request_id,
-        ...githubOptions,
-      });
+      await githubUtils.addBundleSizeReviewer(
+        {
+          pull_number: check.pull_request_id,
+          ...githubOptions,
+        },
+        chosenApproverTeams
+      );
     }
 
     return true;

--- a/bundle-size/github-utils.js
+++ b/bundle-size/github-utils.js
@@ -252,12 +252,7 @@ class GitHubUtils {
     ]);
 
     const potentialReviewers = await this.getTeamMembers_(approverTeams);
-    if (
-      potentialReviewers.length &&
-      potentialReviewers.every(
-        potentialReviewer => !existingReviewers.has(potentialReviewer)
-      )
-    ) {
+    if (!potentialReviewers.some(existingReviewers.has, existingReviewers)) {
       // None of the potential reviewers are in the PR's requested reviewers
       // list, so add a random reviewer here.
       // eslint-disable-next-line no-unused-vars

--- a/bundle-size/github-utils.js
+++ b/bundle-size/github-utils.js
@@ -220,21 +220,15 @@ class GitHubUtils {
   /**
    * Choose a random reviewer from list of potential approver teams.
    *
-   * @param {number} pullRequestId the pull request id.
    * @param {!Array<string>} potentialReviewers list of GitHub usernames of all
    *   users who are members of the teams that can approve the bundle-size
    *   change of this pull request.
    * @return {string} the chosen reviewer username.
    */
-  async getRandomReviewer_(pullRequestId, potentialReviewers) {
-    const reviewer =
-      potentialReviewers[Math.floor(Math.random() * potentialReviewers.length)];
-    this.log(
-      `Chose reviewer ${reviewer} from all of ` +
-        `[${potentialReviewers.join(', ')}] for pull request ${pullRequestId}`
-    );
-
-    return reviewer;
+  async getRandomReviewer_(potentialReviewers) {
+    return potentialReviewers[
+      Math.floor(Math.random() * potentialReviewers.length)
+    ];
   }
 
   /**
@@ -267,9 +261,11 @@ class GitHubUtils {
       // None of the potential reviewers are in the PR's requested reviewers
       // list, so add a random reviewer here.
       // eslint-disable-next-line no-unused-vars
-      const newReviewer = await this.getRandomReviewer_(
-        pullRequest.pull_number,
-        potentialReviewers
+      const newReviewer = await this.getRandomReviewer_(potentialReviewers);
+      this.log(
+        `Chose reviewer ${newReviewer} from all of ` +
+          `[${potentialReviewers.join(', ')}] for pull request ` +
+          `${pullRequest.pull_number}`
       );
       // TODO(#617, danielrozenberg): replace the legacy logic below and add the
       // `newReviewer` as to this PR instead.

--- a/bundle-size/test/api.test.js
+++ b/bundle-size/test/api.test.js
@@ -57,6 +57,10 @@ describe('bundle-size api', () => {
     process.env = {
       TRAVIS_PUSH_BUILD_TOKEN: '0123456789abcdefghijklmnopqrstuvwxyz',
       MAX_ALLOWED_INCREASE: '0.1',
+      FALLBACK_APPROVER_TEAMS:
+        'ampproject/wg-runtime,ampproject/wg-performance',
+      SUPER_USER_TEAMS: 'ampproject/wg-infra',
+      // TODO(#617, danielrozenberg): legacy code.
       APPROVER_TEAMS: '123,234',
       REVIEWER_TEAMS: '123',
     };

--- a/bundle-size/test/api.test.js
+++ b/bundle-size/test/api.test.js
@@ -28,7 +28,6 @@ nock.disableNetConnect();
 nock.enableNetConnect('127.0.0.1');
 jest.mock('../db');
 jest.mock('sleep-promise', () => () => Promise.resolve());
-jest.setTimeout(30000);
 
 describe('bundle-size api', () => {
   let probot;

--- a/bundle-size/test/webhooks.test.js
+++ b/bundle-size/test/webhooks.test.js
@@ -26,7 +26,6 @@ const {setupDb} = require('../setup-db');
 nock.disableNetConnect();
 nock.enableNetConnect('127.0.0.1');
 jest.mock('../db');
-jest.setTimeout(30000);
 
 describe('bundle-size webhooks', () => {
   let probot;


### PR DESCRIPTION
#617

This will make it easier to switch to the new selection algorithm once the logs show that we're getting it right on the "dry-runs"

Tag-along changes:
* Update .env.example with a more accurate set of super-users
* Remove extended timeout for tests since they now pass fairly quickly