### PR TITLE
[project metrics] Augment plotting to allow arbitrary range of results

### DIFF
--- a/project-metrics/metrics_service/cron.yaml
+++ b/project-metrics/metrics_service/cron.yaml
@@ -15,9 +15,13 @@ cron:
   url: /_cron/scrape/builds
   schedule: every 4 hours from 8:00 to 19:00
   
-- description: "Render updated plots of metric result history"
+- description: "Render updated plots of 180 days of metric result history"
   url: /_cron/plot_metric_history
   schedule: every saturday 01:00
+  
+- description: "Render updated plots of a year of metric result history"
+  url: /_cron/plot_metric_history/365
+  schedule: 1st, 3rd saturday of month 01:30
 
 
 - description: "Update absolute-coverage metric."

--- a/project-metrics/metrics_service/metric_plot.py
+++ b/project-metrics/metrics_service/metric_plot.py
@@ -23,8 +23,11 @@ class MetricHistoryPlotter(object):
   drawing on each other.
   """
 
-  def __init__(self, metric: base_metric.MetricImplementation):
+  def __init__(self,
+               metric: base_metric.MetricImplementation,
+               history_days: int = HISTORY_DAYS):
     self.metric = metric
+    self.history_days = history_days
     self.history = self._get_metric_history()
 
   def __del__(self):
@@ -40,14 +43,15 @@ class MetricHistoryPlotter(object):
     Returns:
       A byte buffer containing the plot rendered as a PNG.
     """
-    logging.info('Plotting %d days of results for %s', HISTORY_DAYS,
+    logging.info('Plotting %d days of results for %s', self.history_days,
                  self.metric.name)
     self._make_plot()
     self._set_labels()
     return self._save_plot_to_buffer(width, height)
 
   def _get_metric_history(self) -> Sequence[models.MetricResult]:
-    start_date = datetime.datetime.now() - datetime.timedelta(days=HISTORY_DAYS)
+    start_date = datetime.datetime.now() - datetime.timedelta(
+        days=self.history_days)
 
     session = db.Session()
     history = session.query(models.MetricResult).order_by(
@@ -69,7 +73,7 @@ class MetricHistoryPlotter(object):
     plt.plot(result_dates, result_values, 'b-')
 
   def _set_labels(self):
-    plt.title('%s (Last %d Days)' % (self.metric.label, HISTORY_DAYS))
+    plt.title('%s (Last %d Days)' % (self.metric.label, self.history_days))
     plt.ylabel('Metric Value (%s)' % self.metric.UNIT)
     plt.xlabel('Date')
 

--- a/project-metrics/metrics_service/metric_plot.py
+++ b/project-metrics/metrics_service/metric_plot.py
@@ -10,8 +10,6 @@ from database import db
 from database import models
 from metrics import base as base_metric
 
-HISTORY_DAYS = 180
-
 
 class MetricHistoryPlotter(object):
   """Plots metric results over the last six months.
@@ -23,9 +21,8 @@ class MetricHistoryPlotter(object):
   drawing on each other.
   """
 
-  def __init__(self,
-               metric: base_metric.MetricImplementation,
-               history_days: int = HISTORY_DAYS):
+  def __init__(self, metric: base_metric.MetricImplementation,
+               history_days: int):
     self.metric = metric
     self.history_days = history_days
     self.history = self._get_metric_history()

--- a/project-metrics/metrics_service/server.py
+++ b/project-metrics/metrics_service/server.py
@@ -172,13 +172,16 @@ def show_metrics():
       'show_metrics.html', github_repo=env.get('GITHUB_REPO'), metrics=metrics)
 
 
-@app.route('/history')
-def show_metric_history():
+@app.route('/history', defaults={'history_days': HISTORY_DAYS})
+@app.route('/history/<history_days>')
+def show_metric_history(history_days: Text):
+  history_days = int(history_days)
   metric_names = [cls.__name__ for cls in base.Metric.get_active_metrics()]
   return flask.render_template(
       'show_metric_history.html',
       github_repo=env.get('GITHUB_REPO'),
-      metric_names=metric_names)
+      metric_names=metric_names,
+      history_days=history_days)
 
 
 if __name__ == '__main__':

--- a/project-metrics/metrics_service/server.py
+++ b/project-metrics/metrics_service/server.py
@@ -21,6 +21,7 @@ import scrapers
 
 app = flask.Flask(__name__)
 
+HISTORY_DAYS = 180
 BADGE_COLORS = [
     '#EEEEEE',
     'indianred',
@@ -89,20 +90,25 @@ def recompute(metric_cls_name: Text):
   return 'Successfully recomputed %s.' % metric_cls_name, status.HTTP_200_OK
 
 
-@app.route('/_cron/plot_metric_history')
-def render_metric_history_plot():
+@app.route(
+    '/_cron/plot_metric_history', defaults={'history_days': HISTORY_DAYS})
+@app.route('/_cron/plot_metric_history/<history_days>')
+def render_metric_history_plot(history_days: Text):
   # This header is added to cron requests by GAE, and stripped from any external
   # requests. See
   # https://cloud.google.com/appengine/docs/standard/python3/scheduling-jobs-with-cron-yaml#validating_cron_requests
   if not flask.request.headers.get('X-Appengine-Cron'):
     return 'Attempted to access internal endpoint.', status.HTTP_403_FORBIDDEN
 
-  logging.info('Rendering metric history plots')
+  history_days = int(history_days)
+  logging.info('Rendering metric history plots for last %d days', history_days)
   for metric_cls in base.Metric.get_active_metrics():
     metric = metric_cls()
-    plotter = metric_plot.MetricHistoryPlotter(metric)
+    plotter = metric_plot.MetricHistoryPlotter(
+        metric, history_days=history_days)
     plot_buffer = plotter.plot_metric_history()
-    _save_to_cloud(plot_buffer.read(), '%s-history.png' % metric.name,
+    _save_to_cloud(plot_buffer.read(),
+                   '%s-history-%dd.png' % (metric.name, history_days),
                    'image/png')
 
   return 'History plots updated.', status.HTTP_200_OK
@@ -119,8 +125,10 @@ def list_metrics():
                        }), status.HTTP_200_OK
 
 
-@app.route('/api/plot/<metric_cls_name>.png')
-def metric_history_plot(metric_cls_name: Text):
+@app.route(
+    '/api/plot/<metric_cls_name>.png', defaults={'history_days': HISTORY_DAYS})
+@app.route('/api/plot/<history_days>/<metric_cls_name>.png')
+def metric_history_plot(history_days: Text, metric_cls_name: Text):
   try:
     metric_cls = base.Metric.get_metric(metric_cls_name)
   except KeyError:
@@ -128,7 +136,9 @@ def metric_history_plot(metric_cls_name: Text):
     return ('No active metric found for %s.' %
             metric_cls_name), status.HTTP_404_NOT_FOUND
 
-  plot_bytes = _get_from_cloud('%s-history.png' % metric_cls_name)
+  history_days = int(history_days)
+  plot_bytes = _get_from_cloud('%s-history-%dd.png' %
+                               (metric_cls_name, history_days))
   return flask.send_file(io.BytesIO(plot_bytes), mimetype='image/png')
 
 

--- a/project-metrics/metrics_service/templates/show_metric_history.html
+++ b/project-metrics/metrics_service/templates/show_metric_history.html
@@ -13,7 +13,7 @@
 <body>
   {% if metric_names %}
     {% for name in metric_names %}
-    <img src="/api/plot/{{ name }}.png">
+    <img src="/api/plot/{{ history_days }}/{{ name }}.png">
     {% endfor %}
   {% else %}
   <strong>No metrics available to display.</strong>


### PR DESCRIPTION
This adds a `history_days` optional param to the `/_cron/plot_metric_history`, `/api/plot/*Metric.png`, and `/history` endpoints to allow for generating and viewing results over various time windows