### PR TITLE
[invite] Add method stubs and tests for invitation record

### DIFF
--- a/invite/package.json
+++ b/invite/package.json
@@ -14,6 +14,7 @@
     "lint-conflicts": "eslint --print-config app.ts | eslint-config-prettier-check",
 
     "build": "tsc",
+    "build:watch": "tsc -w --p tsconfig.json",
     "start": "probot run ./app.js",
     "dev": "nodemon",
     "deploy-tag": "git tag 'deploy-invite-'`date --utc '+%Y%m%d%H%M%S'`",

--- a/invite/src/github.ts
+++ b/invite/src/github.ts
@@ -25,16 +25,14 @@ import {ILogger} from './types';
  * Interface for working with the GitHub API.
  */
 export class GitHub {
-  private client: Octokit;
-  private org: string;
-  private logger: ILogger;
-
   /**
    * Constructor.
    */
-  constructor(client: Octokit, org: string, logger: ILogger = console) {
-    Object.assign(this, {client, org, logger});
-  }
+  constructor(
+    private client: Octokit,
+    private org: string,
+    private logger: ILogger = console
+  ) {}
 
   /**
    * Checks whether a user is a member of the organization.

--- a/invite/src/invitation_record.ts
+++ b/invite/src/invitation_record.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2020 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ILogger, Invite} from './types';
+
+/**
+ * A record of invites sent by the bot that may require follow-up actions.
+ */
+export class InvitationRecord {
+  /**
+   * Constructor.
+   */
+  constructor(logger: ILogger = console) {}
+
+  /**
+   * Records an invite created by the bot.
+   */
+  async recordInvite(invite: Invite): Promise<void> {}
+
+  /**
+   * Looks up the invites for a user.
+   */
+  async getInvites(username: string): Promise<Array<Invite>> {
+    return [];
+  }
+
+  /**
+   * Marks a user's invites as archived, indicating all necessary follow-up
+   * actions have been completed.
+   */
+  async archiveInvites(username: string): Promise<void> {}
+}

--- a/invite/src/invitation_record.ts
+++ b/invite/src/invitation_record.ts
@@ -23,7 +23,7 @@ export class InvitationRecord {
   /**
    * Constructor.
    */
-  constructor(logger: ILogger = console) {}
+  constructor(private logger: ILogger = console) {}
 
   /**
    * Records an invite created by the bot.

--- a/invite/src/invitation_record.ts
+++ b/invite/src/invitation_record.ts
@@ -16,6 +16,9 @@
 
 import {ILogger, Invite} from './types';
 
+// TODO: Enable after filling in implementations.
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 /**
  * A record of invites sent by the bot that may require follow-up actions.
  */

--- a/invite/src/types.ts
+++ b/invite/src/types.ts
@@ -28,8 +28,8 @@ export interface ILogger {
  * Possible invite action types.
  */
 export enum InviteAction {
-  INVITE = 1,
-  INVITE_AND_ASSIGN,
+  INVITE = 'invite',
+  INVITE_AND_ASSIGN = 'invite_and_assign',
 }
 
 /**

--- a/invite/src/types.ts
+++ b/invite/src/types.ts
@@ -14,9 +14,31 @@
  * limitations under the License.
  */
 
+/**
+ * A standard logging interface.
+ */
 export interface ILogger {
   debug(message: string, ...extraInfo: any[]): void;
   warn(message: string, ...extraInfo: any[]): void;
   error(message: string, ...extraInfo: any[]): void;
   info(message: string, ...extraInfo: any[]): void;
+}
+
+/**
+ * Possible invite action types.
+ */
+export enum InviteAction {
+  INVITE = 1,
+  INVITE_AND_ASSIGN,
+}
+
+/**
+ * An invite triggered by the bot.
+ */
+export interface Invite {
+  username: string;
+  repo: string;
+  issue_number: number;
+  action: InviteAction;
+  archived?: boolean;
 }

--- a/invite/test/invitation_record.test.ts
+++ b/invite/test/invitation_record.test.ts
@@ -17,7 +17,7 @@
 import {Invite, InviteAction} from '../src/types';
 import {InvitationRecord} from '../src/invitation_record';
 
-describe('invitation record', () => {
+describe.skip('invitation record', () => {
   let record: InvitationRecord;
   const invite: Invite = {
     username: 'someone',

--- a/invite/test/invitation_record.test.ts
+++ b/invite/test/invitation_record.test.ts
@@ -32,15 +32,8 @@ describe.skip('invitation record', () => {
   });
 
   describe('recordInvite', () => {
-    // TODO: Update once the storage interface is determined.
-    it('records an invite', async done => {
-      throw new Error('Not implemented!');
-      done();
-    });
-    it('sets `archived = false`', async done => {
-      throw new Error('Not implemented!');
-      done();
-    });
+    it.todo('records an invite');
+    it.todo('sets `archived = false`');
   });
 
   describe('getInvites', () => {

--- a/invite/test/invitation_record.test.ts
+++ b/invite/test/invitation_record.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2020 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Invite, InviteAction} from '../src/types';
+import {InvitationRecord} from '../src/invitation_record';
+
+describe('invitation record', () => {
+  let record: InvitationRecord;
+  const invite: Invite = {
+    username: 'someone',
+    repo: 'test_repo',
+    issue_number: 1337,
+    action: InviteAction.INVITE,
+  };
+  const archivedInvite: Invite = Object.assign({archived: true}, invite);
+
+  beforeEach(() => {
+    record = new InvitationRecord();
+  });
+
+  describe('recordInvite', () => {
+    // TODO: Update once the storage interface is determined.
+    it('records an invite', async done => {
+      throw new Error('Not implemented!');
+      done();
+    });
+    it('sets `archived = false`', async done => {
+      throw new Error('Not implemented!');
+      done();
+    });
+  });
+
+  describe('getInvites', () => {
+    describe('if no invite record exists for the user', () => {
+      it('returns an empty list', async done => {
+        expect(await record.getInvites('someone')).toEqual([]);
+        done();
+      });
+    });
+
+    describe('if records exists of invites to the user', () => {
+      beforeEach(async () => {
+        await record.recordInvite(invite);
+      });
+
+      it('returns the invites', async done => {
+        expect(await record.getInvites('someone')).toEqual([invite]);
+        done();
+      });
+    });
+
+    describe('if only archived invite records exists for the user', () => {
+      beforeEach(async () => {
+        await record.recordInvite(archivedInvite);
+      });
+
+      it('returns an empty list', async done => {
+        expect(await record.getInvites('someone')).toEqual([]);
+        done();
+      });
+    });
+  });
+
+  describe('archiveInvites', () => {
+    describe('if records exists of any invites to the user', () => {
+      beforeEach(async () => {
+        await record.recordInvite(invite);
+        await record.recordInvite({
+          username: 'someone',
+          repo: 'test_repo',
+          issue_number: 42,
+          action: InviteAction.INVITE,
+        });
+      });
+
+      it('updates the invite records', async done => {
+        await record.archiveInvites('someone');
+
+        const invites: Array<Invite> = await record.getInvites('someone');
+        expect(invites[0].archived).toBe(true);
+        expect(invites[1].archived).toBe(true);
+
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Taking a test-driven approach, defining all the class interfaces and expectations first, then filling in the implementations, so as to allow for better parallelism

This invitation record will eventually contain an implementation backed either by Cloud SQL or Cloud Datastore, which will record invites as they are sent so that the bot can later update the threads and assign issues if/when the invites are accepted.

```
invitation record
  recordInvite
    ✕ records an invite (1ms)
    ✕ sets `archived = false`
  getInvites
    if no invite record exists for the user
      ✓ returns an empty list (1ms)
    if records exists of invites to the user
      ✕ returns the invites (3ms)
    if only archived invite records exists for the user
      ✓ returns an empty list
  archiveInvites
    if records exists of any invites to the user
      ✕ updates the invite records (1ms)
```