### PR TITLE
[invite] Add method stubs and tests for invite bot + webhooks

### DIFF
--- a/invite/src/invite_bot.ts
+++ b/invite/src/invite_bot.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2020 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Octokit} from '@octokit/rest';
+
+import {GitHub} from './github';
+import {ILogger, Invite, InviteAction} from './types';
+import {InvitationRecord} from './invitation_record';
+
+// TODO: Enable after filling in implementations.
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/**
+ * GitHub bot which can invite users to an organization and assign issues in
+ * response to macro comments.
+ */
+export class InviteBot {
+  readonly github: GitHub;
+  readonly record: InvitationRecord;
+
+  /**
+   * Constructor.
+   */
+  constructor(client: Octokit, org: string, private logger: ILogger = console) {
+    this.github = new GitHub(client, org, logger);
+    this.record = new InvitationRecord(logger);
+  }
+
+  /**
+   * Process a comment by identifying and acting on any macros present.
+   */
+  async processComment(
+    repo: string,
+    issue_number: number,
+    comment: string
+  ): Promise<void> {}
+
+  /**
+   * Process an accepted invite by adding comments and assigning issues.
+   */
+  async processAcceptedInvite(repo: string, username: string): Promise<void> {}
+
+  /**
+   * Parses a comment for invitation macros.
+   */
+  parseMacros(comment: string): Record<string, InviteAction> {
+    return {};
+  }
+
+  /**
+   * Attempt to invite the user, record the invite, and comment with an update
+   * about the status of the invite.
+   *
+   * Should be called in response to new comments with the /invite or /tryassign
+   * macros.
+   */
+  async tryInvite(invite: Invite): Promise<boolean> {
+    return false;
+  }
+
+  /**
+   * Attempt to assign the user to the associated issue and comments on the
+   * thread.
+   *
+   * Should be called in response to accepted invitations in order to update the
+   * thread(s) from which the user was invited.
+   */
+  async tryAssign(invite: Invite, accepted: boolean): Promise<void> {}
+}

--- a/invite/test/app.test.ts
+++ b/invite/test/app.test.ts
@@ -14,18 +14,14 @@
  * limitations under the License.
  */
 
-const {Probot} = require('probot');
-const nock = require('nock');
+import {Probot} from 'probot';
+import nock from 'nock';
 
-const {InviteBot} = require('../src/invite_bot');
-const {triggerWebhook} = require('_test_helper');
-
-function fail() {
-  throw new Error('Not implemented!');
-}
+import {InviteBot} from '../src/invite_bot';
+import {triggerWebhook} from './fixtures';
 
 describe('Probot webhooks', () => {
-  let probot: typeof Probot;
+  let probot: Probot;
 
   beforeAll(() => {
     nock.disableNetConnect();
@@ -40,7 +36,7 @@ describe('Probot webhooks', () => {
     // Return a test token for fake authentication flow.
     app.app = {
       getInstallationAccessToken: async () => 'test_token',
-      getSignedJsonWebToken: async () => 'test_token',
+      getSignedJsonWebToken: () => 'test_token',
     };
   });
 

--- a/invite/test/app.test.ts
+++ b/invite/test/app.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2020 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {Probot} = require('probot');
+const nock = require('nock');
+
+const {InviteBot} = require('../src/invite_bot');
+const {triggerWebhook} = require('_test_helper');
+
+function fail() {
+  throw new Error('Not implemented!');
+}
+
+describe('Probot webhooks', () => {
+  let probot: typeof Probot;
+
+  beforeAll(() => {
+    nock.disableNetConnect();
+    process.env = {
+      GITHUB_ARG: 'test_org',
+      GITHUB_ACCESS_TOKEN: '_TOKEN_',
+    };
+
+    probot = new Probot({});
+    const app = probot.load(require('../app'));
+
+    // Return a test token for fake authentication flow.
+    app.app = {
+      getInstallationAccessToken: async () => 'test_token',
+      getSignedJsonWebToken: async () => 'test_token',
+    };
+  });
+
+  afterAll(() => {
+    nock.enableNetConnect();
+  });
+
+  beforeEach(() => {
+    jest
+      .spyOn(InviteBot.prototype, 'processComment')
+      .mockImplementation(async () => {});
+    jest
+      .spyOn(InviteBot.prototype, 'processAcceptedInvite')
+      .mockImplementation(async () => {});
+
+    nock('https://api.github.com')
+      .post('/app/installations/588033/access_tokens')
+      .reply(200, {token: 'test'});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+
+    // Fail the test if there were unused nocks.
+    if (!nock.isDone()) {
+      throw new Error('Not all nock interceptors were used!');
+      nock.cleanAll();
+    }
+  });
+
+  [
+    'issue_comment.created',
+    'pull_request_review.submitted',
+    'pull_request_review_comment.created',
+  ].forEach(eventName => {
+    describe(`on ${eventName} event`, () => {
+      it('processes the comment for macros', async done => {
+        expect(InviteBot.prototype.processComment).toBeCalledWith(
+          'test_repo',
+          1337,
+          'Test comment'
+        );
+
+        await triggerWebhook(probot, eventName);
+        done();
+      });
+    });
+  });
+
+  [
+    'issue_comment.edited',
+    'issue_comment.deleted',
+    'pull_request_review.edited',
+    'pull_request_review.dismissed',
+    'pull_request_review_comment.edited',
+    'pull_request_review_comment.deleted',
+  ].forEach(eventName => {
+    describe(`on ${eventName} event`, () => {
+      it('does not processes the comment', async done => {
+        expect(InviteBot.prototype.processComment).toBeCalledWith(
+          'test_repo',
+          1337,
+          'Test comment'
+        );
+
+        await triggerWebhook(probot, eventName);
+        done();
+      });
+    });
+  });
+
+  describe('on organization.member_added event', () => {
+    it('processes the accepted invite with follow-up actions', async done => {
+      expect(InviteBot.prototype.processComment).toBeCalledWith(
+        'test_repo',
+        'someone'
+      );
+
+      await triggerWebhook(probot, 'organization.member_added');
+      done();
+    });
+  });
+
+  describe('on organization.member_invited event', () => {
+    it('does not process the new membership', async done => {
+      expect(InviteBot.prototype.processComment).not.toBeCalledWith();
+
+      await triggerWebhook(probot, 'organization.member_invited');
+      done();
+    });
+  });
+
+  describe('on organization.member_removed event', () => {
+    it('does not process the new membership', async done => {
+      expect(InviteBot.prototype.processComment).not.toBeCalledWith();
+
+      await triggerWebhook(probot, 'organization.member_removed');
+      done();
+    });
+  });
+});

--- a/invite/test/fixtures/index.ts
+++ b/invite/test/fixtures/index.ts
@@ -15,6 +15,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import {Probot} from 'probot';
 
 /**
  * Get a JSON test fixture object.
@@ -24,3 +25,18 @@ export function getFixture(name: string): Object {
     fs.readFileSync(path.join(__dirname, `${name}.json`)).toString('utf8')
   );
 };
+
+/**
+ * Triggers a Probot webhook event using a payload from `fixtures/`.
+ */
+export async function triggerWebhook(
+  probot: Probot,
+  eventName: string
+): Promise<void> {
+  const [name] = eventName.split('.');
+  await probot.receive({
+    name,
+    id: '',  // required by type definition.
+    payload: getFixture(eventName),
+  });
+}

--- a/invite/test/invite_bot.test.ts
+++ b/invite/test/invite_bot.test.ts
@@ -96,6 +96,11 @@ describe('Invite Bot', () => {
         },
       ]);
     });
+
+    it('ignores `whatever/invite` and `something/tryassign` non-macros', () => {
+      const comment = 'greet/invite @someone and ask/tryAssign @someone_else';
+      expect(inviteBot.parseMacros(comment)).toEqual([]);
+    });
   });
 
   describe('tryInvite', () => {

--- a/invite/test/invite_bot.test.ts
+++ b/invite/test/invite_bot.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Copyright 2020 The AMP HTML Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {mocked} from 'ts-jest/utils';
+
+import {Invite, InviteAction} from '../src/types';
+import {InvitationRecord} from '../src/invitation_record';
+import {InviteBot} from '../src/invite_bot';
+import {GitHub} from '../src/github';
+
+describe('Invite Bot', () => {
+  let inviteBot: InviteBot;
+
+  beforeEach(() => {
+    inviteBot = new InviteBot(/*client=*/ null, 'test_repo');
+
+    jest.spyOn(GitHub.prototype, 'inviteUser');
+    jest.spyOn(GitHub.prototype, 'addComment');
+    jest.spyOn(InvitationRecord.prototype, 'recordInvite');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('parseMacros', () => {
+    describe('comments without macros', () => {
+      it('returns an empty list', () => {
+        const comment = 'random comment';
+        expect(inviteBot.parseMacros(comment)).toEqual({});
+      });
+
+      it('ignores macros without usernames', () => {
+        const comment = '/invite not_a_tag';
+        expect(inviteBot.parseMacros(comment)).toEqual({});
+      });
+    });
+
+    describe('comments with `/invite @user`', () => {
+      it('returns list including Invite action for @user', () => {
+        const comment = '/invite @someone';
+        expect(inviteBot.parseMacros(comment)).toEqual({
+          someone: InviteAction.INVITE,
+        });
+      });
+
+      it('handles multiple `/invite` macros', () => {
+        const comment = '/invite @someone and /invite @someone_else';
+        expect(inviteBot.parseMacros(comment)).toEqual({
+          someone: InviteAction.INVITE,
+          someone_else: InviteAction.INVITE,
+        });
+      });
+    });
+
+    describe('comments with `/tryassign @user`', () => {
+      it('returns list including InviteAndAssign action for @user', () => {
+        const comment = '/tryassign @someone';
+        expect(inviteBot.parseMacros(comment)).toEqual([
+          {
+            someone: InviteAction.INVITE_AND_ASSIGN,
+          },
+        ]);
+      });
+
+      it('handles multiple `/tryassign` macros', () => {
+        const comment = '/tryassign @someone and /tryAssign @someone_else';
+        expect(inviteBot.parseMacros(comment)).toEqual([
+          {
+            someone: InviteAction.INVITE_AND_ASSIGN,
+            someone_else: InviteAction.INVITE_AND_ASSIGN,
+          },
+        ]);
+      });
+    });
+
+    it('handles mix of `/invite` and `/tryassign` macros', () => {
+      const comment = '/invite @someone and /tryAssign @someone_else';
+      expect(inviteBot.parseMacros(comment)).toEqual([
+        {
+          someone: InviteAction.INVITE,
+          someone_else: InviteAction.INVITE_AND_ASSIGN,
+        },
+      ]);
+    });
+  });
+
+  describe('tryInvite', () => {
+    const newInvite: Invite = {
+      username: 'someone',
+      repo: 'test_repo',
+      issue_number: 1337,
+      action: InviteAction.INVITE,
+    };
+
+    describe('when the user has a pending invite from the bot', () => {
+      beforeEach(() => {
+        inviteBot.record.recordInvite({
+          username: 'someone',
+          repo: 'test_repo',
+          issue_number: 42,
+          action: InviteAction.INVITE,
+        });
+      });
+
+      it('it does not attempt to send an invite', async done => {
+        await inviteBot.tryInvite(newInvite);
+        expect(inviteBot.github.inviteUser).not.toBeCalled();
+        done();
+      });
+
+      it('records the requested invite', async done => {
+        await inviteBot.tryInvite(newInvite);
+        expect(inviteBot.record.recordInvite).toBeCalledWith(newInvite);
+        done();
+      });
+
+      it('comments that there is already an invite pending', async done => {
+        await inviteBot.tryInvite(newInvite);
+        expect(inviteBot.github.addComment).toBeCalledWith(
+          'test_repo',
+          1337,
+          'I attempted to invite @someone to `test_org`, but they already ' +
+            'have an invitation pending! I will update this thread when the ' +
+            'invitation is accepted.'
+        );
+        done();
+      });
+    });
+
+    describe('when the user is a member', () => {
+      beforeEach(() => {
+        mocked(inviteBot.github.inviteUser).mockImplementation(
+          async () => false
+        );
+      });
+
+      it('attempts to send an invite', async done => {
+        await inviteBot.tryInvite(newInvite);
+        expect(inviteBot.github.inviteUser).toBeCalledWith('someone');
+        done();
+      });
+
+      it('does not record the requested invite', async done => {
+        await inviteBot.tryInvite(newInvite);
+        expect(inviteBot.record.recordInvite).not.toBeCalled();
+        done();
+      });
+
+      it('comments that the user is already a member', async done => {
+        await inviteBot.tryInvite(newInvite);
+        expect(inviteBot.github.addComment).toBeCalledWith(
+          'test_repo',
+          1337,
+          'You asked me to invite @someone, but they are already a member of ' +
+            '`test_org/test_repo`!'
+        );
+        done();
+      });
+
+      it('returns false', async done => {
+        expect(await inviteBot.tryInvite(newInvite)).toBe(false);
+        done();
+      });
+    });
+
+    describe('when the user is not a member', () => {
+      beforeEach(() => {
+        mocked(inviteBot.github.inviteUser).mockImplementation(
+          async () => true
+        );
+      });
+
+      it('attempts to send an invite', async done => {
+        await inviteBot.tryInvite(newInvite);
+        expect(inviteBot.github.inviteUser).toBeCalledWith('someone');
+        done();
+      });
+
+      it('records the requested invite', async done => {
+        await inviteBot.tryInvite(newInvite);
+        expect(inviteBot.record.recordInvite).toBeCalledWith(newInvite);
+        done();
+      });
+
+      it('comments that the user was invited', async done => {
+        await inviteBot.tryInvite(newInvite);
+        expect(inviteBot.github.addComment).toBeCalledWith(
+          'test_repo',
+          1337,
+          'An invitation to join `test_org` has been sent to @someone. I ' +
+            'will update this thread when the invitation is accepted.'
+        );
+        done();
+      });
+
+      it('returns true', async done => {
+        expect(await inviteBot.tryInvite(newInvite)).toBe(true);
+        done();
+      });
+    });
+
+    describe('when the invite fails', () => {
+      beforeEach(() => {
+        mocked(inviteBot.github.inviteUser).mockImplementation(async () => {
+          throw new Error('Uh-oh!');
+        });
+        jest.spyOn(console, 'error');
+      });
+
+      it('logs an error', async done => {
+        try {
+          await inviteBot.tryInvite(newInvite);
+        } catch (e) {}
+
+        expect(console.error).toBeCalledWith(
+          'Failed to send an invite to @someone: Error: Uh-oh!'
+        );
+        done();
+      });
+
+      it('comments about the error', async done => {
+        try {
+          await inviteBot.tryInvite(newInvite);
+        } catch (e) {}
+
+        expect(inviteBot.github.addComment).toBeCalledWith(
+          'test_repo',
+          1337,
+          'You asked me to send an invite to @someone, but I ran into an ' +
+            'error when I tried. Try sending the invite manually.'
+        );
+        done();
+      });
+
+      it('re-throws the error', async done => {
+        expect(async () => {
+          await inviteBot.tryInvite(newInvite);
+        }).toThrow(new Error('Uh-oh!'));
+        done();
+      });
+    });
+  });
+
+  describe('tryAssign', () => {
+    const newInvite: Invite = {
+      username: 'someone',
+      repo: 'test_repo',
+      issue_number: 1337,
+      action: InviteAction.INVITE_AND_ASSIGN,
+    };
+
+    it('assigns the user to the issue', async done => {
+      await inviteBot.tryAssign(newInvite, true);
+      expect(inviteBot.github.assignIssue).toBeCalledWith(
+        'test_repo',
+        1337,
+        'someone'
+      );
+      done();
+    });
+
+    describe('when @someone just accepted the invitation', () => {
+      it('comments that the issue was assigned', async done => {
+        await inviteBot.tryAssign(newInvite, true);
+        expect(inviteBot.github.addComment).toBeCalledWith(
+          'test_repo',
+          1337,
+          "The invitation to @someone was accepted! I've assigned them to " +
+            'this issue.'
+        );
+        done();
+      });
+    });
+
+    describe('when @someone was already a member of the org', () => {
+      it('comments that the issue was assigned', async done => {
+        await inviteBot.tryAssign(newInvite, false);
+        expect(inviteBot.github.addComment).toBeCalledWith(
+          'test_repo',
+          1337,
+          "It looks like @someone is already a member of `test_org`! I've " +
+            'assigned them to this issue.'
+        );
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
```
Invite Bot
  parseMacros
    ✕ handles mix of `/invite` and `/tryassign` macros (1ms)
    comments without macros
      ✓ returns an empty list (2ms)
      ✓ ignores macros without usernames
    comments with `/invite @user`
      ✕ returns list including Invite action for @user (3ms)
      ✕ handles multiple `/invite` macros (7ms)
    comments with `/tryassign @user`
      ✕ returns list including InviteAndAssign action for @user (3ms)
      ✕ handles multiple `/tryassign` macros (2ms)
  tryInvite
    when the user has a pending invite from the bot
      ✓ it does not attempt to send an invite (2ms)
      ✕ records the requested invite (5ms)
      ✕ comments that there is already an invite pending (1ms)
    when the user is a member
      ✕ attempts to send an invite (1ms)
      ✓ does not record the requested invite
      ✕ comments that the user is already a member (2ms)
      ✓ returns false
    when the user is not a member
      ✕ attempts to send an invite (1ms)
      ✕ records the requested invite (2ms)
      ✕ comments that the user was invited (1ms)
      ✕ returns true (1ms)
    when the invite fails
      ✕ logs an error
      ✕ comments about the error
      ✕ re-throws the error (1ms)
  tryAssign
    ✕ assigns the user to the issue (1ms)
    when @someone just accepted the invitation
      ✕ comments that the issue was assigned (1ms)
    when @someone was already a member of the org
      ✕ comments that the issue was assigned (1ms)

Probot webhooks
  on issue_comment.created event
    ✕ processes the comment for macros (15ms)
  on pull_request_review.submitted event
    ✕ processes the comment for macros
  on pull_request_review_comment.created event
    ✕ processes the comment for macros
  on issue_comment.edited event
    ✕ does not processes the comment (1ms)
  on issue_comment.deleted event
    ✕ does not processes the comment (1ms)
  on pull_request_review.edited event
    ✕ does not processes the comment (1ms)
  on pull_request_review.dismissed event
    ✕ does not processes the comment
  on pull_request_review_comment.edited event
    ✕ does not processes the comment
  on pull_request_review_comment.deleted event
    ✕ does not processes the comment (1ms)
  on organization.member_added event
    ✕ processes the accepted invite with follow-up actions (1ms)
  on organization.member_invited event
    ✕ does not process the new membership (1ms)
  on organization.member_removed event
    ✕ does not process the new membership
```