### PR TITLE
[invite] Add implementation for invitation record methods

### DIFF
--- a/invite/src/github.ts
+++ b/invite/src/github.ts
@@ -18,9 +18,6 @@ import {Octokit} from '@octokit/rest';
 
 import {ILogger} from './types';
 
-// TODO: Enable after filling in implementations.
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 /**
  * Interface for working with the GitHub API.
  */

--- a/invite/src/invitation_record.ts
+++ b/invite/src/invitation_record.ts
@@ -32,7 +32,9 @@ export class InvitationRecord {
   /**
    * Records an invite created by the bot.
    */
-  async recordInvite(invite: Invite): Promise<void> {}
+  async recordInvite(invite: Invite): Promise<void> {
+    await this.db('invites').insert(invite);
+  }
 
   /**
    * Looks up the invites for a user.

--- a/invite/src/invitation_record.ts
+++ b/invite/src/invitation_record.ts
@@ -49,5 +49,9 @@ export class InvitationRecord {
    * Marks a user's invites as archived, indicating all necessary follow-up
    * actions have been completed.
    */
-  async archiveInvites(username: string): Promise<void> {}
+  async archiveInvites(username: string): Promise<void> {
+    await this.db('invites')
+      .where({username})
+      .update({archived: true});
+  }
 }

--- a/invite/src/invitation_record.ts
+++ b/invite/src/invitation_record.ts
@@ -17,9 +17,6 @@
 import {Database} from './db';
 import {ILogger, Invite} from './types';
 
-// TODO: Enable after filling in implementations.
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 /**
  * A record of invites sent by the bot that may require follow-up actions.
  */

--- a/invite/src/invitation_record.ts
+++ b/invite/src/invitation_record.ts
@@ -37,9 +37,14 @@ export class InvitationRecord {
    * Looks up the invites for a user.
    */
   async getInvites(username: string): Promise<Array<Invite>> {
-    return await this.db('invites')
+    return (await this.db('invites')
       .select()
-      .where({username, archived: false});
+      .where({username, archived: false}))
+      .map(invite => {
+        // PostgresQL stores booleans as TINYINT, so we cast it to boolean.
+        invite.archived = !!invite.archived;
+        return invite;
+      });
   }
 
   /**

--- a/invite/src/invitation_record.ts
+++ b/invite/src/invitation_record.ts
@@ -40,7 +40,9 @@ export class InvitationRecord {
    * Looks up the invites for a user.
    */
   async getInvites(username: string): Promise<Array<Invite>> {
-    return [];
+    return await this.db('invites')
+      .select()
+      .where({username, archived: false});
   }
 
   /**

--- a/invite/src/types.ts
+++ b/invite/src/types.ts
@@ -40,5 +40,5 @@ export interface Invite {
   repo: string;
   issue_number: number;
   action: InviteAction;
-  archived?: boolean|number;  // stored as a TINYINT in PostgresQL
+  archived?: boolean | number; // stored as a TINYINT in PostgresQL
 }

--- a/invite/src/types.ts
+++ b/invite/src/types.ts
@@ -40,5 +40,5 @@ export interface Invite {
   repo: string;
   issue_number: number;
   action: InviteAction;
-  archived?: boolean | number; // stored as a TINYINT in PostgresQL
+  archived?: boolean;
 }

--- a/invite/src/types.ts
+++ b/invite/src/types.ts
@@ -40,5 +40,5 @@ export interface Invite {
   repo: string;
   issue_number: number;
   action: InviteAction;
-  archived?: boolean;
+  archived?: boolean|number;  // stored as a TINYINT in PostgresQL
 }

--- a/invite/test/invitation_record.test.ts
+++ b/invite/test/invitation_record.test.ts
@@ -49,20 +49,16 @@ describe('invitation record', () => {
     it('records an invite', async done => {
       record.recordInvite(invite);
 
-      expect(
-        await db('invites')
-          .select()
-          .first()
-      ).toEqual(invite);
+      const recordedInvite = await db('invites').first()
+      expect(recordedInvite).toMatchObject(invite);
       done();
     });
 
     it('sets `archived = false`', async done => {
-      expect(
-        await db('invites')
-          .pluck('archived')
-          .first()
-      ).toEqual(false);
+      record.recordInvite(invite);
+
+      const recordedInvite = await db('invites').first();
+      expect(recordedInvite.archived).toBeFalsy();
       done();
     });
   });

--- a/invite/test/invitation_record.test.ts
+++ b/invite/test/invitation_record.test.ts
@@ -77,7 +77,7 @@ describe('invitation record', () => {
       });
     });
 
-    describe('if records exists of invites to the user', () => {
+    describe('if records exist of invites to the user', () => {
       beforeEach(async () => {
         await record.recordInvite(invite);
         await record.recordInvite(otherInvite);
@@ -105,7 +105,7 @@ describe('invitation record', () => {
   });
 
   describe('archiveInvites', () => {
-    describe('if records exists of any invites to the user', () => {
+    describe('if records exist of any invites to the user', () => {
       beforeEach(async () => {
         await record.recordInvite(invite);
         await record.recordInvite(otherInvite);

--- a/invite/test/invitation_record.test.ts
+++ b/invite/test/invitation_record.test.ts
@@ -39,7 +39,7 @@ describe('invitation record', () => {
     repo: 'test_repo',
     issue_number: 42,
     action: InviteAction.INVITE,
-  }
+  };
   const archivedInvite: Invite = Object.assign({archived: true}, invite);
 
   beforeAll(async () => setupDb(db));
@@ -55,7 +55,7 @@ describe('invitation record', () => {
     it('records an invite', async done => {
       record.recordInvite(invite);
 
-      const recordedInvite: Invite = await db('invites').first()
+      const recordedInvite: Invite = await db('invites').first();
       expect(recordedInvite).toMatchObject(invite);
       done();
     });

--- a/invite/test/invitation_record.test.ts
+++ b/invite/test/invitation_record.test.ts
@@ -84,10 +84,10 @@ describe('invitation record', () => {
       });
 
       it('returns the invites', async done => {
-        const recordedInvites: Array<Invite> = await record.getInvites('someone');
+        const invites: Array<Invite> = await record.getInvites('someone');
 
-        expect(recordedInvites[0]).toMatchObject(invite);
-        expect(recordedInvites[1]).toMatchObject(otherInvite);
+        expect(invites[0]).toMatchObject(invite);
+        expect(invites[1]).toMatchObject(otherInvite);
         done();
       });
     });
@@ -114,9 +114,10 @@ describe('invitation record', () => {
       it('updates the invite records', async done => {
         await record.archiveInvites('someone');
 
-        const invites: Array<Invite> = await record.getInvites('someone');
-        expect(invites[0].archived).toBe(true);
-        expect(invites[1].archived).toBe(true);
+        expect(await record.getInvites('someone')).toEqual([]);
+        const invites = await db('invites').select();
+        expect(invites[0].archived).toBeTruthy();
+        expect(invites[1].archived).toBeTruthy();
 
         done();
       });

--- a/invite/test/invitation_record.test.ts
+++ b/invite/test/invitation_record.test.ts
@@ -34,6 +34,12 @@ describe('invitation record', () => {
     issue_number: 1337,
     action: InviteAction.INVITE,
   };
+  const otherInvite: Invite = {
+    username: 'someone',
+    repo: 'test_repo',
+    issue_number: 42,
+    action: InviteAction.INVITE,
+  }
   const archivedInvite: Invite = Object.assign({archived: true}, invite);
 
   beforeAll(async () => setupDb(db));
@@ -49,7 +55,7 @@ describe('invitation record', () => {
     it('records an invite', async done => {
       record.recordInvite(invite);
 
-      const recordedInvite = await db('invites').first()
+      const recordedInvite: Invite = await db('invites').first()
       expect(recordedInvite).toMatchObject(invite);
       done();
     });
@@ -57,7 +63,7 @@ describe('invitation record', () => {
     it('sets `archived = false`', async done => {
       record.recordInvite(invite);
 
-      const recordedInvite = await db('invites').first();
+      const recordedInvite: Invite = await db('invites').first();
       expect(recordedInvite.archived).toBeFalsy();
       done();
     });
@@ -74,10 +80,14 @@ describe('invitation record', () => {
     describe('if records exists of invites to the user', () => {
       beforeEach(async () => {
         await record.recordInvite(invite);
+        await record.recordInvite(otherInvite);
       });
 
       it('returns the invites', async done => {
-        expect(await record.getInvites('someone')).toEqual([invite]);
+        const recordedInvites: Array<Invite> = await record.getInvites('someone');
+
+        expect(recordedInvites[0]).toMatchObject(invite);
+        expect(recordedInvites[1]).toMatchObject(otherInvite);
         done();
       });
     });
@@ -98,12 +108,7 @@ describe('invitation record', () => {
     describe('if records exists of any invites to the user', () => {
       beforeEach(async () => {
         await record.recordInvite(invite);
-        await record.recordInvite({
-          username: 'someone',
-          repo: 'test_repo',
-          issue_number: 42,
-          action: InviteAction.INVITE,
-        });
+        await record.recordInvite(otherInvite);
       });
 
       it('updates the invite records', async done => {


### PR DESCRIPTION
```
 PASS  test/invitation_record.test.ts
  invitation record
    recordInvite
      ✓ records an invite (5ms)
      ✓ sets `archived = false` (1ms)
    getInvites
      if no invite record exists for the user
        ✓ returns an empty list (2ms)
      if records exists of invites to the user
        ✓ returns the invites (1ms)
      if only archived invite records exists for the user
        ✓ returns an empty list (1ms)
    archiveInvites
      if records exists of any invites to the user
        ✓ updates the invite records (3ms)
```