### PR TITLE
[invite] Add team membership check to GitHub API interface

### DIFF
--- a/invite/app.ts
+++ b/invite/app.ts
@@ -26,6 +26,7 @@ export default (app: Application) => {
     require('dotenv').config();
   }
 
+  const helpUserToTag = process.env.HELP_USER_TO_TAG || null;
   const github = new Octokit({
     authStrategy: createTokenAuth,
     auth: process.env.GITHUB_ACCESS_TOKEN,
@@ -37,6 +38,7 @@ export default (app: Application) => {
     const inviteBot = new InviteBot(
       github,
       payload.repository.owner.login,
+      helpUserToTag,
       log,
     );
     await inviteBot.processComment(
@@ -52,6 +54,7 @@ export default (app: Application) => {
     const inviteBot = new InviteBot(
       github,
       payload.repository.owner.login,
+      helpUserToTag,
       log,
     );
     await inviteBot.processComment(
@@ -67,6 +70,7 @@ export default (app: Application) => {
     const inviteBot = new InviteBot(
       github,
       payload.repository.owner.login,
+      helpUserToTag,
       log,
     );
     await inviteBot.processComment(
@@ -82,6 +86,7 @@ export default (app: Application) => {
     const inviteBot = new InviteBot(
       github,
       payload.repository.owner.login,
+      helpUserToTag,
       log,
     );
     await inviteBot.processComment(
@@ -97,6 +102,7 @@ export default (app: Application) => {
     const inviteBot = new InviteBot(
       github,
       payload.repository.owner.login,
+      helpUserToTag,
       log,
     );
     await inviteBot.processComment(
@@ -109,7 +115,12 @@ export default (app: Application) => {
   app.on('organization.member_added', async (
     {event, payload, log}: Context<Webhooks.WebhookPayloadOrganization>
   ) => {
-    const inviteBot = new InviteBot(github, payload.organization.login, log);
+    const inviteBot = new InviteBot(
+      github,
+      payload.organization.login,
+      helpUserToTag,
+      log,
+    );
     await inviteBot.processAcceptedInvite(payload.membership.user.login);
   });
 };

--- a/invite/src/github.ts
+++ b/invite/src/github.ts
@@ -69,17 +69,18 @@ export class GitHub {
   }
 
   /* Checks whether a user is a member of the organization. */
-  async userIsMember(username: string): Promise<boolean> {  
+  async userIsTeamMember(username: string, teamSlug: string): Promise<boolean> {  
     // The membership API returns status 404 when the user is not a member of
     // the organization, but Octokit handles this by rejecting the promise. We
     // only need the status code to make a determination, so the `catch` handler
     // just forwards along the response.
-    const response = await this.client.orgs.checkMembership({
+    const response = await this.client.teams.getMembershipInOrg({
       org: this.org,
+      team_slug: teamSlug,
       username,
     }).catch(errorResponse => errorResponse); 
 
-    return response.status === 204; 
+    return response.status === 200 && response.data.state === 'active'; 
   }
 }
 

--- a/invite/src/github.ts
+++ b/invite/src/github.ts
@@ -70,6 +70,10 @@ export class GitHub {
 
   /* Checks whether a user is a member of the organization. */
   async userIsMember(username: string): Promise<boolean> {  
+    // The membership API returns status 404 when the user is not a member of
+    // the organization, but Octokit handles this by rejecting the promise. We
+    // only need the status code to make a determination, so the `catch` handler
+    // just forwards along the response.
     const response = await this.client.orgs.checkMembership({
       org: this.org,
       username,

--- a/invite/src/github.ts
+++ b/invite/src/github.ts
@@ -70,9 +70,12 @@ export class GitHub {
 
   /* Checks whether a user is a member of the organization. */
   async userIsMember(username: string): Promise<boolean> {  
-    // https://octokit.github.io/rest.js/#octokit-routes-orgs-check-membership  
-    // octokit.orgs.checkMembership({org, username}); 
-    return false; 
+    const response = await this.client.orgs.checkMembership({
+      org: this.org,
+      username,
+    }).catch(errorResponse => errorResponse); 
+
+    return response.status === 204; 
   }
 }
 

--- a/invite/src/github.ts
+++ b/invite/src/github.ts
@@ -18,13 +18,9 @@ import {Octokit} from '@octokit/rest';
 
 import {ILogger} from './types';
 
-/**
- * Interface for working with the GitHub API.
- */
+/** Interface for working with the GitHub API. */
 export class GitHub {
-  /**
-   * Constructor.
-   */
+  /** Constructor. */
   constructor(
     private client: Octokit,
     private org: string,
@@ -44,9 +40,7 @@ export class GitHub {
     return response.data.state === 'pending';
   }
 
-  /**
-   * Adds a comment to an issue.
-   */
+  /** Adds a comment to an issue. */
   async addComment(
     repo: string,
     issue_number: number,
@@ -60,9 +54,7 @@ export class GitHub {
     });
   }
 
-  /**
-   * Assigns an issue to a user.
-   */
+  /** Assigns an issue to a user. */
   async assignIssue(
     repo: string,
     issue_number: number,
@@ -74,6 +66,13 @@ export class GitHub {
       issue_number,
       assignees: [assignee],
     });
+  }
+
+  /* Checks whether a user is a member of the organization. */
+  async userIsMember(username: string): Promise<boolean> {  
+    // https://octokit.github.io/rest.js/#octokit-routes-orgs-check-membership  
+    // octokit.orgs.checkMembership({org, username}); 
+    return false; 
   }
 }
 

--- a/invite/test/fixtures/team_membership.active.json
+++ b/invite/test/fixtures/team_membership.active.json
@@ -1,0 +1,5 @@
+{
+  "state": "active",
+  "role": "member",
+  "url": "https://api.github.com/organizations/12345/team/67890/memberships/someone"
+}

--- a/invite/test/fixtures/team_membership.not_found.json
+++ b/invite/test/fixtures/team_membership.not_found.json
@@ -1,0 +1,4 @@
+{
+  "message": "Not Found",
+  "documentation_url": "https://developer.github.com/v3/teams/members/#get-team-membership"
+}

--- a/invite/test/fixtures/team_membership.pending.json
+++ b/invite/test/fixtures/team_membership.pending.json
@@ -1,0 +1,5 @@
+{
+  "state": "pending",
+  "role": "member",
+  "url": "https://api.github.com/organizations/12345/team/67890/memberships/someone"
+}

--- a/invite/test/github.test.ts
+++ b/invite/test/github.test.ts
@@ -104,4 +104,33 @@ describe('GitHub interface', () => {
       done();
     });
   });
+
+  describe('userIsMember', () => {  
+    it('GETs /orgs/:org/members/:username', async done => { 
+      nock('https://api.github.com')  
+        .get('/orgs/test_org/members/someone')  
+        .reply(204);  
+
+      await github.userIsMember('someone'); 
+      done(); 
+    }); 
+
+    it('returns true for 204: No Content', async done => {  
+      nock('https://api.github.com')  
+        .get('/orgs/test_org/members/someone')  
+        .reply(204);  
+
+      expect(await github.userIsMember('someone')).toBe(true);  
+      done(); 
+    }); 
+
+    it('returns false for 404: Not Found', async done => {  
+      nock('https://api.github.com')  
+        .get('/orgs/test_org/members/someone')  
+        .reply(404);  
+
+      expect(await github.userIsMember('someone')).toBe(false); 
+      done(); 
+    }); 
+  });
 });

--- a/invite/test/github.test.ts
+++ b/invite/test/github.test.ts
@@ -105,31 +105,40 @@ describe('GitHub interface', () => {
     });
   });
 
-  describe('userIsMember', () => {  
-    it('GETs /orgs/:org/members/:username', async done => { 
+  describe('userIsTeamMember', () => {  
+    it('GETs /orgs/:org/teams/:team_slug/memberships/:username', async done => { 
       nock('https://api.github.com')  
-        .get('/orgs/test_org/members/someone')  
-        .reply(204);  
+        .get('/orgs/test_org/teams/test-team/memberships/someone')  
+        .reply(200, getFixture('team_membership.active'));  
 
-      await github.userIsMember('someone'); 
+      await github.userIsTeamMember('someone', 'test-team'); 
       done(); 
-    }); 
+    });
 
-    it('returns true for 204: No Content', async done => {  
+    it('returns true for "active" membership state', async done => {  
       nock('https://api.github.com')  
-        .get('/orgs/test_org/members/someone')  
-        .reply(204);  
+        .get('/orgs/test_org/teams/test-team/memberships/someone')  
+        .reply(200, getFixture('team_membership.active'));
 
-      expect(await github.userIsMember('someone')).toBe(true);  
+      expect(await github.userIsTeamMember('someone', 'test-team')).toBe(true);  
+      done(); 
+    });
+
+    it('returns false for "pending" membership state', async done => {  
+      nock('https://api.github.com')  
+        .get('/orgs/test_org/teams/test-team/memberships/someone')  
+        .reply(200, getFixture('team_membership.pending'));
+
+      expect(await github.userIsTeamMember('someone', 'test-team')).toBe(false);  
       done(); 
     }); 
 
     it('returns false for 404: Not Found', async done => {  
       nock('https://api.github.com')  
-        .get('/orgs/test_org/members/someone')  
-        .reply(404);  
+        .get('/orgs/test_org/teams/test-team/memberships/someone')  
+        .reply(404, getFixture('team_membership.not_found'));  
 
-      expect(await github.userIsMember('someone')).toBe(false); 
+      expect(await github.userIsTeamMember('someone', 'test-team')).toBe(false); 
       done(); 
     }); 
   });


### PR DESCRIPTION
Will be used to validate that the comment author is in `ampproject/reviewers-amphtml` (similar to Owners Bot) in order to trigger a macro.

Addresses #687 