### PR TITLE
[invite] Add helper to build invite-bot instance from Probot context

### DIFF
--- a/invite/package-lock.json
+++ b/invite/package-lock.json
@@ -9607,12 +9607,6 @@
         "yn": "3.1.1"
       }
     },
-    "tsc": {
-      "version": "1.20150623.0",
-      "resolved": "https://registry.npmjs.org/tsc/-/tsc-1.20150623.0.tgz",
-      "integrity": "sha1-Trw8d04WkUjLx2inNCUz8ILHpuU=",
-      "dev": true
-    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",


### PR DESCRIPTION
The repetitive (long) constructor calls were annoying me, especially with the Probot/Octokit typecast :stuck_out_tongue: 

Addresses https://github.com/ampproject/amp-github-apps/issues/687 and https://github.com/ampproject/meta-tsc/issues/28