### PR TITLE
Report parser error when encountering singleton brace expansion rule patterns

### DIFF
--- a/owners/src/ownership/parser.js
+++ b/owners/src/ownership/parser.js
@@ -261,6 +261,23 @@ class OwnersParser {
       }
     }
 
+    // Check that there are no singleton patterns in brace-expansion format. The
+    // minimatch glob parsing library performs brace-exparnsion, but only if the
+    // braces contain comma-separated patterns. This is not obvious behavior,
+    // and has resulted in broken owners rules.
+    // Ex. `{a,b}.js` becomes /(a|b)\.js/
+    // Ex. `{a}.js` matches /\{a\}\.js/
+    if (/\{[^,]+\}/.test(pattern)) {
+      errors.push(
+        new OwnersParserError(
+          ownersPath,
+          `Brace expansion attempted in pattern '${ruleDef.pattern}', but ` +
+          'braces only contain one pattern! Please remove the extra braces.'
+        )
+      );
+      return {errors};
+    }
+
     // Create rule based on pattern and owners list.
     let rule;
     if (pattern && isRecursive) {

--- a/owners/src/ownership/parser.js
+++ b/owners/src/ownership/parser.js
@@ -266,7 +266,7 @@ class OwnersParser {
     // braces contain comma-separated patterns. This is not obvious behavior,
     // and has resulted in broken owners rules.
     // Ex. `{a,b}.js` becomes /(a|b)\.js/
-    // Ex. `{a}.js` matches /\{a\}\.js/
+    // Ex. `{a}.js` becomes /\{a\}\.js/
     if (/\{[^,]+\}/.test(pattern)) {
       errors.push(
         new OwnersParserError(

--- a/owners/src/ownership/parser.js
+++ b/owners/src/ownership/parser.js
@@ -272,7 +272,7 @@ class OwnersParser {
         new OwnersParserError(
           ownersPath,
           `Brace expansion attempted in pattern '${ruleDef.pattern}', but ` +
-          'braces only contain one pattern! Please remove the extra braces.'
+            'braces only contain one pattern! Please remove the extra braces.'
         )
       );
       return {errors};

--- a/owners/src/ownership/parser.js
+++ b/owners/src/ownership/parser.js
@@ -262,7 +262,7 @@ class OwnersParser {
     }
 
     // Check that there are no singleton patterns in brace-expansion format. The
-    // minimatch glob parsing library performs brace-exparnsion, but only if the
+    // minimatch glob parsing library performs brace-expansion, but only if the
     // braces contain comma-separated patterns. This is not obvious behavior,
     // and has resulted in broken owners rules.
     // Ex. `{a,b}.js` becomes /(a|b)\.js/

--- a/owners/test/ownership/parser.test.js
+++ b/owners/test/ownership/parser.test.js
@@ -301,6 +301,26 @@ describe('owners parser', () => {
         });
       });
 
+      describe('for a singleton pattern in braces', () => {
+        it('reports an error', () => {
+          const {errors} = parser._parseRuleDefinition('', {
+            pattern: '{amp-story-*}.js',
+            owners: [{name: 'coder'}],
+          });
+          expect(errors[0].message).toContain(
+            'braces only contain one pattern'
+          );
+        });
+
+        it('returns no result', () => {
+          const {result} = parser._parseRuleDefinition('', {
+            pattern: '{amp-story-*}.js',
+            owners: [{name: 'coder'}],
+          });
+          expect(result).toBeUndefined();
+        });
+      });
+
       describe('for a directory glob pattern', () => {
         it('reports an error', () => {
           const {errors} = parser._parseRuleDefinition('', {


### PR DESCRIPTION
The minimatch glob parsing library Owners Bot uses for parsing patterns performs brace-expansion, but only if the braces contain comma-separated patterns. This is not obvious behavior, and has resulted in broken owners rules (see https://github.com/ampproject/amphtml/pull/26899).

Ex. `"{a,b}.js"` becomes `/(a|b)\.js/`
Ex. `"{a}.js"` becomes `/\{a\}\.js/`

This PR identifies rules where there is a single pattern specified within a brace-expansion and rejects the rule, reporting an error. This will block future PRs from submitting rules broken in this way.

/cc @Enriqe 