### PR TITLE
[invite] Fix error being logged for empty comments

### DIFF
--- a/invite/src/invite_bot.ts
+++ b/invite/src/invite_bot.ts
@@ -82,8 +82,13 @@ export class InviteBot {
       `processComment: Processing comment by @${author} on ` +
         `${repo}#${issue_number}`
     );
-    const macroList = Object.entries(this.parseMacros(comment));
 
+    if (!comment) {
+      this.logger.info('processComment: Comment is empty; skipping');
+      return;
+    }
+
+    const macroList = Object.entries(this.parseMacros(comment));
     this.logger.debug(`processComment: Found ${macroList.length} macros`);
     if (macroList.length && (await this.userCanTrigger(author))) {
       for (const [username, action] of macroList) {

--- a/invite/test/invite_bot.test.ts
+++ b/invite/test/invite_bot.test.ts
@@ -93,6 +93,13 @@ describe('Invite Bot', () => {
       jest.spyOn(inviteBot, 'tryAssign').mockImplementation(async () => {});
     });
 
+    it('ignores empty comments', async done => {
+      await inviteBot.processComment('test_repo', 1337, null, 'author');
+
+      expect(inviteBot.parseMacros).not.toBeCalled();
+      done();
+    });
+
     it('parses the comment for macros', async done => {
       await inviteBot.processComment('test_repo', 1337, 'My comment', 'author');
 


### PR DESCRIPTION
When the comment field is empty, GitHub sets it to `null`, which results in an error when trying to parse macros. This has no impact except logging errors since empty comments obviously contain no macros. This PR aborts trying to process a comment if it's empty.