### PR TITLE
[release-calendar] RTVBlock Component

### DIFF
--- a/release-calendar/src/client/components/App.tsx
+++ b/release-calendar/src/client/components/App.tsx
@@ -23,6 +23,7 @@ export interface AppState {
   mode: boolean;
   mostRecentRTV: string; //change to RTVObject[]
 }
+
 export class App extends React.Component<{}, AppState> {
   constructor(props: unknown) {
     super(props);

--- a/release-calendar/src/client/components/App.tsx
+++ b/release-calendar/src/client/components/App.tsx
@@ -15,8 +15,41 @@
  */
 
 import * as React from 'react';
+import {FAKERTVANDGITHUBLINKS, SELECTEDCHANEL} from './fakeRTVdata';
 import {Header} from './Header';
+import {RTVTable} from './RTVTable';
 
-export const App = (): JSX.Element => {
-  return <Header title='AMP Release Calendar' />;
-};
+export interface AppState {
+  mode: boolean;
+  //today: Date;
+  mostRecentRTV: string; //change to RTVObject[]
+  searchedValue: string;
+}
+export class App extends React.Component<{}, AppState> {
+  constructor(props: unknown) {
+    super(props);
+    this.state = {
+      mode: true,
+      //today: new Date(),
+      mostRecentRTV: '1234567890123', //updateRTV(this.state.date) output: RTVObject[]
+      searchedValue: 'Before',
+    };
+  }
+  render(): JSX.Element {
+    return (
+      <div>
+        <Header title='AMP Release Calendar' />
+        <div className='AMP-Release-Clanedar-Side-Panel'>
+          <div className='AMP-Release-Calendar-RTV-Table'>
+            <RTVTable
+              mode={this.state.mode}
+              singleRTV={this.state.mostRecentRTV} //RTVObject[]
+              singleChannel={SELECTEDCHANEL} //RTVObject[]
+              fakeData={FAKERTVANDGITHUBLINKS}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/release-calendar/src/client/components/App.tsx
+++ b/release-calendar/src/client/components/App.tsx
@@ -21,18 +21,14 @@ import {RTVTable} from './RTVTable';
 
 export interface AppState {
   mode: boolean;
-  //today: Date;
   mostRecentRTV: string; //change to RTVObject[]
-  searchedValue: string;
 }
 export class App extends React.Component<{}, AppState> {
   constructor(props: unknown) {
     super(props);
     this.state = {
       mode: true,
-      //today: new Date(),
       mostRecentRTV: '1234567890123', //updateRTV(this.state.date) output: RTVObject[]
-      searchedValue: 'Before',
     };
   }
   render(): JSX.Element {

--- a/release-calendar/src/client/components/ManyRTVTable.tsx
+++ b/release-calendar/src/client/components/ManyRTVTable.tsx
@@ -29,7 +29,6 @@ export class ManyRTVTable extends React.Component<ManyRTVTableProps, {}> {
     const fakeData = this.props.fakeData;
 
     for (let i = 0; i < fakeData.length; i++) {
-      console.log(fakeData[i]);
       rows.push(<RTVRow Rtv={fakeData[i]}></RTVRow>);
     }
     return (

--- a/release-calendar/src/client/components/ManyRTVTable.tsx
+++ b/release-calendar/src/client/components/ManyRTVTable.tsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import {RTVRow} from './RTVRow';
+import {RTVRowObject} from '../../types';
+
+export interface ManyRTVTableProps {
+  channel: string;
+  fakeData: RTVRowObject[];
+}
+
+export class ManyRTVTable extends React.Component<ManyRTVTableProps, {}> {
+  render(): JSX.Element {
+    const rows = [];
+    const fakeData = this.props.fakeData;
+
+    for (let i = 0; i < fakeData.length; i++) {
+      console.log(fakeData[i]);
+      rows.push(<RTVRow Rtv={fakeData[i]}></RTVRow>);
+    }
+    return (
+      <table>
+        <thead>Related RTVs</thead>
+        <tbody>{rows}</tbody>
+      </table>
+    );
+  }
+}

--- a/release-calendar/src/client/components/RTVRow.tsx
+++ b/release-calendar/src/client/components/RTVRow.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import {RTVRowObject} from '../../types';
+
+export interface RTVRowProps {
+  Rtv: RTVRowObject;
+}
+
+export class RTVRow extends React.Component<RTVRowProps, {}> {
+  render(): JSX.Element {
+    const RTV = this.props.Rtv.RTV;
+    const link = this.props.Rtv.link;
+    return (
+      <tr>
+        <td>{RTV}</td>
+        <td>{link}</td>
+      </tr>
+    );
+  }
+}

--- a/release-calendar/src/client/components/RTVTable.tsx
+++ b/release-calendar/src/client/components/RTVTable.tsx
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import {ManyRTVTable} from './ManyRTVTable';
+import {RTVRowObject} from '../../types';
+import {SingleRTVBlock} from './SingleRTVBlock';
+
+export interface RTVTableProps {
+  mode: boolean;
+  singleRTV: string;
+  singleChannel: string;
+  fakeData: RTVRowObject[];
+}
+
+export class RTVTable extends React.Component<RTVTableProps, {}> {
+  render(): JSX.Element {
+    const mode = this.props.mode;
+    if (mode) {
+      return <SingleRTVBlock RTV={this.props.singleRTV} />;
+    } else {
+      return (
+        <ManyRTVTable
+          channel={this.props.singleChannel}
+          fakeData={this.props.fakeData}
+        />
+      );
+    }
+  }
+}

--- a/release-calendar/src/client/components/SingleRTVBlock.tsx
+++ b/release-calendar/src/client/components/SingleRTVBlock.tsx
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+
+export interface SingleRTVBlockProps {
+  RTV: string;
+}
+
+export class SingleRTVBlock extends React.Component<SingleRTVBlockProps, {}> {
+  render(): JSX.Element {
+    const RTV = this.props.RTV;
+    return (
+      <tr>
+        <ul> {'Selected RTV: ' + RTV} </ul>
+        <ul>{'Release Inforamtion... blah blah'}</ul>
+        <ul>{'blah blah blah'}</ul>
+        <ul>{'blah blah'}</ul>
+        <ul>{'blah'}</ul>
+      </tr>
+    );
+  }
+}

--- a/release-calendar/src/client/components/SingleRTVBlock.tsx
+++ b/release-calendar/src/client/components/SingleRTVBlock.tsx
@@ -25,6 +25,10 @@ export class SingleRTVBlock extends React.Component<SingleRTVBlockProps, {}> {
     const RTV = this.props.RTV;
     return (
       <tr>
+        {/*TODO(ajwhatson): links to issue #765,
+         replace with information that
+         links RTV to github and the PRs
+         associated with it*/}
         <ul> {'Selected RTV: ' + RTV} </ul>
         <ul>{'Release Inforamtion... blah blah'}</ul>
         <ul>{'blah blah blah'}</ul>

--- a/release-calendar/src/client/components/fakeRTVdata.tsx
+++ b/release-calendar/src/client/components/fakeRTVdata.tsx
@@ -16,6 +16,7 @@
 import {Channel, CurrentRelease, RTVRowObject} from '../../types';
 
 export const SELECTEDCHANEL = Channel.STABLE;
+
 export const FAKERTVANDGITHUBLINKS = [
   new RTVRowObject('RTVexample', 'githublink example'),
   new RTVRowObject('RTVexample', 'githublink example'),
@@ -24,6 +25,7 @@ export const FAKERTVANDGITHUBLINKS = [
   new RTVRowObject('RTVexample', 'githublink example'),
   new RTVRowObject('RTVexample', 'githublink example'),
 ];
+
 export const CURRENTRELEASES = [
   new CurrentRelease(Channel.LTS, 'RTVexample'),
   new CurrentRelease(Channel.STABLE, 'RTVexample'),

--- a/release-calendar/src/client/components/fakeRTVdata.tsx
+++ b/release-calendar/src/client/components/fakeRTVdata.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Channel, CurrentRelease, RTVRowObject} from '../../types';
+
+export const SELECTEDCHANEL = Channel.STABLE;
+export const FAKERTVANDGITHUBLINKS = [
+  new RTVRowObject('RTVexample', 'githublink example'),
+  new RTVRowObject('RTVexample', 'githublink example'),
+  new RTVRowObject('RTVexample', 'githublink example'),
+  new RTVRowObject('RTVexample', 'githublink example'),
+  new RTVRowObject('RTVexample', 'githublink example'),
+  new RTVRowObject('RTVexample', 'githublink example'),
+];
+export const CURRENTRELEASES = [
+  new CurrentRelease(Channel.LTS, 'RTVexample'),
+  new CurrentRelease(Channel.STABLE, 'RTVexample'),
+  new CurrentRelease(Channel.OPT_IN_BETA, 'RTVexample'),
+  new CurrentRelease(Channel.OPT_IN_EXPERIMENTAL, 'RTVexample'),
+  new CurrentRelease(Channel.PERCENT_BETA, 'RTVexample'),
+  new CurrentRelease(Channel.PERCENT_EXPERIMENTAL, 'RTVexample'),
+  new CurrentRelease(Channel.NIGHTLY, 'RTVexample'),
+];

--- a/release-calendar/src/types.ts
+++ b/release-calendar/src/types.ts
@@ -23,3 +23,33 @@ export enum Channel {
   OPT_IN_EXPERIMENTAL = 'opt-in-experimental',
   NIGHTLY = 'nightly',
 }
+export class CurrentRelease {
+  channel: Channel;
+  RTV: string;
+  isDisplayed: boolean;
+  constructor(channel: Channel, RTV: string, isDisplayed = false) {
+    this.channel = channel;
+    this.RTV = RTV;
+    this.isDisplayed = isDisplayed;
+  }
+}
+export class RTVRowObject {
+  RTV: string;
+  link: string;
+  constructor(RTV: string, link: string) {
+    this.RTV = RTV;
+    this.link = link;
+  }
+}
+export class Event {
+  RTV: string;
+  channel: Channel;
+  date: Date;
+  isRollback: boolean;
+  constructor(RTV: string, channel: Channel, date: Date, isRollback: boolean) {
+    this.RTV = RTV;
+    this.channel = channel;
+    this.date = date;
+    this.isRollback = isRollback;
+  }
+}


### PR DESCRIPTION
To switch from displaying SingleRTVTable to ManyRTVTable, change the mode from true to false, which is within the App Component's state.

The RTVHeader Component has two hierarchies that change depending on if the user is searching for a single RTV history or a single Channels history. When looking for a single RTV, the mode will be true and displayed will be the inner SingleRTVTable Component. When looking for a single Channel, the mode will be false and the display will be the inner ManyRTVTable. The ManyRTVTable also had many RTVRows which are RTVs within the desired Channel. 

Note: all data is static and mostly likely will change down the line as I consider how information will flow through my app. The types I have created represent the information I will need to correctly populate the components. 