### PR TITLE
Truncate text that is over the GitHub API limit for CheckRun output

### DIFF
--- a/owners/src/ownership/owners_check.js
+++ b/owners/src/ownership/owners_check.js
@@ -50,12 +50,20 @@ class CheckRun {
    * @return {!object} JSON object describing check-run.
    */
   get json() {
+    let text = `${this.text}\n\n${this.helpText}`;
+    if (text.length > this.textLimit) {
+      const info = '…[TRUNCATED]';
+      const over = text.length + info.length - this.textLimit;
+      const partialText = this.text.substr(0, this.text.length - over);
+      text = `${partialText}${info}\n\n${this.helpText}`;
+    }
+
     const checkRun = {
       name: GITHUB_CHECKRUN_NAME,
       output: {
         title: this.summary,
         summary: this.summary,
-        text: `${this.text}\n\n${this.helpText}`,
+        text,
       },
     };
 
@@ -72,6 +80,7 @@ class CheckRun {
     return checkRun;
   }
 }
+CheckRun.prototype.textLimit = 65535;
 CheckRun.prototype.helpText =
   'For a description of the OWNERS file syntax, see ' +
   `[this example file](${EXAMPLE_OWNERS_LINK}).\n` +

--- a/owners/src/ownership/owners_check.js
+++ b/owners/src/ownership/owners_check.js
@@ -21,6 +21,9 @@ const GITHUB_CHECKRUN_NAME = 'ampproject/owners-check';
 const EXAMPLE_OWNERS_LINK = 'http://ampproject-owners-bot.appspot.com/example';
 const OWNERS_TREE_LINK = 'http://ampproject-owners-bot.appspot.com/tree';
 
+// GitHub API for Check Runs (https://developer.github.com/v3/checks/runs/) has
+// an undocumented character limit for the `output.text` field.
+const CHECKRUN_TEXT_LIMIT = 65535;
 const CheckRunState = {
   SUCCESS: 'success',
   IN_PROGRESS: 'in_progress',
@@ -80,7 +83,7 @@ class CheckRun {
     return checkRun;
   }
 }
-CheckRun.prototype.textLimit = 65535;
+CheckRun.prototype.textLimit = CHECKRUN_TEXT_LIMIT;
 CheckRun.prototype.helpText =
   'For a description of the OWNERS file syntax, see ' +
   `[this example file](${EXAMPLE_OWNERS_LINK}).\n` +

--- a/owners/test/ownership/owners_check.test.js
+++ b/owners/test/ownership/owners_check.test.js
@@ -87,7 +87,7 @@ describe('check run', () => {
     });
 
     it('truncates text over the limit', () => {
-      sandbox.stub(CheckRun.prototype, 'textLimit').value(40)
+      sandbox.stub(CheckRun.prototype, 'textLimit').value(40);
       const checkRun = new CheckRun(
         CheckRunState.IN_PROGRESS,
         'Test summary',

--- a/owners/test/ownership/owners_check.test.js
+++ b/owners/test/ownership/owners_check.test.js
@@ -85,6 +85,21 @@ describe('check run', () => {
       expect(checkRunJson.conclusion).toBeUndefined();
       expect(checkRunJson.completed_at).toBeUndefined();
     });
+
+    it('truncates text over the limit', () => {
+      sandbox.stub(CheckRun.prototype, 'textLimit').value(40)
+      const checkRun = new CheckRun(
+        CheckRunState.IN_PROGRESS,
+        'Test summary',
+        'Test text content that is over the limit'
+      );
+      const checkRunJson = checkRun.json;
+
+      expect(checkRunJson.output.text.length).toEqual(40);
+      expect(checkRunJson.output.text).toEqual(
+        'Test text content…[TRUNCATED]\n\nHELP TEXT'
+      );
+    });
   });
 });
 


### PR DESCRIPTION
Truncates output text of check-runs to the API limit of 65535 characters. Result is pretty abrupt "…[TRUNCATED]" and it's possible it could screw up formatting, such as by truncating within an italic block or something, but since this case is so rare I think that's good enough.