### PR TITLE
Make /invite/.prettierrc match /.prettierrc

### DIFF
--- a/invite/.prettierrc
+++ b/invite/.prettierrc
@@ -2,5 +2,6 @@
   "bracketSpacing": false,
   "singleQuote": true,
   "trailingComma": "es5",
-  "quoteProps": "preserve"
+  "quoteProps": "preserve",
+  "arrowParens": "avoid"
 }

--- a/invite/src/invitation_record.ts
+++ b/invite/src/invitation_record.ts
@@ -43,9 +43,7 @@ export class InvitationRecord {
   async getInvites(username: string): Promise<Array<Invite>> {
     this.logger.info(`getInvites: Looking up recorded invites to @${username}`);
     return (
-      await this.db('invites')
-        .select()
-        .where({username, archived: false})
+      await this.db('invites').select().where({username, archived: false})
     ).map(invite => {
       // PostgresQL stores booleans as TINYINT, so we cast it to boolean.
       invite.archived = !!invite.archived;
@@ -59,8 +57,6 @@ export class InvitationRecord {
    */
   async archiveInvites(username: string): Promise<void> {
     this.logger.info(`archiveInvites: Archiving invites to @${username}`);
-    await this.db('invites')
-      .where({username})
-      .update({archived: true});
+    await this.db('invites').where({username}).update({archived: true});
   }
 }


### PR DESCRIPTION
This should have been updated when Prettier package was upgraded. It opts out of a newly-introduced rule of wrapping single parameters in arrow functions in parentheses, which I reeally dislike and would prefer not to enable unless y'all have a very strong preference. For now, this maintains the rules the way they were before the package update