### PR TITLE
[error-issue] Creates error-issue bot to glue blame finding and issue creation

### DIFF
--- a/error-issue/index.ts
+++ b/error-issue/index.ts
@@ -19,7 +19,7 @@ import statusCodes from 'http-status-codes';
 import {ErrorIssueBot} from './src/bot';
 import {ErrorReport} from './src/types';
 
-const GITHUB_REPO = process.env.GITHUB_REPO || 'rcebulko/amphtml';
+const GITHUB_REPO = process.env.GITHUB_REPO || 'ampproject/amphtml';
 const [GITHUB_REPO_OWNER, GITHUB_REPO_NAME] = GITHUB_REPO.split('/');
 const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
 

--- a/error-issue/index.ts
+++ b/error-issue/index.ts
@@ -15,7 +15,44 @@
  */
 
 import express from 'express';
+import statusCodes from 'http-status-codes';
+import {ErrorIssueBot} from './src/bot';
+import {ErrorReport} from './src/types';
 
-module.exports.app = (req: express.Request, res: express.Response) => {
-  res.sendStatus(200);
+const GITHUB_REPO = process.env.GITHUB_REPO || 'rcebulko/amphtml';
+const [GITHUB_REPO_OWNER, GITHUB_REPO_NAME] = GITHUB_REPO.split('/');
+const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
+
+const bot = new ErrorIssueBot(
+  GITHUB_ACCESS_TOKEN,
+  GITHUB_REPO_OWNER,
+  GITHUB_REPO_NAME,
+);
+
+module.exports.app = async (req: express.Request, res: express.Response) => {
+  const errorReport = req.method === 'POST' ? req.body : req.query;
+  const {errorId, firstSeen, dailyOccurrences, stacktrace} = errorReport;
+
+  if (!(errorId && firstSeen && dailyOccurrences && stacktrace)) {
+    res.status(statusCodes.BAD_REQUEST);
+    return res.send('Missing error report params');
+  }
+
+  console.debug(`Processing http://go/ampe/${errorId}`);
+  const parsedReport: ErrorReport = {
+    errorId,
+    firstSeen: new Date(firstSeen),
+    dailyOccurrences: parseInt(dailyOccurrences, 10),
+    stacktrace,
+  };
+
+  try {
+    const issueUrl = await bot.report(parsedReport);
+    res.redirect(302, issueUrl);
+  } catch (errResp) {
+    console.warn(errResp);
+    res.status(errResp.status || 500);
+    res.set('Content-Type', 'application/json');
+    res.send(JSON.stringify(errResp, null, 2));
+  }
 };

--- a/error-issue/index.ts
+++ b/error-issue/index.ts
@@ -26,7 +26,7 @@ const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
 const bot = new ErrorIssueBot(
   GITHUB_ACCESS_TOKEN,
   GITHUB_REPO_OWNER,
-  GITHUB_REPO_NAME,
+  GITHUB_REPO_NAME
 );
 
 module.exports.app = async (req: express.Request, res: express.Response) => {

--- a/error-issue/package-lock.json
+++ b/error-issue/package-lock.json
@@ -3374,6 +3374,11 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http-status-codes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.4.0.tgz",
+      "integrity": "sha512-JrT3ua+WgH8zBD3HEJYbeEgnuQaAnUeRRko/YojPAJjGmIfGD3KPU/asLdsLwKjfxOmQe5nXMQ0pt/7MyapVbQ=="
+    },
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",

--- a/error-issue/package.json
+++ b/error-issue/package.json
@@ -14,7 +14,7 @@
     "lint-conflicts": "eslint --print-config app.ts | eslint-config-prettier-check",
     "build": "tsc",
     "build:watch": "tsc -w --p tsconfig.json",
-    "start": "functions-framework --target=dist/app",
+    "start": "functions-framework --target=app --source=dist",
     "dev": "nodemon",
     "deploy-tag": "git tag 'deploy-error-issue-'`date --utc '+%Y%m%d%H%M%S'`",
     "test": "jest",
@@ -26,7 +26,8 @@
     "@octokit/graphql": "4.3.1",
     "@octokit/rest": "16.43.1",
     "@probot/serverless-gcf": "0.2.0",
-    "dotenv": "8.2.0"
+    "dotenv": "8.2.0",
+    "http-status-codes": "1.4.0"
   },
   "devDependencies": {
     "@google-cloud/functions-framework": "1.5.1",

--- a/error-issue/src/blame_finder.stub.ts
+++ b/error-issue/src/blame_finder.stub.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {RateLimitedGraphQL} from './rate_limited_graphql.stub';
+import {BlameRange, ILogger} from './types';
+
+/**
+ * Service for looking up Git blame info for lines in a stacktrace.
+ */
+export class BlameFinder {
+  constructor(
+    private repoOwner: string,
+    private repoName: string,
+    client: RateLimitedGraphQL,
+    private logger: ILogger = console
+  ) {}
+
+  /** Fetches the blame ranges for each line in a stacktrace. */
+  async blameForStacktrace(stacktrace: string): Promise<Array<BlameRange>> {
+    return [];
+  }
+}

--- a/error-issue/src/blame_finder.stub.ts
+++ b/error-issue/src/blame_finder.stub.ts
@@ -29,6 +29,7 @@ export class BlameFinder {
   ) {}
 
   /** Fetches the blame ranges for each line in a stacktrace. */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async blameForStacktrace(stacktrace: string): Promise<Array<BlameRange>> {
     return [];
   }

--- a/error-issue/src/bot.ts
+++ b/error-issue/src/bot.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Octokit} from '@octokit/rest';
+import statusCodes from 'http-status-codes';
+
+import {RateLimitedGraphQL} from './rate_limited_graphql.stub';
+import {BlameFinder} from './blame_finder.stub';
+import {IssueBuilder} from './issue_builder.stub';
+import {ErrorReport} from './types';
+
+const GRAPHQL_FREQ_MS = parseInt(process.env.GRAPHQL_FREQ_MS, 10) || 100;
+
+export class ErrorIssueBot {
+  private octokit: Octokit;
+  private blameFinder: BlameFinder;
+
+  constructor(
+    token: string,
+    private repoOwner: string,
+    private repoName: string
+  ) {
+    this.octokit = new Octokit({auth: token});
+    this.blameFinder = new BlameFinder(
+      repoOwner,
+      repoName,
+      new RateLimitedGraphQL(token, GRAPHQL_FREQ_MS)
+    );
+  }
+
+  /** Builds the issue to create. */
+  async buildErrorIssue(
+    errorReport: ErrorReport
+  ): Promise<Octokit.IssuesCreateParams> {
+    const {stacktrace} = errorReport;
+    const blameRanges = await this.blameFinder.blameForStacktrace(stacktrace);
+    const builder = new IssueBuilder(errorReport, blameRanges);
+    return {
+      owner: this.repoOwner,
+      repo: this.repoName,
+      title: builder.title,
+      labels: builder.labels,
+      body: builder.body,
+    };
+  }
+}

--- a/error-issue/src/bot.ts
+++ b/error-issue/src/bot.ts
@@ -56,4 +56,11 @@ export class ErrorIssueBot {
       body: builder.body,
     };
   }
+
+  /** Creates an error report issue and returns the issue URL. */
+  async report(errorReport: ErrorReport): Promise<string> {
+    const issue = await this.buildErrorIssue(errorReport);
+    const {data} = await this.octokit.issues.create(issue);
+    return data.html_url;
+  }
 }

--- a/error-issue/src/bot.ts
+++ b/error-issue/src/bot.ts
@@ -15,7 +15,6 @@
  */
 
 import {Octokit} from '@octokit/rest';
-import statusCodes from 'http-status-codes';
 
 import {RateLimitedGraphQL} from './rate_limited_graphql.stub';
 import {BlameFinder} from './blame_finder.stub';

--- a/error-issue/src/issue_builder.stub.ts
+++ b/error-issue/src/issue_builder.stub.ts
@@ -20,13 +20,13 @@ import {BlameRange, ErrorReport} from './types';
  * Builds a GitHub issue for a reported error.
  */
 export class IssueBuilder {
-  get title(): string{
+  get title(): string {
     return 'title';
   }
-  get labels(): Array<string>{
+  get labels(): Array<string> {
     return ['label'];
   }
-  get body(): string{
+  get body(): string {
     return 'body';
   }
 

--- a/error-issue/src/issue_builder.stub.ts
+++ b/error-issue/src/issue_builder.stub.ts
@@ -20,9 +20,15 @@ import {BlameRange, ErrorReport} from './types';
  * Builds a GitHub issue for a reported error.
  */
 export class IssueBuilder {
-  public title: string = 'title';
-  public labels: Array<string> = ['label'];
-  public body: string = 'body'
+  get title(): string{
+    return 'title';
+  }
+  get labels(): Array<string>{
+    return ['label'];
+  }
+  get body(): string{
+    return 'body';
+  }
 
   constructor(report: ErrorReport, private blames: Array<BlameRange>) {}
 }

--- a/error-issue/src/issue_builder.stub.ts
+++ b/error-issue/src/issue_builder.stub.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {BlameRange, ErrorReport} from './types';
+
+/**
+ * Builds a GitHub issue for a reported error.
+ */
+export class IssueBuilder {
+  public title: string = 'title';
+  public labels: Array<string> = ['label'];
+  public body: string = 'body'
+
+  constructor(report: ErrorReport, private blames: Array<BlameRange>) {}
+}

--- a/error-issue/src/rate_limited_graphql.stub.ts
+++ b/error-issue/src/rate_limited_graphql.stub.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {graphql} from '@octokit/graphql';
+import {GraphQLResponse} from './types';
+
+/** Wrapper around the GraphQL client providing built-in query rate-limiting. */
+export class RateLimitedGraphQL {
+  constructor(token: string, private frequencyMs: number) {
+  }
+
+  async runQuery(query: string): Promise<GraphQLResponse> {
+    return null as GraphQLResponse;
+  }
+}

--- a/error-issue/src/rate_limited_graphql.stub.ts
+++ b/error-issue/src/rate_limited_graphql.stub.ts
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-import {graphql} from '@octokit/graphql';
 import {GraphQLResponse} from './types';
 
 /** Wrapper around the GraphQL client providing built-in query rate-limiting. */
 export class RateLimitedGraphQL {
-  constructor(token: string, private frequencyMs: number) {
-  }
+  constructor(token: string, private frequencyMs: number) {}
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async runQuery(query: string): Promise<GraphQLResponse> {
     return null as GraphQLResponse;
   }

--- a/error-issue/src/types.ts
+++ b/error-issue/src/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** A standard logging interface. */
+export interface ILogger {
+  debug(message: string, ...extraInfo: any[]): void;
+  warn(message: string, ...extraInfo: any[]): void;
+  error(message: string, ...extraInfo: any[]): void;
+  info(message: string, ...extraInfo: any[]): void;
+}
+
+/**
+ * Information about a range of lines from a Git blame.
+ * See https://developer.github.com/v4/object/blamerange/
+ */
+export interface BlameRange {
+  path: string;
+  startingLine: number;
+  endingLine: number;
+
+  author: string;
+  committedDate: Date;
+  prNumber: number;
+  changedFiles: number;
+}
+
+namespace GraphQL {
+  interface User {
+    login: string;
+  }
+
+  interface Commit {
+    changedFiles: number;
+    committedDate: string;
+    messageHeadline: string;
+    author: {user: User};
+  }
+
+  interface Blame {
+    ranges: Array<{
+      commit: Commit;
+      startingLine: number;
+      endingLine: number;
+    }>;
+  }
+
+  export interface QueryResponse {
+    repository: {
+      ref: null | {target: {blame: Blame}};
+    };
+  }
+}
+export type GraphQLResponse = GraphQL.QueryResponse;
+
+/** Information about a Pantheon error report. */
+export interface ErrorReport {
+  errorId: string;
+  firstSeen: Date;
+  dailyOccurrences: number;
+  stacktrace: string;
+}

--- a/error-issue/test/bot.test.ts
+++ b/error-issue/test/bot.test.ts
@@ -55,17 +55,23 @@ describe('ErrorIssueBot', () => {
       },
     ]);
 
-    jest.spyOn(IssueBuilder.prototype, 'title', 'get').mockReturnValue('issue title');
-    jest.spyOn(IssueBuilder.prototype, 'labels', 'get').mockReturnValue(['label']);
-    jest.spyOn(IssueBuilder.prototype, 'body', 'get').mockReturnValue('issue body');
+    jest
+      .spyOn(IssueBuilder.prototype, 'title', 'get')
+      .mockReturnValue('issue title');
+    jest
+      .spyOn(IssueBuilder.prototype, 'labels', 'get')
+      .mockReturnValue(['label']);
+    jest
+      .spyOn(IssueBuilder.prototype, 'body', 'get')
+      .mockReturnValue('issue body');
   });
 
   describe('buildErrorIssue', () => {
     it('determines blame for the stacktrace', async () => {
       await bot.buildErrorIssue(errorReport);
-      expect(
-        BlameFinder.prototype.blameForStacktrace
-      ).toHaveBeenCalledWith(stacktrace);
+      expect(BlameFinder.prototype.blameForStacktrace).toHaveBeenCalledWith(
+        stacktrace
+      );
     });
 
     it('builds the issue to be created', async () => {
@@ -92,7 +98,7 @@ describe('ErrorIssueBot', () => {
           });
           return true;
         })
-        .reply(201, { html_url: issueUrl });
+        .reply(201, {html_url: issueUrl});
 
       await expect(bot.report(errorReport)).resolves.toEqual(issueUrl);
     });
@@ -100,10 +106,10 @@ describe('ErrorIssueBot', () => {
     it('propagates the error when the API call fails', async () => {
       nock('https://api.github.com')
         .post('/repos/test_org/test_repo/issues')
-        .reply(401, { name: 'HttpError', status: 401 });
+        .reply(401, {name: 'HttpError', status: 401});
 
       await expect(bot.report(errorReport)).rejects.toMatchObject({
-        status: 401
+        status: 401,
       });
     });
   });

--- a/error-issue/test/bot.test.ts
+++ b/error-issue/test/bot.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {BlameFinder} from '../src/blame_finder.stub';
+import {IssueBuilder} from '../src/issue_builder.stub';
+import {ErrorIssueBot} from '../src/bot';
+
+describe('ErrorIssueBot', () => {
+  let bot: ErrorIssueBot;
+
+  const errorId = 'CL6chqbN2-bzBA';
+  const firstSeen = new Date('Feb 25, 2020');
+  const dailyOccurrences = 54647;
+  const stacktrace = `Error: null is not an object (evaluating 'b.acceleration.x')
+        at x (https://raw.githubusercontent.com/ampproject/amphtml/2004030010070/extensions/amp-delight-player/0.1/amp-delight-player.js:421:13)
+        at event (https://raw.githubusercontent.com/ampproject/amphtml/2004030010070/src/event-helper-listen.js:58:27)`;
+  const errorReport = {errorId, firstSeen, dailyOccurrences, stacktrace};
+
+  beforeEach(() => {
+    bot = new ErrorIssueBot('__TOKEN__', 'test_org', 'test_repo');
+
+    jest.spyOn(BlameFinder.prototype, 'blameForStacktrace').mockResolvedValue([
+      {
+        path: 'extensions/amp-delight-player/0.1/amp-delight-player.js',
+        startingLine: 396,
+        endingLine: 439,
+        author: 'xymw',
+        committedDate: new Date('2018-11-12T21:22:43.000Z'),
+        prNumber: 17939,
+        changedFiles: 15,
+      },
+      {
+        path: 'src/event-helper-listen.js',
+        startingLine: 57,
+        endingLine: 59,
+        author: 'rsimha',
+        committedDate: new Date('2017-12-13T23:56:40.000Z'),
+        prNumber: 12450,
+        changedFiles: 340,
+      },
+    ]);
+
+    jest.spyOn(IssueBuilder.prototype, 'title', 'get').mockReturnValue('issue title');
+    jest.spyOn(IssueBuilder.prototype, 'labels', 'get').mockReturnValue(['label']);
+    jest.spyOn(IssueBuilder.prototype, 'body', 'get').mockReturnValue('issue body');
+  });
+
+  describe('buildErrorIssue', () => {
+    it('determines blame for the stacktrace', async () => {
+      await bot.buildErrorIssue(errorReport);
+      expect(
+        BlameFinder.prototype.blameForStacktrace
+      ).toHaveBeenCalledWith(stacktrace);
+    });
+
+    it('builds the issue to be created', async () => {
+      await expect(bot.buildErrorIssue(errorReport)).resolves.toMatchObject({
+        owner: 'test_org',
+        repo: 'test_repo',
+        title: 'issue title',
+        labels: ['label'],
+        body: 'issue body',
+      });
+    });
+  });
+});

--- a/error-issue/test/bot.test.ts
+++ b/error-issue/test/bot.test.ts
@@ -31,8 +31,17 @@ describe('ErrorIssueBot', () => {
         at event (https://raw.githubusercontent.com/ampproject/amphtml/2004030010070/src/event-helper-listen.js:58:27)`;
   const errorReport = {errorId, firstSeen, dailyOccurrences, stacktrace};
 
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
+
+  afterAll(() => {
+    nock.enableNetConnect();
+  });
+
   beforeEach(() => {
     bot = new ErrorIssueBot('__TOKEN__', 'test_org', 'test_repo');
+    nock.cleanAll();
 
     jest.spyOn(BlameFinder.prototype, 'blameForStacktrace').mockResolvedValue([
       {
@@ -54,6 +63,14 @@ describe('ErrorIssueBot', () => {
         changedFiles: 340,
       },
     ]);
+
+  afterEach(() => {
+    // Fail the test if there were unused nocks.
+    if (!nock.isDone()) {
+      throw new Error('Not all nock interceptors were used!');
+    }
+    nock.cleanAll();
+  });
 
     jest
       .spyOn(IssueBuilder.prototype, 'title', 'get')

--- a/error-issue/test/bot.test.ts
+++ b/error-issue/test/bot.test.ts
@@ -64,13 +64,13 @@ describe('ErrorIssueBot', () => {
       },
     ]);
 
-  afterEach(() => {
-    // Fail the test if there were unused nocks.
-    if (!nock.isDone()) {
-      throw new Error('Not all nock interceptors were used!');
-    }
-    nock.cleanAll();
-  });
+    afterEach(() => {
+      // Fail the test if there were unused nocks.
+      if (!nock.isDone()) {
+        throw new Error('Not all nock interceptors were used!');
+      }
+      nock.cleanAll();
+    });
 
     jest
       .spyOn(IssueBuilder.prototype, 'title', 'get')


### PR DESCRIPTION
Part of https://github.com/ampproject/error-tracker/issues/112

Uses stubbed implementations of the BlameFinder (https://github.com/ampproject/amp-github-apps/pull/779) and IsssueBuilder (https://github.com/ampproject/amp-github-apps/pull/780) while they are under review.

Easiest to follow commit-by-commit
Top-down view:
```
 PASS  test/bot.test.ts
  ErrorIssueBot
    buildErrorIssue
      ✓ determines blame for the stacktrace (20ms)
      ✓ builds the issue to be created (14ms)
    report
      ✓ creates an error issue (36ms)
      ✓ propagates the error when the API call fails (10ms)

------------------------------|---------|----------|---------|---------|-------------------
File                          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------------------------|---------|----------|---------|---------|-------------------
All files                     |   83.33 |      100 |   54.55 |   83.33 |                   
 blame_finder.stub.ts         |      80 |      100 |      50 |      80 | 33                
 bot.ts                       |     100 |      100 |     100 |     100 |                   
 issue_builder.stub.ts        |      40 |      100 |      25 |      40 | 24-30             
 rate_limited_graphql.stub.ts |   66.67 |      100 |      50 |   66.67 | 26                
------------------------------|---------|----------|---------|---------|-------------------
```