### PR TITLE
[release-calendar] Event Handling

### DIFF
--- a/release-calendar/src/client/components/App.tsx
+++ b/release-calendar/src/client/components/App.tsx
@@ -16,33 +16,30 @@
 
 import '../stylesheets/app.scss';
 import * as React from 'react';
-import {ApiService} from '../api-service';
 import {Calendar} from './Calendar';
+import {Channel} from '../../types';
 import {ChannelTable} from './ChannelTable';
-import {EventSourceInput} from '@fullcalendar/core/structs/event-source';
 import {Header} from './Header';
-import {getEvents} from '../models/release-event';
 
 interface AppState {
-  events: EventSourceInput[];
+  channels: Channel[];
 }
 
 export class App extends React.Component<{}, AppState> {
-  private apiService: ApiService;
-
   constructor(props: unknown) {
     super(props);
     this.state = {
-      events: [],
+      channels: [],
     };
-    this.apiService = new ApiService();
   }
 
-  async componentDidMount(): Promise<void> {
-    const releases = await this.apiService.getReleases();
-    const events = getEvents(releases);
-    this.setState({events});
-  }
+  handleSelectedChannel = (channel: Channel, toChecked: boolean): void => {
+    this.setState({
+      channels: toChecked
+        ? this.state.channels.concat(channel)
+        : this.state.channels.filter((item) => channel !== item),
+    });
+  };
 
   render(): JSX.Element {
     return (
@@ -50,10 +47,13 @@ export class App extends React.Component<{}, AppState> {
         <Header title='AMP Release Calendar' />
         <div className='main-container'>
           <div className='col-channel-table'>
-            <ChannelTable />
+            <ChannelTable
+              channels={this.state.channels}
+              handleSelectedChannel={this.handleSelectedChannel}
+            />
           </div>
           <div className='col-calendar'>
-            <Calendar events={this.state.events} />
+            <Calendar channels={this.state.channels} />
           </div>
         </div>
       </React.Fragment>

--- a/release-calendar/src/client/components/Calendar.tsx
+++ b/release-calendar/src/client/components/Calendar.tsx
@@ -52,12 +52,9 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
   }
 
   render(): JSX.Element {
-    const displayedEvents: EventSourceInput[] = [];
-    this.props.channels.forEach((channel) => {
-      if (this.state.events.has(channel)) {
-        displayedEvents.push(this.state.events.get(channel));
-      }
-    });
+    const displayEvents: EventSourceInput[] = this.props.channels
+      .filter((channel) => this.state.events.has(channel))
+      .map((channel) => this.state.events.get(channel));
     return (
       <div className='calendar'>
         <FullCalendar
@@ -68,7 +65,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
             right: 'dayGridMonth,timeGridWeek,listWeek',
           }}
           plugins={[dayGridPlugin, timeGridPlugin]}
-          eventSources={displayedEvents}
+          eventSources={displayEvents}
           contentHeight={CALENDAR_CONTENT_HEIGHT} //will be 430 when header is added
           fixedWeekCount={false}
           displayEventTime={false}

--- a/release-calendar/src/client/components/Calendar.tsx
+++ b/release-calendar/src/client/components/Calendar.tsx
@@ -16,7 +16,10 @@
 
 import '../stylesheets/calendar.scss';
 import * as React from 'react';
+import {ApiService} from '../api-service';
+import {Channel} from '../../types';
 import {EventSourceInput} from '@fullcalendar/core/structs/event-source';
+import {getEvents} from '../models/release-event';
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import timeGridPlugin from '@fullcalendar/timegrid';
@@ -25,11 +28,36 @@ const CALENDAR_CONTENT_HEIGHT = 480;
 const EVENT_LIMIT_DISPLAYED = 3;
 
 export interface CalendarProps {
-  events: EventSourceInput[];
+  channels: Channel[];
 }
 
-export class Calendar extends React.Component<CalendarProps, {}> {
+export interface CalendarState {
+  events: Map<Channel, EventSourceInput>;
+}
+
+export class Calendar extends React.Component<CalendarProps, CalendarState> {
+  private apiService: ApiService;
+
+  constructor(props: Readonly<CalendarProps>) {
+    super(props);
+    this.state = {
+      events: new Map<Channel, EventSourceInput>(),
+    };
+    this.apiService = new ApiService();
+  }
+
+  async componentDidMount(): Promise<void> {
+    const releases = await this.apiService.getReleases();
+    this.setState({events: getEvents(releases)});
+  }
+
   render(): JSX.Element {
+    const displayedEvents: EventSourceInput[] = [];
+    this.props.channels.forEach((channel) => {
+      if (this.state.events.has(channel)) {
+        displayedEvents.push(this.state.events.get(channel));
+      }
+    });
     return (
       <div className='calendar'>
         <FullCalendar
@@ -40,7 +68,7 @@ export class Calendar extends React.Component<CalendarProps, {}> {
             right: 'dayGridMonth,timeGridWeek,listWeek',
           }}
           plugins={[dayGridPlugin, timeGridPlugin]}
-          eventSources={this.props.events}
+          eventSources={displayedEvents}
           contentHeight={CALENDAR_CONTENT_HEIGHT} //will be 430 when header is added
           fixedWeekCount={false}
           displayEventTime={false}

--- a/release-calendar/src/client/components/ChannelTable.tsx
+++ b/release-calendar/src/client/components/ChannelTable.tsx
@@ -18,11 +18,16 @@ import '../stylesheets/channelTable.scss';
 import * as React from 'react';
 import {Channel} from '../../types';
 
-export class ChannelTable extends React.Component<{}, {}> {
-  //TODO(ajwhatson):
-  // add event handling with onClick functions
-  // send state from app carrying array of selected channels
-  // add app call for most recent releases in each channel
+interface ChannelTableProps {
+  channels: Channel[];
+  handleSelectedChannel: (channel: Channel, checked: boolean) => void;
+}
+
+export class ChannelTable extends React.Component<ChannelTableProps, {}> {
+  constructor(props: Readonly<ChannelTableProps>) {
+    super(props);
+    this.handleChannelClick = this.handleChannelClick.bind(this);
+  }
 
   rows = [
     {channel: Channel.STABLE, title: 'Stable'},
@@ -33,6 +38,13 @@ export class ChannelTable extends React.Component<{}, {}> {
     {channel: Channel.NIGHTLY, title: 'Nightly'},
     {channel: Channel.LTS, title: 'Long Term Stable'},
   ];
+
+  handleChannelClick = (
+    channel: Channel,
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): void => {
+    this.props.handleSelectedChannel(channel, event.target.checked);
+  };
 
   render(): JSX.Element {
     return (
@@ -48,7 +60,10 @@ export class ChannelTable extends React.Component<{}, {}> {
                     <input
                       type='checkbox'
                       className='click-square'
-                      id={row.channel}></input>
+                      id={row.channel}
+                      onChange={(e): void =>
+                        this.handleChannelClick(row.channel, e)
+                      }></input>
                     <i></i>
                   </div>
                   <div className='row-text'>{row.title}</div>

--- a/release-calendar/src/client/models/release-event.ts
+++ b/release-calendar/src/client/models/release-event.ts
@@ -23,6 +23,7 @@ function convertReleaseToEvent(release: Release): EventInput {
   return {
     title: release.name,
     start: release.date,
+    //TODO: I plan to use className as how I will move colors to central location
     className: release.channel,
     extendedProps: {isRollback: release.isRollback},
   };
@@ -40,23 +41,24 @@ export function getEvents(releases: Release[]): Map<Channel, EventSourceInput> {
   colors.set(Channel.OPT_IN_EXPERIMENTAL, 'silver');
   colors.set(Channel.NIGHTLY, 'red');
 
-  const mapReleasesToEventInputs = new Map<Channel, EventInput[]>();
+  const eventInputs = new Map<Channel, EventInput[]>();
   releases.forEach((release) => {
     const event = convertReleaseToEvent(release);
-    const channelEvents = mapReleasesToEventInputs.get(release.channel);
+    const channelEvents = eventInputs.get(release.channel);
     if (!channelEvents) {
-      mapReleasesToEventInputs.set(release.channel, [event]);
+      eventInputs.set(release.channel, [event]);
     } else {
-      mapReleasesToEventInputs.set(release.channel, [...channelEvents, event]);
+      eventInputs.set(release.channel, [...channelEvents, event]);
     }
   });
-  const mapEventInputToEventSources = new Map<Channel, EventSourceInput>();
-  mapReleasesToEventInputs.forEach((event, channel) => {
-    mapEventInputToEventSources.set(channel, {
-      events: event,
+  const eventSources = new Map<Channel, EventSourceInput>();
+  eventInputs.forEach((eventInput, channel) => {
+    eventSources.set(channel, {
+      events: eventInput,
+      //TODO: will remove when colors declarations are moved to a central location
       color: colors.get(channel),
       textColor: 'white',
     });
   });
-  return mapEventInputToEventSources;
+  return eventSources;
 }


### PR DESCRIPTION
This PR focuses on handling when rows in the `ChannelTable` are checked and sending those selected channels up to the root `App` and back down to the `Calendar`. 

Included:
-  `channels`, an array of selected `Channel`s, which is a state structure in `App` and a prop in `ChannelTable` and `Calendar`.
- the function `handleSelectedChannel` in `App` to handle adding a new channel to the `channels` array or removing a channel that is getting deselected.
- the transfer of `ApiService` to `Calendar` from `App` so that `events`, the `Map<Channel, EventSourceInput>`, can be isolated to only the component that needs it, `Calendar`. 
- the restructuring of `getEvents` to return a `Map<Channel, EventSourceInput>`instead of the more rigid array of `EventSourceInput[]`
