### PR TITLE
[release-calendar] Add tooltip to Calendar Events

### DIFF
--- a/release-calendar/package-lock.json
+++ b/release-calendar/package-lock.json
@@ -930,6 +930,11 @@
         }
       }
     },
+    "@popperjs/core": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.3.3.tgz",
+      "integrity": "sha512-yEvVC8RfhRPkD9TUn7cFcLcgoJePgZRAOR7T21rcRY5I8tpuhzeWfGa7We7tB14fe9R7wENdqUABcMdwD4SQLw=="
+    },
     "@sinonjs/commons": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
@@ -937,6 +942,15 @@
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
+      }
+    },
+    "@tippyjs/react": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@tippyjs/react/-/react-4.0.2.tgz",
+      "integrity": "sha512-iAKTjUmrXqTTJ4HZRDgmvVfUiv9pTzJoDjPLDbmvB6vttkuYvZ/o8NhHa72vMFgHpiMFNoYWtB8OCRR6x5Zs8w==",
+      "requires": {
+        "prop-types": "^15.6.2",
+        "tippy.js": "^6.2.0"
       }
     },
     "@types/anymatch": {
@@ -11685,6 +11699,14 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tippy.js": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.2.0.tgz",
+      "integrity": "sha512-xb7xq4vSkrhZHvbRx7l8otFL7z2id+U0VPDX+MHXa8B/4PtJ/nvap6/peLHjMk45VmRIvEhF0KFoqviJ6EEtug==",
+      "requires": {
+        "@popperjs/core": "^2.3.2"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -12431,7 +12453,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "string-width": {

--- a/release-calendar/package.json
+++ b/release-calendar/package.json
@@ -31,6 +31,7 @@
     "@fullcalendar/interaction": "4.4.0",
     "@fullcalendar/react": "4.4.0",
     "@fullcalendar/timegrid": "4.4.0",
+    "@tippyjs/react": "^4.0.2",
     "express": "4.17.1",
     "mysql": "2.18.1",
     "node-fetch": "2.6.0",

--- a/release-calendar/src/client/components/Calendar.tsx
+++ b/release-calendar/src/client/components/Calendar.tsx
@@ -15,12 +15,16 @@
  */
 
 import '../stylesheets/calendar.scss';
+import 'tippy.js/dist/tippy.css';
 import * as React from 'react';
 import {ApiService} from '../api-service';
 import {Channel} from '../../types';
+import {EventApi, View} from '@fullcalendar/core';
 import {EventSourceInput} from '@fullcalendar/core/structs/event-source';
 import {getEvents} from '../models/release-event';
 import FullCalendar from '@fullcalendar/react';
+import ReactDOM from 'react-dom';
+import Tippy from '@tippyjs/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import timeGridPlugin from '@fullcalendar/timegrid';
 
@@ -51,6 +55,29 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     this.setState({events: getEvents(releases)});
   }
 
+  tooltip = (arg: {
+    isMirror: boolean;
+    isStart: boolean;
+    isEnd: boolean;
+    event: EventApi;
+    el: HTMLElement;
+    view: View;
+  }): void => {
+    const Content = (): JSX.Element => (
+      <Tippy
+        interactive={true}
+        trigger={'click'}
+        placement={'left'}
+        arrow={false}
+        offset={[0, 5]}
+        //TODO: decide on the content of each tooltip and create component for it
+        content={<div>{arg.event.classNames}</div>}>
+        <button className={'event-button'}>{arg.event.title}</button>
+      </Tippy>
+    );
+    ReactDOM.render(<Content />, arg.el);
+  };
+
   render(): JSX.Element {
     const displayEvents: EventSourceInput[] = this.props.channels
       .filter((channel) => this.state.events.has(channel))
@@ -70,6 +97,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
           fixedWeekCount={false}
           displayEventTime={false}
           views={{month: {eventLimit: EVENT_LIMIT_DISPLAYED}}}
+          eventRender={this.tooltip}
         />
       </div>
     );

--- a/release-calendar/src/client/stylesheets/calendar.scss
+++ b/release-calendar/src/client/stylesheets/calendar.scss
@@ -10,3 +10,16 @@
   rgba(0, 0, 0, 0.14) 0px 1px 2px,
   rgba(0, 0, 0, 0.12) 0px 1px 4px;
 }
+
+.event-button {
+  outline: none;
+  background-color: inherit;
+  border-color: inherit;
+  color: inherit;
+  padding-left: 3px;
+  padding-top: 3px;
+  text-align: left;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
This will add a tooltip (see https://github.com/atomiks/tippyjs-react and https://atomiks.github.io/tippyjs/) to each event displayed on the `Calender`.

<img width="328" alt="Screen Shot 2020-04-22 at 12 12 39 PM" src="https://user-images.githubusercontent.com/35901106/80023613-a8c81d00-8492-11ea-9b71-83b2d848f919.png">

Included:
- Installation of `tippyjs-react`
- Access to event elements through `eventRender`
- Adjustment to ReactDOM by to create a event button and a tooltip
- Styling for `event-button` with the purpose of allowing for an inherited appearance and a click area over the full button surface