### PR TITLE
[release-calendar] Add api call getReleases for all releases

### DIFF
--- a/release-calendar/src/client/api-service.ts
+++ b/release-calendar/src/client/api-service.ts
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-import {ApiServiceInterface, Channel, Promotion} from '../types';
-import {CurrentReleases, EventInput} from './models/view-models';
+import {Channel, Promotion} from '../types';
+import {CurrentReleases, MyEventInput} from './models/view-models';
 import fetch from 'node-fetch';
 const SERVER_URL = `http://localhost:3000`;
 
-export class ApiService implements ApiServiceInterface {
+export class ApiService {
   private getPromotionRequest(url: string): Promise<Promotion[]> {
     return fetch(url).then((result) => result.json());
   }
 
-  async getReleases(): Promise<EventInput[]> {
+  async getReleases(): Promise<MyEventInput[]> {
     const allPromotions = await this.getPromotionRequest(SERVER_URL);
     const map = new Map<Channel, Date>();
     return allPromotions.map((promotion: Promotion) => {
       const date = map.get(promotion.channel) || new Date();
       map.set(promotion.channel, promotion.date);
-      return new EventInput(promotion, date);
+      return new MyEventInput(promotion, date);
     });
   }
 

--- a/release-calendar/src/client/api-service.ts
+++ b/release-calendar/src/client/api-service.ts
@@ -15,7 +15,7 @@
  */
 
 import {Channel, Promotion} from '../types';
-import {CurrentReleases, MyEventInput} from './models/view-models';
+import {CurrentReleases, ReleaseEventInput} from './models/view-models';
 import fetch from 'node-fetch';
 const SERVER_URL = `http://localhost:3000`;
 
@@ -24,13 +24,13 @@ export class ApiService {
     return fetch(url).then((result) => result.json());
   }
 
-  async getReleases(): Promise<MyEventInput[]> {
+  async getReleases(): Promise<ReleaseEventInput[]> {
     const allPromotions = await this.getPromotionRequest(SERVER_URL);
     const map = new Map<Channel, Date>();
     return allPromotions.map((promotion: Promotion) => {
       const date = map.get(promotion.channel) || new Date();
       map.set(promotion.channel, promotion.date);
-      return new MyEventInput(promotion, date);
+      return new ReleaseEventInput(promotion, date);
     });
   }
 

--- a/release-calendar/src/client/api-service.ts
+++ b/release-calendar/src/client/api-service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {ApiServiceInterface, Promotion} from '../types';
+import {ApiServiceInterface, Channel, Promotion} from '../types';
 import {CurrentReleases, EventInput} from './models/view-models';
 import fetch from 'node-fetch';
 const SERVER_URL = `http://localhost:3000`;
@@ -26,24 +26,12 @@ export class ApiService implements ApiServiceInterface {
 
   async getReleases(): Promise<EventInput[]> {
     const allPromotions = await this.getPromotionRequest(SERVER_URL);
-    const map = new Map();
-    allPromotions.forEach((promotion) => {
-      const channelPromotions = map.get(promotion.channel) || [];
-      map.set(promotion.channel, [...channelPromotions, promotion]);
+    const map = new Map<Channel, Date>();
+    return allPromotions.map((promotion: Promotion) => {
+      const date = map.get(promotion.channel) || new Date();
+      map.set(promotion.channel, promotion.date);
+      return new EventInput(promotion, date);
     });
-    const collect: EventInput[] = [];
-    map.forEach((promotionsInChannel: Promotion[]) => {
-      collect.push(new EventInput(promotionsInChannel[0], new Date()));
-      collect.push(
-        ...promotionsInChannel
-          .slice(1)
-          .map(
-            (promotion, i) =>
-              new EventInput(promotion, promotionsInChannel[i].date),
-          ),
-      );
-    });
-    return collect;
   }
 
   async getCurrentReleases(): Promise<CurrentReleases> {

--- a/release-calendar/src/client/api-service.ts
+++ b/release-calendar/src/client/api-service.ts
@@ -14,28 +14,20 @@
  * limitations under the License.
  */
 
-import {
-  ApiServiceInterface,
-  Promotion as PromotionEntity,
-  Release as ReleaseEntity,
-} from '../types';
-import {CurrentReleases, Release} from './models/view-models';
+import {ApiServiceInterface, Promotion as PromotionEntity} from '../types';
+import {CurrentReleases, EventInput} from './models/view-models';
 import fetch from 'node-fetch';
 const SERVER_URL = `http://localhost:3000`;
 
 export class ApiService implements ApiServiceInterface {
-  private getReleaseRequest(url: string): Promise<ReleaseEntity[]> {
-    return fetch(url).then((result) => result.json());
-  }
-
   private getPromotionRequest(url: string): Promise<PromotionEntity[]> {
     return fetch(url).then((result) => result.json());
   }
 
-  async getReleases(): Promise<Release[]> {
-    const releases = await this.getReleaseRequest(SERVER_URL);
-    return releases.map((release: ReleaseEntity) => {
-      return new Release(release);
+  async getReleases(): Promise<EventInput[]> {
+    const promotions = await this.getPromotionRequest(SERVER_URL);
+    return promotions.map((promotion: PromotionEntity) => {
+      return new EventInput(promotion);
     });
   }
 

--- a/release-calendar/src/client/api-service.ts
+++ b/release-calendar/src/client/api-service.ts
@@ -32,13 +32,15 @@ export class ApiService implements ApiServiceInterface {
     const collect: EventInput[] = [];
     //each row is all the promotions that have occured in a single channel
     gridOfPromotions.forEach((rowOfPromotions: Promotion[]) => {
-      const endDate: Date = new Date();
-      collect.push(new EventInput(rowOfPromotions[0], endDate));
-      for (let i = 1; i < rowOfPromotions.length; i++) {
-        collect.push(
-          new EventInput(rowOfPromotions[i], rowOfPromotions[i - 1].date),
-        );
-      }
+      collect.push(new EventInput(rowOfPromotions[0], new Date()));
+      collect.push(
+        ...rowOfPromotions
+          .slice(1)
+          .map(
+            (promotion, i) =>
+              new EventInput(promotion, rowOfPromotions[i].date),
+          ),
+      );
     });
     return collect;
   }

--- a/release-calendar/src/client/api-service.ts
+++ b/release-calendar/src/client/api-service.ts
@@ -23,22 +23,23 @@ export class ApiService implements ApiServiceInterface {
   private getPromotionRequest(url: string): Promise<Promotion[]> {
     return fetch(url).then((result) => result.json());
   }
-  private getPromotionRequests(url: string): Promise<Promotion[][]> {
-    return fetch(url).then((result) => result.json());
-  }
 
   async getReleases(): Promise<EventInput[]> {
-    const gridOfPromotions = await this.getPromotionRequests(SERVER_URL);
+    const allPromotions = await this.getPromotionRequest(SERVER_URL);
+    const map = new Map();
+    allPromotions.forEach((promotion) => {
+      const channelPromotions = map.get(promotion.channel) || [];
+      map.set(promotion.channel, [...channelPromotions, promotion]);
+    });
     const collect: EventInput[] = [];
-    //each row is all the promotions that have occured in a single channel
-    gridOfPromotions.forEach((rowOfPromotions: Promotion[]) => {
-      collect.push(new EventInput(rowOfPromotions[0], new Date()));
+    map.forEach((promotionsInChannel: Promotion[]) => {
+      collect.push(new EventInput(promotionsInChannel[0], new Date()));
       collect.push(
-        ...rowOfPromotions
+        ...promotionsInChannel
           .slice(1)
           .map(
             (promotion, i) =>
-              new EventInput(promotion, rowOfPromotions[i].date),
+              new EventInput(promotion, promotionsInChannel[i].date),
           ),
       );
     });

--- a/release-calendar/src/client/api-service.ts
+++ b/release-calendar/src/client/api-service.ts
@@ -28,17 +28,15 @@ export class ApiService implements ApiServiceInterface {
   }
 
   async getReleases(): Promise<EventInput[]> {
-    const promotions = await this.getPromotionRequests(SERVER_URL);
+    const gridOfPromotions = await this.getPromotionRequests(SERVER_URL);
     const collect: EventInput[] = [];
-    promotions.forEach((promotionsInChannel: Promotion[]) => {
+    //each row is all the promotions that have occured in a single channel
+    gridOfPromotions.forEach((rowOfPromotions: Promotion[]) => {
       const endDate: Date = new Date();
-      collect.push(new EventInput(promotionsInChannel[0], endDate));
-      for (let i = 1; i < promotionsInChannel.length; i++) {
+      collect.push(new EventInput(rowOfPromotions[0], endDate));
+      for (let i = 1; i < rowOfPromotions.length; i++) {
         collect.push(
-          new EventInput(
-            promotionsInChannel[i],
-            promotionsInChannel[i - 1].date,
-          ),
+          new EventInput(rowOfPromotions[i], rowOfPromotions[i - 1].date),
         );
       }
     });

--- a/release-calendar/src/client/components/Calendar.tsx
+++ b/release-calendar/src/client/components/Calendar.tsx
@@ -19,7 +19,7 @@ import * as React from 'react';
 import {ApiService} from '../api-service';
 import {Channel} from '../../types';
 import {EventSourceInput} from '@fullcalendar/core/structs/event-source';
-import {getEvents} from '../models/release-event';
+import {getAllReleasesEvents} from '../models/release-event';
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import timeGridPlugin from '@fullcalendar/timegrid';
@@ -48,7 +48,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
 
   async componentDidMount(): Promise<void> {
     const releases = await this.apiService.getReleases();
-    this.setState({events: getEvents(releases)});
+    this.setState({events: getAllReleasesEvents(releases)});
   }
 
   render(): JSX.Element {

--- a/release-calendar/src/client/models/release-event.ts
+++ b/release-calendar/src/client/models/release-event.ts
@@ -17,28 +17,20 @@
 import {Channel} from '../../types';
 import {EventInput} from '@fullcalendar/core/structs/event';
 import {EventSourceInput} from '@fullcalendar/core/structs/event-source';
-import {Release} from './view-models';
 
-function convertReleaseToEvent(release: Release): EventInput {
-  return {
-    title: release.name,
-    start: release.date,
-    className: release.channel,
-    extendedProps: {isRollback: release.isRollback},
-  };
-}
-
-export function getEvents(releases: Release[]): Map<Channel, EventSourceInput> {
+export function getAllReleasesEvents(
+  events: EventInput[],
+): Map<Channel, EventSourceInput> {
   const eventInputs = new Map<Channel, EventInput[]>();
-  releases.forEach((release) => {
-    const event = convertReleaseToEvent(release);
-    const channelEvents = eventInputs.get(release.channel);
+  events.forEach((event) => {
+    const channelEvents = eventInputs.get(event.channel);
     if (!channelEvents) {
-      eventInputs.set(release.channel, [event]);
+      eventInputs.set(event.channel, [event]);
     } else {
-      eventInputs.set(release.channel, [...channelEvents, event]);
+      eventInputs.set(event.channel, [...channelEvents, event]);
     }
   });
+
   const eventSources = new Map<Channel, EventSourceInput>();
   eventInputs.forEach((eventInput, channel) => {
     eventSources.set(channel, {

--- a/release-calendar/src/client/models/release-event.ts
+++ b/release-calendar/src/client/models/release-event.ts
@@ -23,12 +23,8 @@ export function getAllReleasesEvents(
 ): Map<Channel, EventSourceInput> {
   const eventInputs = new Map<Channel, EventInput[]>();
   events.forEach((event) => {
-    const channelEvents = eventInputs.get(event.channel);
-    if (!channelEvents) {
-      eventInputs.set(event.channel, [event]);
-    } else {
-      eventInputs.set(event.channel, [...channelEvents, event]);
-    }
+    const channelEvents = eventInputs.get(event.channel) || [];
+    eventInputs.set(event.channel, [...channelEvents, event]);
   });
 
   const eventSources = new Map<Channel, EventSourceInput>();

--- a/release-calendar/src/client/models/release-event.ts
+++ b/release-calendar/src/client/models/release-event.ts
@@ -15,13 +15,13 @@
  */
 
 import {Channel} from '../../types';
-import {EventInput} from '@fullcalendar/core/structs/event';
 import {EventSourceInput} from '@fullcalendar/core/structs/event-source';
+import {MyEventInput} from './view-models';
 
 export function getAllReleasesEvents(
-  events: EventInput[],
+  events: MyEventInput[],
 ): Map<Channel, EventSourceInput> {
-  const eventInputs = new Map<Channel, EventInput[]>();
+  const eventInputs = new Map<Channel, MyEventInput[]>();
   events.forEach((event) => {
     const channelEvents = eventInputs.get(event.channel) || [];
     eventInputs.set(event.channel, [...channelEvents, event]);

--- a/release-calendar/src/client/models/release-event.ts
+++ b/release-calendar/src/client/models/release-event.ts
@@ -16,12 +16,12 @@
 
 import {Channel} from '../../types';
 import {EventSourceInput} from '@fullcalendar/core/structs/event-source';
-import {MyEventInput} from './view-models';
+import {ReleaseEventInput} from './view-models';
 
 export function getAllReleasesEvents(
-  events: MyEventInput[],
+  events: ReleaseEventInput[],
 ): Map<Channel, EventSourceInput> {
-  const eventInputs = new Map<Channel, MyEventInput[]>();
+  const eventInputs = new Map<Channel, ReleaseEventInput[]>();
   events.forEach((event) => {
     const channelEvents = eventInputs.get(event.channel) || [];
     eventInputs.set(event.channel, [...channelEvents, event]);

--- a/release-calendar/src/client/models/view-models.ts
+++ b/release-calendar/src/client/models/view-models.ts
@@ -17,7 +17,7 @@
 import {Channel, Promotion} from '../../types';
 import {EventInput} from '@fullcalendar/core';
 
-export class MyEventInput implements EventInput {
+export class ReleaseEventInput implements EventInput {
   constructor(promotion: Promotion, endDate: Date) {
     this.title = promotion.releaseName;
     this.start = promotion.date;

--- a/release-calendar/src/client/models/view-models.ts
+++ b/release-calendar/src/client/models/view-models.ts
@@ -14,21 +14,31 @@
  * limitations under the License.
  */
 
-import {Channel, Promotion, Release as ReleaseEntity} from '../../types';
+import {Channel, Promotion} from '../../types';
 
-export class Release {
-  constructor(entity: ReleaseEntity) {
-    const currentPromotion = entity.promotions[0];
-    this.name = entity.name;
-    this.channel = currentPromotion.channel;
-    this.date = currentPromotion.date;
-    this.isRollback = this.channel == Channel.ROLLBACK;
+export class EventInput {
+  constructor(promotion: Promotion) {
+    this.title = promotion.releaseName;
+    this.start = promotion.date;
+    this.className = promotion.channel;
+    this.extendedProps = {
+      isRollback: promotion.channel == Channel.ROLLBACK,
+      channel: promotion.channel,
+    };
   }
 
-  name: string;
-  channel: Channel;
-  date: Date;
-  isRollback: boolean;
+  get rollback(): boolean {
+    return this.extendedProps.isRollback;
+  }
+
+  get channel(): Channel {
+    return this.extendedProps.channel;
+  }
+
+  title: string;
+  start: Date;
+  className: Channel;
+  extendedProps: {isRollback: boolean; channel: Channel};
 }
 
 export class CurrentReleases {

--- a/release-calendar/src/client/models/view-models.ts
+++ b/release-calendar/src/client/models/view-models.ts
@@ -15,8 +15,9 @@
  */
 
 import {Channel, Promotion} from '../../types';
+import {EventInput} from '@fullcalendar/core';
 
-export class EventInput {
+export class MyEventInput implements EventInput {
   constructor(promotion: Promotion, endDate: Date) {
     this.title = promotion.releaseName;
     this.start = promotion.date;

--- a/release-calendar/src/client/models/view-models.ts
+++ b/release-calendar/src/client/models/view-models.ts
@@ -17,18 +17,14 @@
 import {Channel, Promotion} from '../../types';
 
 export class EventInput {
-  constructor(promotion: Promotion) {
+  constructor(promotion: Promotion, endDate: Date) {
     this.title = promotion.releaseName;
     this.start = promotion.date;
+    this.end = endDate;
     this.className = promotion.channel;
     this.extendedProps = {
-      isRollback: promotion.channel == Channel.ROLLBACK,
       channel: promotion.channel,
     };
-  }
-
-  get rollback(): boolean {
-    return this.extendedProps.isRollback;
   }
 
   get channel(): Channel {
@@ -37,8 +33,9 @@ export class EventInput {
 
   title: string;
   start: Date;
+  end: Date;
   className: Channel;
-  extendedProps: {isRollback: boolean; channel: Channel};
+  extendedProps: {channel: Channel};
 }
 
 export class CurrentReleases {

--- a/release-calendar/src/client/stylesheets/_base.scss
+++ b/release-calendar/src/client/stylesheets/_base.scss
@@ -10,7 +10,6 @@ $nightly: Tomato;
 body {
     font-family: Arial, Helvetica Neue, Helvetica, sans-serif;
     font-size: 14px;
-    line-height: 3em;
     color: #24292e;
     margin: 0px;
     -webkit-appearance: none;

--- a/release-calendar/src/client/stylesheets/channelTable.scss
+++ b/release-calendar/src/client/stylesheets/channelTable.scss
@@ -18,6 +18,7 @@
 }
 
 .row-text {
+    line-height: 3em;
     margin-left: 4em;
     text-align: left;
     text-overflow: clip;

--- a/release-calendar/src/server/repository-service.ts
+++ b/release-calendar/src/server/repository-service.ts
@@ -44,21 +44,12 @@ export class RepositoryService {
     return releaseQuery;
   }
 
-  getReleases(): Promise<Release[]> {
-    const releaseQuery = this.releaseRepository
-      .createQueryBuilder('release')
-      .leftJoinAndSelect('release.promotions', 'promotion')
+  getReleases(): Promise<Promotion[]> {
+    const promotionQuery = this.promotionRepository
+      .createQueryBuilder('promotion')
       .getMany();
 
-    releaseQuery.then((releases) => {
-      releases.forEach((release) =>
-        release.promotions.sort(
-          (a, b): number => b.date.getTime() - a.date.getTime(),
-        ),
-      );
-    });
-
-    return releaseQuery;
+    return promotionQuery;
   }
 
   async getCurrentReleases(): Promise<Promotion[]> {

--- a/release-calendar/src/server/repository-service.ts
+++ b/release-calendar/src/server/repository-service.ts
@@ -54,16 +54,12 @@ export class RepositoryService {
     return releaseQuery;
   }
 
-  getReleases(): Promise<Promotion[][]> {
-    const channelQueries = this.channels.map((eachChannel) =>
-      this.promotionRepository
-        .createQueryBuilder('promotion')
-        .where('promotion.channel = :channel', {channel: eachChannel})
-        .select('promotion')
-        .orderBy('promotion.date', 'DESC')
-        .getMany(),
-    );
-    return Promise.all(channelQueries);
+  async getReleases(): Promise<Promotion[]> {
+    const channelQueries = this.promotionRepository
+      .createQueryBuilder('promotion')
+      .orderBy('promotion.date', 'DESC')
+      .getMany();
+    return channelQueries;
   }
 
   async getCurrentReleases(): Promise<Promotion[]> {

--- a/release-calendar/src/server/repository-service.ts
+++ b/release-calendar/src/server/repository-service.ts
@@ -60,7 +60,6 @@ export class RepositoryService {
         .createQueryBuilder('promotion')
         .where('promotion.channel = :channel', {channel: eachChannel})
         .select('promotion')
-        .addSelect('promotion.releaseName')
         .orderBy('promotion.date', 'DESC')
         .getMany(),
     );

--- a/release-calendar/src/types.ts
+++ b/release-calendar/src/types.ts
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  CurrentReleases,
-  Release as ReleaseViewModel,
-} from './client/models/view-models';
+import {CurrentReleases} from './client/models/view-models';
+import {EventInput} from '@fullcalendar/core';
 
 export enum Channel {
   LTS = 'lts',
@@ -55,6 +53,6 @@ export class Promotion {
 }
 
 export interface ApiServiceInterface {
-  getReleases: () => Promise<ReleaseViewModel[]>;
+  getReleases: () => Promise<EventInput[]>;
   getCurrentReleases: () => Promise<CurrentReleases>;
 }

--- a/release-calendar/src/types.ts
+++ b/release-calendar/src/types.ts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {CurrentReleases} from './client/models/view-models';
-import {EventInput} from '@fullcalendar/core';
 
 export enum Channel {
   LTS = 'lts',
@@ -50,9 +48,4 @@ export class Promotion {
   channel: Channel;
   releaseName: string;
   date: Date;
-}
-
-export interface ApiServiceInterface {
-  getReleases: () => Promise<EventInput[]>;
-  getCurrentReleases: () => Promise<CurrentReleases>;
 }


### PR DESCRIPTION
Why we need a .getReleases() : getReleases will be used by the client side to query for the all the releases to be displayed on in the `Calendar`.

Included: 
- Removal of the `Release` type on the Client side. Before the data to be displayed on the `Calender` was being transformed from what the server side version of the `Release`type into the client side version of the `Release` type and then to `EventInput`. Now data will go straight from client side `Release` to `EventInput.`
- Addition of an end date to EventInput so that calendar events have a duration
- Addition of a server side `getReleases()` query that groups promotions by channel and then orders by date so to allow for the end date to be calculated later on the server side.
- Change of of a client side `getAllReleasesEvents()` (formally just `getEvents` to preemptively remove confusion for a future `getSingleReleaseEvents()`) so that `getAllReleasesEvents()` is ready to receive an array of `EventInputs`

Note: `Channel.ROLLBACK` will be removed in a future pr.