### PR TITLE
[owners] Fix team @ mentions

### DIFF
--- a/owners/index.js
+++ b/owners/index.js
@@ -39,6 +39,7 @@ module.exports = app => {
       let handlerGithub;
       try {
         handlerGithub = GitHub.fromContext(context);
+        handlerGithub.user = github;
       } catch (e) {
         // Some webhooks do not provide a GitHub instance in their context.
         handlerGithub = github;

--- a/owners/src/api/github.js
+++ b/owners/src/api/github.js
@@ -143,6 +143,9 @@ class GitHub {
    */
   constructor(client, owner, repository, logger = console) {
     Object.assign(this, {client, owner, repository, logger});
+    // Optionally allow for providing a separate user-authenticated client for
+    // team @mention workarounds.
+    this.user = this;
   }
 
   /**

--- a/owners/src/api/github.js
+++ b/owners/src/api/github.js
@@ -368,16 +368,19 @@ class GitHub {
    *
    * @param {number} number PR number.
    * @param {string} body comment body.
+   * @return {Object} API response
    */
   async createBotComment(number, body) {
     this.logger.info(`Adding bot comment to PR #${number}`);
     this.logger.debug('[createBotComment]', number, body);
 
-    await this._customRequest(
+    const {data} = await this._customRequest(
       'POST',
       `/repos/${this.owner}/${this.repository}/issues/${number}/comments`,
       {body}
     );
+
+    return data
   }
 
   /**
@@ -388,16 +391,19 @@ class GitHub {
    *
    * @param {number} commentId ID of comment to update.
    * @param {string} body comment body.
+   * @return {Object} API response
    */
   async updateComment(commentId, body) {
     this.logger.info(`Replacing comment with ID ${commentId}`);
     this.logger.debug('[updateComment]', commentId, body);
 
-    await this._customRequest(
+    const {data} = await this._customRequest(
       'PATCH',
       `/repos/${this.owner}/${this.repository}/issues/comments/${commentId}`,
       {body}
     );
+
+    return data;
   }
 
   /**

--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -81,7 +81,7 @@ class OwnersNotifier {
    * @param {!GitHub} github GitHub API interface.
    */
   async createNotificationComment(github) {
-    const [botComment] = await github.getBotComments(this.pr.number);
+    let [botComment] = await github.getBotComments(this.pr.number);
     const notifies = this.getOwnersToNotify();
     delete notifies[this.pr.author];
 
@@ -100,11 +100,24 @@ class OwnersNotifier {
       return;
     }
 
-    const comment = fileNotifyComments.join('\n\n');
+    const body = fileNotifyComments.join('\n\n');
+    let comment;
     if (botComment) {
-      await github.updateComment(botComment.id, comment);
+      comment = await github.updateComment(botComment.id, body);
     } else {
-      await github.createBotComment(this.pr.number, comment);
+      botComment = await github.createBotComment(this.pr.number, body);
+    }
+
+    // App-authenticated comments appear to come from the app user (ie.
+    // `amp-owners-bot`) but can't tag teams. The workaround is doing a fake
+    // update to the comment with a user-authenticated client, which enables the
+    // @ mention but leaves the comment author as the app name.
+    const teamNotifies = Object.keys(notifies).filter(n => n.includes('/'));
+    if (teamNotifies.length) {
+      await github.user.updateComment(
+        botComment.id,
+        `${body}\n<!-- Edited to fix team @mention -->`
+      );
     }
   }
 

--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -116,7 +116,7 @@ class OwnersNotifier {
     if (teamNotifies.length) {
       await github.user.updateComment(
         botComment.id,
-        `${body}\n<!-- Edited to fix team @mention -->`
+        `${body}\n<!-- Edited to fix team @ mention -->`
       );
     }
   }

--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -101,9 +101,8 @@ class OwnersNotifier {
     }
 
     const body = fileNotifyComments.join('\n\n');
-    let comment;
     if (botComment) {
-      comment = await github.updateComment(botComment.id, body);
+      await github.updateComment(botComment.id, body);
     } else {
       botComment = await github.createBotComment(this.pr.number, body);
     }

--- a/owners/test/api/github.test.js
+++ b/owners/test/api/github.test.js
@@ -480,6 +480,16 @@ describe('GitHub API', () => {
         .reply(200);
       await github.createBotComment(24574, 'test comment');
     });
+
+    it('returns the created comment', async () => {
+      expect.assertions(1);
+      nock('https://api.github.com')
+        .post('/repos/test_owner/test_repo/issues/24574/comments')
+        .reply(200, { id: 1337 });
+
+      const {id} = await github.createBotComment(24574, 'test comment');
+      expect(id).toEqual(1337);
+    });
   });
 
   describe('updateComment', () => {
@@ -492,6 +502,16 @@ describe('GitHub API', () => {
         })
         .reply(200);
       await github.updateComment(24574, 'updated comment');
+    });
+
+    it('returns the updated comment', async () => {
+      expect.assertions(1);
+      nock('https://api.github.com')
+        .patch('/repos/test_owner/test_repo/issues/comments/24574')
+        .reply(200, { id: 1337 });
+
+      const {id} = await github.updateComment(24574, 'updated comment');
+      expect(id).toEqual(1337)
     });
   });
 

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -193,10 +193,11 @@ describe('notifier', () => {
   describe('createNotificationComment', () => {
     let getCommentsStub;
     let notifier;
+    const botComment = {id: 42}
 
     beforeEach(() => {
-      sandbox.stub(GitHub.prototype, 'createBotComment');
-      sandbox.stub(GitHub.prototype, 'updateComment').returns();
+      sandbox.stub(GitHub.prototype, 'createBotComment').returns(botComment);
+      sandbox.stub(GitHub.prototype, 'updateComment').returns(botComment);
       getCommentsStub = sandbox.stub(GitHub.prototype, 'getBotComments');
       getCommentsStub.returns([]);
 
@@ -237,13 +238,21 @@ describe('notifier', () => {
           expect.assertions(2);
           await notifier.createNotificationComment(github);
 
-          sandbox.assert.calledOnce(github.updateComment);
           const [commentId, comment] = github.updateComment.getCall(0).args;
           expect(commentId).toEqual(42);
           expect(comment).toContain(
             'Hey @a_subscriber, these files were changed:\n```\nfoo/main.js\n```',
             'Hey @ampproject/some_team, these files were changed:\n```\nfoo/main.js\n```'
           );
+        });
+
+        it('updates team mentions with the user client', async () => {
+          expect.assertions(2);
+          await notifier.createNotificationComment(github);
+
+          const [commentId, comment] = github.updateComment.getCall(1).args;
+          expect(commentId).toEqual(42);
+          expect(comment).toContain('<!-- Edited to fix team @mention -->');
         });
       });
 
@@ -259,6 +268,28 @@ describe('notifier', () => {
             'Hey @a_subscriber, these files were changed:\n```\nfoo/main.js\n```',
             'Hey @ampproject/some_team, these files were changed:\n```\nfoo/main.js\n```'
           );
+        });
+
+        it('updates team mentions with the user client', async () => {
+          expect.assertions(2);
+          await notifier.createNotificationComment(github);
+
+          sandbox.assert.calledOnce(github.createBotComment);
+          sandbox.assert.calledOnce(github.updateComment);
+          const [commentId, comment] = github.updateComment.getCall(0).args;
+          expect(commentId).toEqual(42);
+          expect(comment).toContain('<!-- Edited to fix team @mention -->');
+        });
+
+        it('does not update if no team is mentioned', async done => {
+          OwnersNotifier.prototype.getOwnersToNotify.restore();
+          sandbox.stub(OwnersNotifier.prototype, 'getOwnersToNotify').returns({
+            'a_subscriber': ['foo/main.js'],
+          });
+          await notifier.createNotificationComment(github);
+
+          sandbox.assert.notCalled(github.updateComment);
+          done();
         });
       });
     });

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -252,7 +252,7 @@ describe('notifier', () => {
 
           const [commentId, comment] = github.updateComment.getCall(1).args;
           expect(commentId).toEqual(42);
-          expect(comment).toContain('<!-- Edited to fix team @mention -->');
+          expect(comment).toContain('<!-- Edited to fix team @ mention -->');
         });
       });
 
@@ -278,7 +278,7 @@ describe('notifier', () => {
           sandbox.assert.calledOnce(github.updateComment);
           const [commentId, comment] = github.updateComment.getCall(0).args;
           expect(commentId).toEqual(42);
-          expect(comment).toContain('<!-- Edited to fix team @mention -->');
+          expect(comment).toContain('<!-- Edited to fix team @ mention -->');
         });
 
         it('does not update if no team is mentioned', async done => {


### PR DESCRIPTION
App-authenticated comments appear to come from the app user (ie. `amp-owners-bot`) but can't tag teams. The workaround is doing a fake update to the comment with a user-authenticated client, which enables the @ mention but leaves the comment author as the app name.

![image](https://user-images.githubusercontent.com/6694512/80234100-916d6900-8625-11ea-9d48-78b2394d92db.png)
