### PR TITLE
[error-issue] Add auto-linking of created issue to GCP error

### DIFF
--- a/error-issue/index.ts
+++ b/error-issue/index.ts
@@ -36,6 +36,7 @@ const bot = new ErrorIssueBot(
 
 const stackdriver = new StackdriverApi(PROJECT_ID);
 const monitor = new ErrorMonitor(stackdriver);
+const lister = new ErrorMonitor(stackdriver, 2500, 40);
 
 /** Endpoint to create a GitHub issue for an error report. */
 export async function errorIssue(req: express.Request, res: express.Response) {
@@ -90,7 +91,7 @@ function createErrorReportUrl(report: ErrorReport) {
 /** Diagnostic endpoint to list new untracked errors. */
 export async function errorList(req: express.Request, res: express.Response) {
   try {
-    const reports = await monitor.newErrorsToReport();
+    const reports = await lister.newErrorsToReport();
     res.json({
       errorReports: reports.map(report => ({
         createUrl: createErrorReportUrl(report),

--- a/error-issue/package.json
+++ b/error-issue/package.json
@@ -16,7 +16,9 @@
     "build:watch": "tsc -w --p tsconfig.json",
     "start": "functions-framework --target=app --source=dist",
     "dev": "nodemon",
-    "deploy-tag": "git tag 'deploy-error-issue-'`date --utc '+%Y%m%d%H%M%S'`",
+    "deploy-tag-issue": "git tag 'deploy-error-issue-'`date --utc '+%Y%m%d%H%M%S'`",
+    "deploy-tag-monitor": "git tag 'deploy-error-monitor-'`date --utc '+%Y%m%d%H%M%S'`",
+    "deploy-tag-list": "git tag 'deploy-error-list-'`date --utc '+%Y%m%d%H%M%S'`",
     "test": "jest",
     "test:watch": "jest --watch --notify --notifyMode=change"
   },

--- a/error-issue/src/stackdriver_api.ts
+++ b/error-issue/src/stackdriver_api.ts
@@ -69,22 +69,37 @@ export class StackdriverApi {
   }
 
   /**
-   * List groups of errors.
+   * Fetch one or more error groups from the Stackdriver API.
    * See https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.groupStats/list
    */
-  async listGroups(
-    pageSize: number = 20
-  ): Promise<Array<Stackdriver.ErrorGroupStats>> {
-    console.info(`Fetching first ${pageSize} error groups`);
+  private async getGroups(opts: {
+    pageSize?: number,
+    groupId?: string
+  }): Promise<Array<Stackdriver.ErrorGroupStats>> {
     const {errorGroupStats} = await this.request('groupStats', 'GET', {
       'timeRange.period': 'PERIOD_1_DAY',
-      pageSize,
       timedCountDuration: `${SECONDS_IN_DAY}s`,
+      ...opts,
     });
 
     return errorGroupStats.map((stats: Stackdriver.SerializedErrorGroupStats) =>
       this.deserialize(stats)
     );
+  }
+
+  /** List groups of errors. */
+  async listGroups(
+    pageSize: number = 20
+  ): Promise<Array<Stackdriver.ErrorGroupStats>> {
+    console.info(`Fetching first ${pageSize} error groups`);
+    return this.getGroups({pageSize});
+  }
+
+  /** Get details about an error group. */
+  async getGroup(groupId: string): Promise<Stackdriver.ErrorGroupStats> {
+    console.info(`Fetching group stats for error gorup "${groupId}"`);
+    const errorGroupStats = await this.getGroups({groupId});
+    return errorGroupStats[0];
   }
 
   /**


### PR DESCRIPTION
With this PR, error issues created by the bot can/will be automatically linked to the originating error in error tracking. It also updates the `error-issue` endpoint to accept just an error ID, in which case it will fetch the remaining details from Stackdriver.

If you add the following code as a bookmarklet:

```
javascript:(function()%7Bconst %7BerrorId%7D %3D location.pathname.match(%2F%5C%2Ferrors%5C%2F(%3F<errorId>%5B%5E%5C%2F%3F%5D%2B)%2F).groups%3Bwindow.open(%60https%3A%2F%2Fus-central1-amp-error-issue-bot.cloudfunctions.net%2Ferror-issue%3FerrorId%3D%24%7BerrorId%7D%26linkIssue%3D1%60%2C'_blank')%7D)()
````
clicking it while viewing any error in AMP Error Reporting will create, link, and redirect to the new GitHub issue.