### PR TITLE
[release-calendar] Add getRelease()

### DIFF
--- a/release-calendar/src/client/api-service.ts
+++ b/release-calendar/src/client/api-service.ts
@@ -30,7 +30,7 @@ export class ApiService {
 
   async getRelease(requestedRelease: string): Promise<ReleaseEventInput[]> {
     const release = await this.getReleaseRequest(
-      SERVER_URL + '/releases/' + requestedRelease,
+      `${SERVER_URL}/releases/${requestedRelease}`,
     );
     return [
       new ReleaseEventInput(release.promotions[0], new Date()),
@@ -55,7 +55,7 @@ export class ApiService {
 
   async getCurrentReleases(): Promise<CurrentReleases> {
     const currentReleases = await this.getPromotionRequest(
-      SERVER_URL + '/current-releases/',
+      `${SERVER_URL}/current-releases/`,
     );
     return new CurrentReleases(currentReleases);
   }

--- a/release-calendar/src/client/api-service.ts
+++ b/release-calendar/src/client/api-service.ts
@@ -28,9 +28,9 @@ export class ApiService {
     return fetch(url).then((result) => result.json());
   }
 
-  async getRelease(releaseString: string): Promise<ReleaseEventInput[]> {
+  async getRelease(requestedRelease: string): Promise<ReleaseEventInput[]> {
     const release = await this.getReleaseRequest(
-      SERVER_URL + '/release/' + releaseString,
+      SERVER_URL + '/release/' + requestedRelease,
     );
     return [
       new ReleaseEventInput(release.promotions[0], new Date()),

--- a/release-calendar/src/client/api-service.ts
+++ b/release-calendar/src/client/api-service.ts
@@ -20,14 +20,16 @@ import fetch from 'node-fetch';
 const SERVER_URL = `http://localhost:3000`;
 
 export class ApiService implements ApiService {
-  private getRequest(url: string): Promise<ReleaseEntity[]> {
+  private getRequest(url: string): Promise<ReleaseEntity> {
     return fetch(url).then((result) => result.json());
   }
 
-  async getReleases(): Promise<Release[]> {
-    const releases = await this.getRequest(SERVER_URL);
-    return releases.map((release: ReleaseEntity) => {
-      return new Release(release);
+  async getRelease(releaseName: string): Promise<Release[]> {
+    const release = await this.getRequest(
+      SERVER_URL + '/release/' + releaseName,
+    );
+    return release.promotions.map((promotion) => {
+      return new Release(release, promotion);
     });
   }
 }

--- a/release-calendar/src/client/api-service.ts
+++ b/release-calendar/src/client/api-service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Release} from './models/view-models';
+import {EventInput} from './models/view-models';
 import {Release as ReleaseEntity} from '../types';
 import fetch from 'node-fetch';
 const SERVER_URL = `http://localhost:3000`;
@@ -24,12 +24,23 @@ export class ApiService implements ApiService {
     return fetch(url).then((result) => result.json());
   }
 
-  async getRelease(releaseName: string): Promise<Release[]> {
+  private getRequests(url: string): Promise<ReleaseEntity[]> {
+    return fetch(url).then((result) => result.json());
+  }
+
+  async getReleases(): Promise<EventInput[]> {
+    const releases = await this.getRequests(SERVER_URL);
+    return releases.map((release) => {
+      return new EventInput(release, release.promotions[0]);
+    });
+  }
+
+  async getRelease(releaseName: string): Promise<EventInput[]> {
     const release = await this.getRequest(
       SERVER_URL + '/release/' + releaseName,
     );
     return release.promotions.map((promotion) => {
-      return new Release(release, promotion);
+      return new EventInput(release, promotion);
     });
   }
 }

--- a/release-calendar/src/client/api-service.ts
+++ b/release-calendar/src/client/api-service.ts
@@ -30,7 +30,7 @@ export class ApiService {
 
   async getRelease(requestedRelease: string): Promise<ReleaseEventInput[]> {
     const release = await this.getReleaseRequest(
-      SERVER_URL + '/release/' + requestedRelease,
+      SERVER_URL + '/releases/' + requestedRelease,
     );
     return [
       new ReleaseEventInput(release.promotions[0], new Date()),

--- a/release-calendar/src/client/components/App.tsx
+++ b/release-calendar/src/client/components/App.tsx
@@ -23,6 +23,7 @@ import {Header} from './Header';
 
 interface AppState {
   channels: Channel[];
+  release: string;
 }
 
 export class App extends React.Component<{}, AppState> {
@@ -30,6 +31,7 @@ export class App extends React.Component<{}, AppState> {
     super(props);
     this.state = {
       channels: [],
+      release: null,
     };
   }
 
@@ -38,6 +40,12 @@ export class App extends React.Component<{}, AppState> {
       channels: toChecked
         ? this.state.channels.concat(channel)
         : this.state.channels.filter((item) => channel !== item),
+    });
+  };
+
+  handleSelectedRelease = (selectedRelease: string): void => {
+    this.setState({
+      release: this.state.release != selectedRelease ? selectedRelease : null,
     });
   };
 
@@ -50,10 +58,14 @@ export class App extends React.Component<{}, AppState> {
             <ChannelTable
               channels={this.state.channels}
               handleSelectedChannel={this.handleSelectedChannel}
+              handleSelectedRelease={this.handleSelectedRelease}
             />
           </div>
           <div className='col-calendar'>
-            <Calendar channels={this.state.channels} />
+            <Calendar
+              channels={this.state.channels}
+              singleRelease={this.state.release}
+            />
           </div>
         </div>
       </React.Fragment>

--- a/release-calendar/src/client/components/Calendar.tsx
+++ b/release-calendar/src/client/components/Calendar.tsx
@@ -47,7 +47,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
   }
 
   async componentDidMount(): Promise<void> {
-    const releases = await this.apiService.getReleases();
+    const releases = await this.apiService.getRelease('1234567890123');
     this.setState({events: getEvents(releases)});
   }
 

--- a/release-calendar/src/client/components/Calendar.tsx
+++ b/release-calendar/src/client/components/Calendar.tsx
@@ -19,7 +19,10 @@ import * as React from 'react';
 import {ApiService} from '../api-service';
 import {Channel} from '../../types';
 import {EventSourceInput} from '@fullcalendar/core/structs/event-source';
-import {getEvents} from '../models/release-event';
+import {
+  getAllReleasesEvents,
+  getSingleReleaseEvents,
+} from '../models/release-event';
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import timeGridPlugin from '@fullcalendar/timegrid';
@@ -29,10 +32,12 @@ const EVENT_LIMIT_DISPLAYED = 3;
 
 export interface CalendarProps {
   channels: Channel[];
+  singleRelease: string;
 }
 
 export interface CalendarState {
-  events: Map<Channel, EventSourceInput>;
+  allEvents: Map<Channel, EventSourceInput>;
+  singleEvents: EventSourceInput[];
 }
 
 export class Calendar extends React.Component<CalendarProps, CalendarState> {
@@ -41,20 +46,40 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
   constructor(props: Readonly<CalendarProps>) {
     super(props);
     this.state = {
-      events: new Map<Channel, EventSourceInput>(),
+      allEvents: new Map<Channel, EventSourceInput>(),
+      singleEvents: [],
     };
     this.apiService = new ApiService();
   }
 
   async componentDidMount(): Promise<void> {
-    const releases = await this.apiService.getRelease('1234567890123');
-    this.setState({events: getEvents(releases)});
+    const releases = await this.apiService.getReleases();
+    this.setState({allEvents: getAllReleasesEvents(releases)});
+  }
+
+  async componentDidUpdate(prevProps: CalendarProps): Promise<void> {
+    if (prevProps.singleRelease != this.props.singleRelease) {
+      if (prevProps.singleRelease == null) {
+        const release = await this.apiService.getRelease(
+          this.props.singleRelease,
+        );
+        this.setState({singleEvents: getSingleReleaseEvents(release)});
+      } else {
+        this.setState({singleEvents: []});
+      }
+    }
   }
 
   render(): JSX.Element {
-    const displayEvents: EventSourceInput[] = this.props.channels
-      .filter((channel) => this.state.events.has(channel))
-      .map((channel) => this.state.events.get(channel));
+    //TODO: fix indent rule in my prettier config, currently enlint and prettier are at odds
+    /* eslint-disable @typescript-eslint/indent */
+    const displayEvents: EventSourceInput[] =
+      this.props.singleRelease != null
+        ? this.state.singleEvents
+        : this.props.channels
+            .filter((channel) => this.state.allEvents.has(channel))
+            .map((channel) => this.state.allEvents.get(channel));
+
     return (
       <div className='calendar'>
         <FullCalendar

--- a/release-calendar/src/client/components/ChannelTable.tsx
+++ b/release-calendar/src/client/components/ChannelTable.tsx
@@ -21,6 +21,7 @@ import {Channel} from '../../types';
 interface ChannelTableProps {
   channels: Channel[];
   handleSelectedChannel: (channel: Channel, checked: boolean) => void;
+  handleSelectedRelease: (release: string) => void;
 }
 
 export class ChannelTable extends React.Component<ChannelTableProps, {}> {
@@ -46,13 +47,17 @@ export class ChannelTable extends React.Component<ChannelTableProps, {}> {
     this.props.handleSelectedChannel(channel, event.target.checked);
   };
 
+  handleReleaseClick = (release: string): void => {
+    this.props.handleSelectedRelease(release);
+  };
+
   render(): JSX.Element {
     return (
       <React.Fragment>
         <h1 className='title-bar'>Current Releases</h1>
         <div className='row-container'>
           {this.rows.map((row) => {
-            const rtv = '0000000000000';
+            const rtv = '1234567890123';
             return (
               <React.Fragment key={row.channel}>
                 <label className='row-button' htmlFor={row.channel}>
@@ -68,7 +73,11 @@ export class ChannelTable extends React.Component<ChannelTableProps, {}> {
                   </div>
                   <div className='row-text'>{row.title}</div>
                 </label>
-                <button className='release-button'>{rtv}</button>
+                <button
+                  className='release-button'
+                  onClick={(): void => this.handleReleaseClick(rtv)}>
+                  {rtv}
+                </button>
               </React.Fragment>
             );
           })}

--- a/release-calendar/src/client/models/release-event.ts
+++ b/release-calendar/src/client/models/release-event.ts
@@ -17,28 +17,20 @@
 import {Channel} from '../../types';
 import {EventInput} from '@fullcalendar/core/structs/event';
 import {EventSourceInput} from '@fullcalendar/core/structs/event-source';
-import {Release} from './view-models';
 
-function convertReleaseToEvent(release: Release): EventInput {
-  return {
-    title: release.name,
-    start: release.date,
-    className: release.channel,
-    extendedProps: {isRollback: release.isRollback},
-  };
-}
-
-export function getEvents(releases: Release[]): Map<Channel, EventSourceInput> {
+export function getAllReleasesEvents(
+  events: EventInput[],
+): Map<Channel, EventSourceInput> {
   const eventInputs = new Map<Channel, EventInput[]>();
-  releases.forEach((release) => {
-    const event = convertReleaseToEvent(release);
-    const channelEvents = eventInputs.get(release.channel);
+  events.forEach((event) => {
+    const channelEvents = eventInputs.get(event.getChannel);
     if (!channelEvents) {
-      eventInputs.set(release.channel, [event]);
+      eventInputs.set(event.channel, [event]);
     } else {
-      eventInputs.set(release.channel, [...channelEvents, event]);
+      eventInputs.set(event.channel, [...channelEvents, event]);
     }
   });
+
   const eventSources = new Map<Channel, EventSourceInput>();
   eventInputs.forEach((eventInput, channel) => {
     eventSources.set(channel, {
@@ -47,4 +39,14 @@ export function getEvents(releases: Release[]): Map<Channel, EventSourceInput> {
     });
   });
   return eventSources;
+}
+
+export function getSingleReleaseEvents(
+  eventInputs: EventInput[],
+): EventSourceInput[] {
+  return eventInputs.map(
+    (event: EventInput): EventSourceInput => {
+      return {events: [event], textColor: 'white'};
+    },
+  );
 }

--- a/release-calendar/src/client/models/view-models.ts
+++ b/release-calendar/src/client/models/view-models.ts
@@ -20,7 +20,7 @@ import {EventInput} from '@fullcalendar/core';
 export class ReleaseEventInput implements EventInput {
   constructor(promotion: Promotion, endDate: Date) {
     const dayPriorToEnd = new Date(endDate);
-    dayPriorToEnd.setDate(dayPriorToEnd.getDate() - 1);
+    dayPriorToEnd.setDate(endDate.getDate() - 1);
     this.title = promotion.releaseName;
     this.start = promotion.date;
     this.end = dayPriorToEnd;

--- a/release-calendar/src/client/models/view-models.ts
+++ b/release-calendar/src/client/models/view-models.ts
@@ -19,12 +19,15 @@ import {EventInput} from '@fullcalendar/core';
 
 export class ReleaseEventInput implements EventInput {
   constructor(promotion: Promotion, endDate: Date) {
+    const endTime = new Date(endDate);
+    endTime.setDate(endTime.getDate() - 1);
     this.title = promotion.releaseName;
     this.start = promotion.date;
-    this.end = endDate;
+    this.end = endTime;
     this.className = promotion.channel;
     this.extendedProps = {
       channel: promotion.channel,
+      preciseEnd: endDate,
     };
   }
 
@@ -32,11 +35,15 @@ export class ReleaseEventInput implements EventInput {
     return this.extendedProps.channel;
   }
 
+  get perciseEnd(): Date {
+    return this.extendedProps.preciseEnd;
+  }
+
   title: string;
   start: Date;
   end: Date;
   className: Channel;
-  extendedProps: {channel: Channel};
+  extendedProps: {channel: Channel; preciseEnd: Date};
 }
 
 export class CurrentReleases {

--- a/release-calendar/src/client/models/view-models.ts
+++ b/release-calendar/src/client/models/view-models.ts
@@ -20,7 +20,7 @@ import {EventInput} from '@fullcalendar/core';
 export class ReleaseEventInput implements EventInput {
   constructor(promotion: Promotion, endDate: Date) {
     const dayPriorToEnd = new Date(endDate);
-    dayPriorToEnd.setDate(endDate.getDate() - 1);
+    dayPriorToEnd.setDate(dayPriorToEnd.getDate() - 1);
     this.title = promotion.releaseName;
     this.start = promotion.date;
     this.end = dayPriorToEnd;

--- a/release-calendar/src/client/models/view-models.ts
+++ b/release-calendar/src/client/models/view-models.ts
@@ -16,16 +16,27 @@
 
 import {Channel, Promotion, Release as ReleaseEntity} from '../../types';
 
-export class Release {
-  constructor(entity: ReleaseEntity, promotion: Promotion) {
-    this.name = entity.name;
-    this.channel = promotion.channel;
-    this.date = promotion.date;
-    this.isRollback = this.channel == Channel.ROLLBACK;
+export class EventInput {
+  constructor(release: ReleaseEntity, promotion: Promotion) {
+    this.title = release.name;
+    this.start = promotion.date;
+    this.className = promotion.channel;
+    this.extendedProps = {
+      isRollback: promotion.channel == Channel.ROLLBACK,
+      channel: promotion.channel,
+    };
   }
 
-  name: string;
-  channel: Channel;
-  date: Date;
-  isRollback: boolean;
+  get rollback(): boolean {
+    return this.extendedProps.isRollback;
+  }
+
+  get channel(): Channel {
+    return this.extendedProps.channel;
+  }
+
+  title: string;
+  start: Date;
+  className: Channel;
+  extendedProps: {isRollback: boolean; channel: Channel};
 }

--- a/release-calendar/src/client/models/view-models.ts
+++ b/release-calendar/src/client/models/view-models.ts
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-import {Channel, Release as ReleaseEntity} from '../../types';
+import {Channel, Promotion, Release as ReleaseEntity} from '../../types';
 
 export class Release {
-  constructor(entity: ReleaseEntity) {
-    const currentPromotion = entity.promotions[0];
+  constructor(entity: ReleaseEntity, promotion: Promotion) {
     this.name = entity.name;
-    this.channel = currentPromotion.channel;
-    this.date = currentPromotion.date;
+    this.channel = promotion.channel;
+    this.date = promotion.date;
     this.isRollback = this.channel == Channel.ROLLBACK;
   }
 

--- a/release-calendar/src/client/models/view-models.ts
+++ b/release-calendar/src/client/models/view-models.ts
@@ -19,11 +19,11 @@ import {EventInput} from '@fullcalendar/core';
 
 export class ReleaseEventInput implements EventInput {
   constructor(promotion: Promotion, endDate: Date) {
-    const endTime = new Date(endDate);
-    endTime.setDate(endTime.getDate() - 1);
+    const dayPriorToEnd = new Date(endDate);
+    dayPriorToEnd.setDate(endDate.getDate() - 1);
     this.title = promotion.releaseName;
     this.start = promotion.date;
-    this.end = endTime;
+    this.end = dayPriorToEnd;
     this.className = promotion.channel;
     this.extendedProps = {
       channel: promotion.channel,

--- a/release-calendar/src/server/app.ts
+++ b/release-calendar/src/server/app.ts
@@ -58,5 +58,10 @@ async function main(): Promise<void> {
     const releases = await repositoryService.getReleases();
     res.json(releases);
   });
+
+  app.get('/release/:release', async (req, res) => {
+    const releases = await repositoryService.getRelease(req.params.release);
+    res.json(releases);
+  });
 }
 main();

--- a/release-calendar/src/server/app.ts
+++ b/release-calendar/src/server/app.ts
@@ -59,9 +59,9 @@ async function main(): Promise<void> {
     res.json(releases);
   });
 
-  app.get('/release/:release', async (req, res) => {
-    const releases = await repositoryService.getRelease(req.params.release);
-    res.json(releases);
+  app.get('/releases/:release', async (req, res) => {
+    const release = await repositoryService.getRelease(req.params.release);
+    res.json(release);
   });
 
   app.get('/current-releases/', async (req, res) => {

--- a/release-calendar/src/server/repository-service.ts
+++ b/release-calendar/src/server/repository-service.ts
@@ -32,12 +32,6 @@ export class RepositoryService {
       .where('release.name = :name', {name})
       .getOne();
 
-    releaseQuery.then((release) => {
-      release.promotions.sort(
-        (a, b): number => b.date.getTime() - a.date.getTime(),
-      );
-    });
-
     return releaseQuery;
   }
 

--- a/release-calendar/src/server/repository-service.ts
+++ b/release-calendar/src/server/repository-service.ts
@@ -59,7 +59,7 @@ export class RepositoryService {
 
   async getCurrentReleases(): Promise<Promotion[]> {
     return Promise.all(
-      this.channels.map((channel) => {
+      Object.keys(Channel).map((channel) => {
         return this.promotionRepository
           .createQueryBuilder('promotion')
           .where('promotion.channel = :channel', {channel})

--- a/release-calendar/src/server/repository-service.ts
+++ b/release-calendar/src/server/repository-service.ts
@@ -59,7 +59,7 @@ export class RepositoryService {
 
   async getCurrentReleases(): Promise<Promotion[]> {
     return Promise.all(
-      Object.keys(Channel).map((channel) => {
+      this.channels.map((channel) => {
         return this.promotionRepository
           .createQueryBuilder('promotion')
           .where('promotion.channel = :channel', {channel})


### PR DESCRIPTION
Why we need a ` getRelease(requestedRelease: string)`: getRelease will be used by the client side to query for all the promotions a single release has underwent so that they can be displayed on the `Calender.`

This is what one example release looks like as it flows from Nightly to LTS.
<img width="537" alt="Screen Shot 2020-04-28 at 12 08 03 PM" src="https://user-images.githubusercontent.com/35901106/80527305-048a1e80-8949-11ea-9e47-ff3821ad58b2.png">


Included:

- Addition of a server side getRelease() query that joins the promotions and release tables and selects the requested release and all of its promotions (promotions in descending order)
- Addition of the `Release` string that will live in the `App` state but also in the props of `Calendar`
- Event handling associated with clicking on a `rtv-button`
- Addition of `getSingleReleaseEvents()` which converts the `ReleaseEventInputs` into `EventSourceInput[]` to be read by the calendar.

TODO: Toggle between a `rtv-button` and `channel-row`