### PR TITLE
[release-calendar] 🐛 Remove getCurrentReleases bug 🐛

### DIFF
--- a/release-calendar/src/server/repository-service.ts
+++ b/release-calendar/src/server/repository-service.ts
@@ -28,16 +28,6 @@ export class RepositoryService {
     this.promotionRepository = connection.getRepository(PromotionEntity);
   }
 
-  channels = [
-    Channel.LTS,
-    Channel.NIGHTLY,
-    Channel.OPT_IN_BETA,
-    Channel.OPT_IN_EXPERIMENTAL,
-    Channel.PERCENT_BETA,
-    Channel.PERCENT_EXPERIMENTAL,
-    Channel.STABLE,
-  ];
-
   getRelease(name: string): Promise<Release> {
     const releaseQuery = this.releaseRepository
       .createQueryBuilder('release')
@@ -64,7 +54,15 @@ export class RepositoryService {
 
   async getCurrentReleases(): Promise<Promotion[]> {
     return Promise.all(
-      Object.keys(Channel).map((channel) => {
+      [
+        Channel.LTS,
+        Channel.NIGHTLY,
+        Channel.OPT_IN_BETA,
+        Channel.OPT_IN_EXPERIMENTAL,
+        Channel.PERCENT_BETA,
+        Channel.PERCENT_EXPERIMENTAL,
+        Channel.STABLE,
+      ].map((channel) => {
         return this.promotionRepository
           .createQueryBuilder('promotion')
           .where('promotion.channel = :channel', {channel})


### PR DESCRIPTION
The bug: 
```
Object.keys(Channel).map((channel) => 
return this.promotionRepository
          .createQueryBuilder('promotion')
          .where('promotion.channel = :channel', {channel})
```
**channel** isn't being recognized correctly. Queries are only being recognized if the channel does not include a hyphen :(