### PR TITLE
[onduty] Add handlers to receive rotation updates

### DIFF
--- a/onduty/cloud_build.yaml
+++ b/onduty/cloud_build.yaml
@@ -55,4 +55,4 @@ steps:
 secrets:
   - kmsKeyName: projects/amp-error-issue-bot/locations/global/keyRings/amp-github-apps-keyring/cryptoKeys/app-env-key
     secretEnv:
-      GITHUB_ACCESS_TOKEN: CiQABN6IaPZSyyye8RQMSAQS9cuNfhhzPNu8WL1TMYz1dmiotIESUQBEODKdI3TUF4Jr5JfLIOkyDr6KGTuTQAUjwd0HCs/HAWqYFMWuiXINpN4/vIaMMSdUbxxPtNv09QSyGp206wuF8qgaJ3G9mSBd0V9pd7OVDQ==
+      GITHUB_ACCESS_TOKEN: CiQA/MPS5ZuGhFpj7GILuU9q9XcWuTxgLNqVJssCybRAKUJdtBMSUQB8LNNh3TCOBOOjZPO7mZU3WK5xbTbxOJP21z+21p3+pmpEYL2AgfRfNA3ozyYZzYWM/AJqanuYluyVikKhBtQUUO1y5RuTOzRHKwsWwlz6fw==

--- a/onduty/index.ts
+++ b/onduty/index.ts
@@ -44,10 +44,16 @@ module.exports.refreshRotation = (
 ) => {
   const {access_token: token, ...rotations}: RotationReporterPayload = req.body;
 
-  if (token === GITHUB_ACCESS_TOKEN) {
-    bot.handleUpdate(rotations);
-    res.sendStatus(statusCodes.OK);
-  } else {
-    res.sendStatus(statusCodes.UNAUTHORIZED);
+  try {
+    if (token === GITHUB_ACCESS_TOKEN) {
+      bot.handleUpdate(rotations);
+      res.sendStatus(statusCodes.OK);
+    } else {
+      res.sendStatus(statusCodes.UNAUTHORIZED);
+    }
+  } catch (e) {
+    console.error(e);
+    res.status(statusCodes.INTERNAL_SERVER_ERROR);
+    res.send(String(e));
   }
 };

--- a/onduty/index.ts
+++ b/onduty/index.ts
@@ -38,15 +38,15 @@ const octokit = new Octokit({auth: `token ${GITHUB_ACCESS_TOKEN}`});
 const github = new GitHub(octokit, GITHUB_ORG);
 const bot = new OndutyBot(github, ROTATION_TEAMS);
 
-module.exports.refreshRotation = (
+export async function refreshRotation(
   req: express.Request,
   res: express.Response
-) => {
+) {
   const {access_token: token, ...rotations}: RotationReporterPayload = req.body;
 
   try {
     if (token === GITHUB_ACCESS_TOKEN) {
-      bot.handleUpdate(rotations);
+      await bot.handleUpdate(rotations);
       res.sendStatus(statusCodes.OK);
     } else {
       res.sendStatus(statusCodes.UNAUTHORIZED);
@@ -56,4 +56,4 @@ module.exports.refreshRotation = (
     res.status(statusCodes.INTERNAL_SERVER_ERROR);
     res.send(String(e));
   }
-};
+}

--- a/onduty/index.ts
+++ b/onduty/index.ts
@@ -14,12 +14,40 @@
  * limitations under the License.
  */
 
+import {GitHub} from './src/github';
+import {Octokit} from '@octokit/rest';
+import {OndutyBot} from './src/bot';
+import {RotationReporterPayload, RotationTeamMap} from 'onduty';
 import express from 'express';
+import statusCodes from 'http-status-codes';
+
+require('dotenv').config();
+const {
+  GITHUB_ACCESS_TOKEN,
+  GITHUB_ORG,
+  RELEASE_ONDUTY_TEAM,
+  BUILD_COP_TEAM,
+} = process.env;
+
+const ROTATION_TEAMS: RotationTeamMap = {
+  'release-on-duty': RELEASE_ONDUTY_TEAM,
+  'build-cop': BUILD_COP_TEAM,
+};
+
+const octokit = new Octokit({auth: `token ${GITHUB_ACCESS_TOKEN}`});
+const github = new GitHub(octokit, GITHUB_ORG);
+const bot = new OndutyBot(github, ROTATION_TEAMS);
 
 module.exports.refreshRotation = (
   req: express.Request,
   res: express.Response
 ) => {
-  // TODO(#778): Update GitHub teams based on rotations.
-  res.send('Triggered `reportRotation`');
+  const {access_token: token, ...rotations}: RotationReporterPayload = req.body;
+
+  if (token === GITHUB_ACCESS_TOKEN) {
+    bot.handleUpdate(rotations);
+    res.sendStatus(statusCodes.OK);
+  } else {
+    res.sendStatus(statusCodes.UNAUTHORIZED);
+  }
 };

--- a/onduty/package-lock.json
+++ b/onduty/package-lock.json
@@ -3306,6 +3306,11 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http-status-codes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.4.0.tgz",
+      "integrity": "sha512-JrT3ua+WgH8zBD3HEJYbeEgnuQaAnUeRRko/YojPAJjGmIfGD3KPU/asLdsLwKjfxOmQe5nXMQ0pt/7MyapVbQ=="
+    },
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",

--- a/onduty/package.json
+++ b/onduty/package.json
@@ -26,6 +26,7 @@
     "@octokit/rest": "16.43.1",
     "@probot/serverless-gcf": "0.2.0",
     "dotenv": "8.2.0",
+    "http-status-codes": "1.4.0",
     "sleep-promise": "8.0.1"
   },
   "devDependencies": {

--- a/onduty/redacted.env
+++ b/onduty/redacted.env
@@ -1,6 +1,6 @@
 # TODO: Change below once bot is functional and teams are set up
-GITHUB_REPO=amp-rcebulko-test-org/amphtml
+# Note: Access token is also used to authenticate rotation update requests.
 GITHUB_ACCESS_TOKEN=[REDACTED]
-
+GITHUB_ORG=amp-rcebulko-test-org
 RELEASE_ONDUTY_TEAM=release-on-duty
 BUILD_COP_TEAM=build-cop

--- a/onduty/src/bot.ts
+++ b/onduty/src/bot.ts
@@ -24,7 +24,7 @@ import {
 } from 'onduty';
 import sleep from 'sleep-promise';
 
-const API_RATE_LIMIT_MS = 250;
+const API_RATE_LIMIT_MS = Number(process.env.API_RATE_LIMIT_MS) || 250;
 
 export class OndutyBot {
   constructor(

--- a/onduty/src/bot.ts
+++ b/onduty/src/bot.ts
@@ -35,7 +35,7 @@ export class OndutyBot {
 
   async updateRotation(type: RotationType, rotation: Rotation): Promise<void> {
     const teamName = this.rotationTeams[type];
-    this.logger.info('[updateRotation] Updating ${type} rotation');
+    this.logger.info(`[updateRotation] Updating ${type} rotation`);
 
     const members = await this.github.getTeamMembers(teamName);
     const currentRotation = Object.values(rotation)
@@ -54,7 +54,7 @@ export class OndutyBot {
     }
   }
 
-  async handleUpdate(update: RotationUpdate) {
+  async handleUpdate(update: RotationUpdate): Promise<void> {
     for (const [type, rotation] of Object.entries(update)) {
       await this.updateRotation(type as RotationType, rotation);
     }

--- a/onduty/test/e2e.test.ts
+++ b/onduty/test/e2e.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Request, Response} from 'express';
+import {RotationReporterPayload} from 'onduty';
+import {refreshRotation} from '..';
+import nock from 'nock';
+
+describe('On-Duty Bot', () => {
+  let response: Response;
+  const request = (body: RotationReporterPayload): Request =>
+    ({body, query: {}} as Request);
+
+  beforeAll(() => {
+    nock.disableNetConnect();
+    console.debug = jest.fn();
+    console.info = jest.fn();
+    console.error = jest.fn();
+  });
+  afterAll(() => nock.enableNetConnect());
+
+  beforeEach(() => {
+    nock.cleanAll();
+    response = ({
+      send: jest.fn(),
+      sendStatus: jest.fn(),
+      status: jest.fn(),
+    } as unknown) as Response;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+
+    // Fail the test if there were unused nocks.
+    if (!nock.isDone()) {
+      throw new Error('Not all nock interceptors were used!');
+    }
+  });
+
+  it('refreshes GitHub teams with new rotations', async () => {
+    nock('https://api.github.com')
+      .get('/orgs/test_org/teams/build-team/members')
+      .reply(200, [{login: 'old-builder-primary'}, {login: 'builder-primary'}])
+      .put('/orgs/test_org/teams/build-team/memberships/builder-secondary')
+      .reply(200)
+      .delete('/orgs/test_org/teams/build-team/memberships/old-builder-primary')
+      .reply(204)
+      .get('/orgs/test_org/teams/release-team/members')
+      .reply(200, [{login: 'old-onduty-primary'}, {login: 'onduty-primary'}])
+      .put('/orgs/test_org/teams/release-team/memberships/onduty-secondary')
+      .reply(200)
+      .delete(
+        '/orgs/test_org/teams/release-team/memberships/old-onduty-primary'
+      )
+      .reply(204);
+
+    await refreshRotation(
+      request({
+        'build-cop': {
+          primary: 'builder-primary',
+          secondary: 'builder-secondary',
+        },
+        'release-on-duty': {
+          primary: 'onduty-primary',
+          secondary: 'onduty-secondary',
+        },
+        'access_token': '_TOKEN_',
+      }),
+      response
+    );
+
+    expect(response.sendStatus).toHaveBeenCalledWith(200);
+  });
+
+  it('returns 401 Unauthorized for an invalid token', async () => {
+    await refreshRotation(
+      request({
+        'build-cop': {
+          primary: 'builder-primary',
+          secondary: 'builder-secondary',
+        },
+        'release-on-duty': {
+          primary: 'onduty-primary',
+          secondary: 'onduty-secondary',
+        },
+        'access_token': '_BAD_TOKEN_',
+      }),
+      response
+    );
+
+    expect(response.sendStatus).toHaveBeenCalledWith(401);
+  });
+
+  it('returns 500 Internal Server Error if something goes wrong', async () => {
+    nock('https://api.github.com')
+      .get('/orgs/test_org/teams/build-team/members')
+      .reply(401, 'Bad authentication token');
+
+    await refreshRotation(
+      request({
+        'build-cop': {
+          primary: 'builder-primary',
+          secondary: 'builder-secondary',
+        },
+        'release-on-duty': {
+          primary: 'onduty-primary',
+          secondary: 'onduty-secondary',
+        },
+        'access_token': '_TOKEN_',
+      }),
+      response
+    );
+
+    expect(response.status).toHaveBeenCalledWith(500);
+    expect(response.send).toHaveBeenCalledWith(
+      'HttpError: Bad authentication token'
+    );
+  });
+});

--- a/onduty/test/jest-preload.ts
+++ b/onduty/test/jest-preload.ts
@@ -16,3 +16,9 @@
 
 // Allow the environment to override if desired.
 process.env.LOG_LEVEL = process.env.LOG_LEVEL || 'warn';
+
+process.env.GITHUB_ACCESS_TOKEN = '_TOKEN_';
+process.env.GITHUB_ORG = 'test_org';
+process.env.RELEASE_ONDUTY_TEAM = 'release-team';
+process.env.BUILD_COP_TEAM = 'build-team';
+process.env.AMP_RATE_LIMIT_MS = '1';

--- a/onduty/types/index.d.ts
+++ b/onduty/types/index.d.ts
@@ -31,4 +31,8 @@ declare module 'onduty' {
   export type RotationType = 'build-cop' | 'release-on-duty';
   export type RotationUpdate = Record<RotationType, Rotation>;
   export type RotationTeamMap = Record<RotationType, string>;
+
+  export interface RotationReporterPayload extends RotationUpdate {
+    access_token: string;
+  }
 }


### PR DESCRIPTION
I've confirmed this is functioning as expected on my test org.

```
 PASS  test/e2e.test.ts
  On-Duty Bot
    ✓ refreshes GitHub teams with new rotations (1048ms)
    ✓ returns 401 Unauthorized for an invalid token (2ms)
    ✓ returns 500 Internal Server Error if something goes wrong (7ms)

------------|---------|----------|---------|---------|-------------------
File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------|---------|----------|---------|---------|-------------------
All files   |     100 |      100 |     100 |     100 |                   
 onduty     |     100 |      100 |     100 |     100 |                   
  index.ts  |     100 |      100 |     100 |     100 |                   
 onduty/src |     100 |      100 |     100 |     100 |                   
  bot.ts    |     100 |      100 |     100 |     100 |                   
  github.ts |     100 |      100 |     100 |     100 |                   
------------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        5.034s, estimated 7s
```

Part of #778 