### PR TITLE
[release-calendar] Calendar view date

### DIFF
--- a/release-calendar/src/client/components/Calendar.tsx
+++ b/release-calendar/src/client/components/Calendar.tsx
@@ -56,6 +56,8 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     this.apiService = new ApiService();
   }
 
+  calendarReference = React.createRef<FullCalendar>();
+
   async componentDidMount(): Promise<void> {
     const releases = await this.apiService.getReleases();
     this.setState({allEvents: getAllReleasesEvents(releases)});
@@ -68,11 +70,18 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
           this.props.singleRelease,
         );
         this.setState({singleEvents: getSingleReleaseEvents(release)});
+        this.gotoDate(release[0].start);
       } else {
         this.setState({singleEvents: []});
+        this.gotoDate(new Date());
       }
     }
   }
+
+  gotoDate = (date: Date): void => {
+    const calendarApi = this.calendarReference.current.getApi();
+    calendarApi.gotoDate(date);
+  };
 
   tooltip = (arg: {
     isMirror: boolean;
@@ -114,6 +123,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
             center: 'title',
             right: 'dayGridMonth,timeGridWeek,listWeek',
           }}
+          ref={this.calendarReference}
           plugins={[dayGridPlugin, timeGridPlugin]}
           eventSources={displayEvents}
           contentHeight={CALENDAR_CONTENT_HEIGHT}

--- a/release-calendar/src/client/components/ChannelTable.tsx
+++ b/release-calendar/src/client/components/ChannelTable.tsx
@@ -43,6 +43,7 @@ export class ChannelTable extends React.Component<
     };
     this.apiService = new ApiService();
     this.handleChannelClick = this.handleChannelClick.bind(this);
+    this.handleReleaseClick = this.handleReleaseClick.bind(this);
   }
 
   async componentDidMount(): Promise<void> {


### PR DESCRIPTION
This will navigate the calendar to a relevant date when a release is selected.

Undesirable behavior: Let's say a user went to select a release, but was viewing the calendar in a different month than one where the requested release had been promoted in. Then, when they select to view the release, the calendar could appear empty.

Fix: Change the calendar to display the month of the latest release promotion when a release is selected. Also, when a release is unselected, return the viewer to the current month.

Included: 
- reference to the calendar element, `referenceCalendar`, in order to access the `FullCalendar` method `gotoDate()`, https://fullcalendar.io/docs/Calendar-gotoDate.
- creation of my own `gotoDate(date: Date)` which uses the `referenceCalendar` to change the calendar view date
- use of `gotoDate()` when the `Calendar` component `singleRelease` state is changed
- very unrelated to anything else, but the binding of `handleReleaseClick()` in `ChannelTable` that I should have done long ago