### PR TITLE
Add missing build targets and leave linting to apps

### DIFF
--- a/build-system/build-targets.js
+++ b/build-system/build-targets.js
@@ -26,9 +26,12 @@ const {gitDiffNameOnlyMaster} = require('./git');
 const ALL_TARGETS = [
   'BUNDLE_SIZE',
   'CHECKLIST',
+  'ERROR_ISSUE',
   'INVITE',
+  'ONDUTY',
   'OWNERS',
   'PR_DEPLOY',
+  'RELEASE_CALENDAR',
   'TEST_STATUS',
 ];
 
@@ -53,12 +56,20 @@ const targetMatchers = [
     func: file => file.startsWith('invite/'),
   },
   {
+    targets: ['ONDUTY'],
+    func: file => file.startsWith('onduty/'),
+  },
+  {
     targets: ['OWNERS'],
     func: file => file.startsWith('owners/'),
   },
   {
     targets: ['PR_DEPLOY'],
     func: file => file.startsWith('pr-deploy/'),
+  },
+  {
+    targets: ['RELEASE_CALENDAR'],
+    func: file => file.startsWith('release-calendar/'),
   },
   {
     targets: ['TEST_STATUS'],

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, the AMP HTML authors
+ * Copyright 2018, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -54,7 +54,6 @@ function runAppTests(appName) {
  * @return {number} process exit code.
  */
 function main() {
-  timedExecOrDie('eslint . --ext .ts,.tsx');
   let buildTargets = new Set(ALL_TARGETS);
 
   if (isTravisPushBuild()) {
@@ -76,8 +75,14 @@ function main() {
   if (buildTargets.has('OWNERS')) {
     runAppTests('owners');
   }
+  if (buildTargets.has('ONDUTY')) {
+    runAppTests('onduty');
+  }
   if (buildTargets.has('PR_DEPLOY')) {
     runAppTests('pr-deploy');
+  }
+  if (buildTargets.has('RELEASE_CALENDAR')) {
+    runAppTests('release-calendar');
   }
   if (buildTargets.has('TEST_STATUS')) {
     runAppTests('test-status');

--- a/bundle-size/__mocks__/db.js
+++ b/bundle-size/__mocks__/db.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, the AMP HTML authors
+ * Copyright 2018, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/bundle-size/api.js
+++ b/bundle-size/api.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, the AMP HTML authors
+ * Copyright 2018, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/bundle-size/app.js
+++ b/bundle-size/app.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, the AMP HTML authors
+ * Copyright 2018, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/bundle-size/common.js
+++ b/bundle-size/common.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, the AMP HTML authors
+ * Copyright 2018, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/bundle-size/db.js
+++ b/bundle-size/db.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, the AMP HTML authors
+ * Copyright 2018, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/bundle-size/github-utils.js
+++ b/bundle-size/github-utils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, the AMP HTML authors
+ * Copyright 2018, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/bundle-size/setup-db.js
+++ b/bundle-size/setup-db.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, the AMP HTML authors
+ * Copyright 2018, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/bundle-size/test/_test_helper.js
+++ b/bundle-size/test/_test_helper.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, the AMP HTML authors
+ * Copyright 2019, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/bundle-size/test/api.test.js
+++ b/bundle-size/test/api.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, the AMP HTML authors
+ * Copyright 2018, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/bundle-size/test/webhooks.test.js
+++ b/bundle-size/test/webhooks.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, the AMP HTML authors
+ * Copyright 2018, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/bundle-size/webhooks.js
+++ b/bundle-size/webhooks.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018, the AMP HTML authors
+ * Copyright 2018, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/checklist/test/fixtures/index.ts
+++ b/checklist/test/fixtures/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, the AMP HTML authors
+ * Copyright 2020, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/error-issue/test/fixtures/index.ts
+++ b/error-issue/test/fixtures/index.ts
@@ -13,20 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Copyright 2020, the AMP HTML authors
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 import {GraphQLResponse} from 'error-issue-bot';
 import fs from 'fs';

--- a/invite/src/db.ts
+++ b/invite/src/db.ts
@@ -13,20 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Copyright 2020, the AMP HTML authors
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 require('dotenv').config();
 

--- a/invite/src/setup_db.ts
+++ b/invite/src/setup_db.ts
@@ -13,20 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Copyright 2020, the AMP HTML authors
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 import {Database, dbConnect} from './db';
 

--- a/invite/test/fixtures/index.ts
+++ b/invite/test/fixtures/index.ts
@@ -13,20 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Copyright 2020, the AMP HTML authors
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 import {Probot} from 'probot';
 import {WebhookEvent} from '@octokit/webhooks';

--- a/test-status/__mocks__/auth.js
+++ b/test-status/__mocks__/auth.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, the AMP HTML authors
+ * Copyright 2019, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/test-status/__mocks__/db-connect.js
+++ b/test-status/__mocks__/db-connect.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, the AMP HTML authors
+ * Copyright 2019, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/test-status/api.js
+++ b/test-status/api.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, the AMP HTML authors
+ * Copyright 2019, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/test-status/app.js
+++ b/test-status/app.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, the AMP HTML authors
+ * Copyright 2019, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/test-status/auth.js
+++ b/test-status/auth.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, the AMP HTML authors
+ * Copyright 2019, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/test-status/db-connect.js
+++ b/test-status/db-connect.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, the AMP HTML authors
+ * Copyright 2019, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/test-status/db.js
+++ b/test-status/db.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, the AMP HTML authors
+ * Copyright 2019, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/test-status/setup-db.js
+++ b/test-status/setup-db.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, the AMP HTML authors
+ * Copyright 2019, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/test-status/test/api.test.js
+++ b/test-status/test/api.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, the AMP HTML authors
+ * Copyright 2019, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/test-status/test/web.test.js
+++ b/test-status/test/web.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, the AMP HTML authors
+ * Copyright 2019, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/test-status/test/webhooks.test.js
+++ b/test-status/test/webhooks.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, the AMP HTML authors
+ * Copyright 2019, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/test-status/web.js
+++ b/test-status/web.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, the AMP HTML authors
+ * Copyright 2019, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/test-status/webhooks.js
+++ b/test-status/webhooks.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, the AMP HTML authors
+ * Copyright 2019, the AMP HTML authors. All Rights Reserved
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
This PR:
- Fixes the Copyright notice across the repo
- Adds build targets for all the recently added apps that were missing
- Removes the top-level `eslint`, since each app (that passes) now lints as part of `npm test`

Note: I plan to follow up with a PR simplifying the build targets for apps to prevent this common error where new apps never get tested in CI