### PR TITLE
[onduty] Never remove bot user from rotation teams

### DIFF
--- a/onduty/redacted.env
+++ b/onduty/redacted.env
@@ -3,3 +3,4 @@ GITHUB_ACCESS_TOKEN=[REDACTED]
 GITHUB_ORG=ampproject
 RELEASE_ONDUTY_TEAM=release-on-duty
 BUILD_COP_TEAM=build-cop
+BOT_USERNAME=ampprojectbot

--- a/onduty/src/bot.ts
+++ b/onduty/src/bot.ts
@@ -24,6 +24,7 @@ import {
 } from 'onduty';
 import sleep from 'sleep-promise';
 
+const BOT_USERNAME = process.env.BOT_USERNAME;
 const API_RATE_LIMIT_MS = Number(process.env.API_RATE_LIMIT_MS) || 250;
 
 export class OndutyBot {
@@ -42,7 +43,9 @@ export class OndutyBot {
       .filter(Boolean)
       .map(user => user.toLowerCase());
     const newMembers = currentRotation.filter(user => !members.includes(user));
-    const oldMembers = members.filter(user => !currentRotation.includes(user));
+    const oldMembers = members.filter(
+      user => user !== BOT_USERNAME && !currentRotation.includes(user)
+    );
 
     for (const newMember of newMembers) {
       await this.github.addToTeam(teamName, newMember);

--- a/onduty/test/bot.test.ts
+++ b/onduty/test/bot.test.ts
@@ -82,6 +82,14 @@ describe('OndutyBot', () => {
         'builder-old-primary'
       );
     });
+
+    it('ignores the bot user', async () => {
+      await bot.updateRotation('build-cop', rotations['build-cop']);
+      expect(github.removeFromTeam).not.toHaveBeenCalledWith(
+        'build-team',
+        'bot-user'
+      );
+    });
   });
 
   describe('handleUpdates', () => {

--- a/onduty/test/jest-preload.ts
+++ b/onduty/test/jest-preload.ts
@@ -21,4 +21,5 @@ process.env.GITHUB_ACCESS_TOKEN = '_TOKEN_';
 process.env.GITHUB_ORG = 'test_org';
 process.env.RELEASE_ONDUTY_TEAM = 'release-team';
 process.env.BUILD_COP_TEAM = 'build-team';
+process.env.BOT_USERNAME = 'bot-user';
 process.env.AMP_RATE_LIMIT_MS = '1';


### PR DESCRIPTION
- [ ] merge this PR (`@rcebulko`)
- [ ] `@ampprojectbot` is added as a Maintainer of `@ampproject/release-on-duty` (`@rsimha`|`@mrjoro`)
- [ ] `@ampprojectbot` is added as a Maintainer of `@ampproject/build-cop` (`@rsimha`|`@mrjoro`)
- [ ] deploy the update (`@rcebulko`)