### PR TITLE
Enable pretest linting for `checklist`

### DIFF
--- a/checklist/package.json
+++ b/checklist/package.json
@@ -17,6 +17,7 @@
     "start": "probot run ./dist/app.js",
     "dev": "nodemon",
     "deploy-tag": "git tag 'deploy-checklist-'`date --utc '+%Y%m%d%H%M%S'`",
+    "pretest": "npm run lint",
     "test": "echo No tests defined for this app!",
     "test:watch": "jest --watch --notify --notifyMode=change"
   },


### PR DESCRIPTION
Ensures that all PRs pass lint checks during testing/CI