### PR TITLE
[error-issue] Fix bugs/weird quirks in URL encoding

### DIFF
--- a/error-issue/index.ts
+++ b/error-issue/index.ts
@@ -25,6 +25,7 @@ import {ErrorIssueBot} from './src/bot';
 import {ErrorReport, ServiceGroupType} from 'error-issue-bot';
 import {StackdriverApi} from './src/stackdriver_api';
 import express from 'express';
+import querystring from 'querystring';
 import statusCodes from 'http-status-codes';
 
 const GITHUB_REPO = process.env.GITHUB_REPO || 'ampproject/amphtml';
@@ -134,10 +135,7 @@ export async function errorMonitor(
 }
 
 function createErrorReportUrl(report: ErrorReport): string {
-  const params = Object.entries(report)
-    .map(([key, val]) => `${key}=${encodeURIComponent(val)}`)
-    .join('&');
-
+  const params = querystring.stringify(report);
   return `${ERROR_ISSUE_ENDPOINT}?${params}`;
 }
 

--- a/error-issue/index.ts
+++ b/error-issue/index.ts
@@ -54,7 +54,7 @@ function errorReportFromJson({
   firstSeen?: string;
   dailyOccurrences?: string | number;
   stacktrace?: string;
-  seenInVersions?: Array<string>;
+  seenInVersions?: string | Array<string>;
 }): ErrorReport {
   if (firstSeen && dailyOccurrences && stacktrace && seenInVersions) {
     return {
@@ -62,7 +62,9 @@ function errorReportFromJson({
       firstSeen: new Date(firstSeen),
       dailyOccurrences: Number(dailyOccurrences),
       stacktrace,
-      seenInVersions,
+      seenInVersions: Array.isArray(seenInVersions)
+        ? seenInVersions
+        : [seenInVersions],
     };
   }
 

--- a/error-issue/index.ts
+++ b/error-issue/index.ts
@@ -135,7 +135,10 @@ export async function errorMonitor(
 }
 
 function createErrorReportUrl(report: ErrorReport): string {
-  const params = querystring.stringify(report);
+  const params = querystring.stringify({
+    ...report,
+    firstSeen: report.firstSeen.toString(),
+  });
   return `${ERROR_ISSUE_ENDPOINT}?${params}`;
 }
 

--- a/error-issue/package-lock.json
+++ b/error-issue/package-lock.json
@@ -5612,6 +5612,11 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",

--- a/error-issue/package.json
+++ b/error-issue/package.json
@@ -30,7 +30,8 @@
     "dotenv": "8.2.0",
     "google-auth-library": "6.0.0",
     "http-status-codes": "1.4.0",
-    "node-fetch": "2.6.0"
+    "node-fetch": "2.6.0",
+    "querystring": "0.2.0"
   },
   "devDependencies": {
     "@google-cloud/functions-framework": "1.5.1",

--- a/error-issue/src/utils.ts
+++ b/error-issue/src/utils.ts
@@ -56,7 +56,11 @@ export function parseSource(source: string): null | StackFrame {
 export function parseStacktrace(stacktrace: string): Array<StackFrame> {
   return stacktrace
     .split('\n')
-    .map(line => line.match(/^\s*at .*\((?<source>.+)\)$/))
+    .map(
+      line =>
+        line.match(/^\s*at .*\((?<source>.+)\)$/) ||
+        line.match(/^\s*at (?<source>https:.+)$/)
+    )
     .filter(Boolean)
     .map(({groups}) => parseSource(groups.source));
 }

--- a/error-issue/test/utils.test.ts
+++ b/error-issue/test/utils.test.ts
@@ -103,4 +103,24 @@ describe('parseStacktrace', () => {
       },
     ]);
   });
+
+  it('handles lines with no function included', () => {
+    const frames = parseStacktrace(
+      `Error: undefined is not an object (evaluating 'b.length')
+        at https://raw.githubusercontent.com/ampproject/amphtml/2004030010070/extensions/amp-next-page/1.0/service.js:785
+        at https://raw.githubusercontent.com/ampproject/amphtml/2004030010070/extensions/amp-next-page/1.0/service.js:294`
+    );
+    expect(frames).toEqual([
+      {
+        rtv: '2004030010070',
+        path: 'extensions/amp-next-page/1.0/service.js',
+        line: 785,
+      },
+      {
+        rtv: '2004030010070',
+        path: 'extensions/amp-next-page/1.0/service.js',
+        line: 294,
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Fixes three bugs:

1. `seenInVersions` list is incorrectly URL-encoded; should be encoded as a repeated query param, instead is encoded as comma-separate list.
- Fixed by using `querystring.stringify` library
2. Stacktraces with a different format fail parsing
- Fixed by adding a fallback regex check
3. Query parameter `seenInVersions` is expected as an array, but when it's a one-item array it gets parsed as a string
- Fixed by wrapping in an array