### PR TITLE
Linkize stack traces to the relevant file

### DIFF
--- a/error-issue/package.json
+++ b/error-issue/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "lint": "eslint . --ext .ts",
-    "fix": "npm run list -- --fix",
+    "fix": "npm run lint -- --fix",
     "build": "tsc",
     "build:watch": "tsc -w --p tsconfig.json",
     "start": "functions-framework --target=app --source=dist",

--- a/error-issue/src/issue_builder.ts
+++ b/error-issue/src/issue_builder.ts
@@ -75,13 +75,19 @@ export class IssueBuilder {
 
   get bodyStacktrace(): string {
     const indent = (line: string): string => line.replace(/^\s*/, '    ');
+    const linkize = (line: string): string => {
+      return line.replace(
+        /https:\/\/[^\/]+\/(?<owner>[^\/]+)\/(?<repo>[^\/]+)\/(?<ref>[^\/]+)\/(?<path>[^:]+):(?<line>\d+)/,
+        '<a href="https://github.com/$<owner>/$<repo>/blob/$<ref>/$<path>#L$<line>">$<path>:$<line></a>'
+      );
+    };
     return [
       'Stacktrace',
       '---',
-      '```',
+      '<pre><code>',
       this.message,
-      ...this.stack.map(indent),
-      '```',
+      ...this.stack.map(indent).map(linkize),
+      '</code></pre>',
     ].join('\n');
   }
 

--- a/error-issue/test/fixtures/created-issue.md
+++ b/error-issue/test/fixtures/created-issue.md
@@ -6,11 +6,11 @@ Details
 
 Stacktrace
 ---
-```
+<pre><code>
 Error: null is not an object (evaluating 'b.acceleration.x')
-    at x (https://raw.githubusercontent.com/ampproject/amphtml/2004030010070/extensions/amp-delight-player/0.1/amp-delight-player.js:421:13)
-    at event (https://raw.githubusercontent.com/ampproject/amphtml/2004030010070/src/event-helper-listen.js:58:27)
-```
+    at x (<a href="https://github.com/ampproject/amphtml/blob/2004030010070/extensions/amp-delight-player/0.1/amp-delight-player.js#L421">extensions/amp-delight-player/0.1/amp-delight-player.js:421</a>:13)
+    at event (<a href="https://github.com/ampproject/amphtml/blob/2004030010070/src/event-helper-listen.js#L58">src/event-helper-listen.js:58</a>:27)
+</code></pre>
 
 Notes
 ---

--- a/error-issue/test/issue_builder.test.ts
+++ b/error-issue/test/issue_builder.test.ts
@@ -145,11 +145,11 @@ describe('IssueBuilder', () => {
   describe('bodyStacktrace', () => {
     it('renders the indented stacktrace in markdown', () => {
       expect(builder.bodyStacktrace).toContain(
-        '```\n' +
+        '<pre><code>\n' +
           "Error: null is not an object (evaluating 'b.acceleration.x')\n" +
-          '    at x (https://raw.githubusercontent.com/ampproject/amphtml/2004030010070/extensions/amp-delight-player/0.1/amp-delight-player.js:421:13)\n' +
-          '    at event (https://raw.githubusercontent.com/ampproject/amphtml/2004030010070/src/event-helper-listen.js:58:27)\n' +
-          '```'
+          '    at x (<a href="https://github.com/ampproject/amphtml/blob/2004030010070/extensions/amp-delight-player/0.1/amp-delight-player.js#L421">extensions/amp-delight-player/0.1/amp-delight-player.js:421</a>:13)\n' +
+          '    at event (<a href="https://github.com/ampproject/amphtml/blob/2004030010070/src/event-helper-listen.js#L58">src/event-helper-listen.js:58</a>:27)\n' +
+          '</code></pre>'
       );
     });
   });

--- a/error-issue/test/rate_limited_graphql.test.ts
+++ b/error-issue/test/rate_limited_graphql.test.ts
@@ -48,13 +48,17 @@ describe('RateLimitedGraphQL', () => {
   });
 
   it('returns the query result', async () => {
-    nock('https://api.github.com').post('/graphql').reply(200, response);
+    nock('https://api.github.com')
+      .post('/graphql')
+      .reply(200, response);
 
     await expect(client.runQuery(query)).resolves.toEqual(response.data);
   });
 
   it('queues multiple queries and executes after delay', async () => {
-    nock('https://api.github.com').post('/graphql').reply(200, response);
+    nock('https://api.github.com')
+      .post('/graphql')
+      .reply(200, response);
 
     const firstQuery = client.runQuery(query);
     // If later queries execute before they are nocked, the test will fail.
@@ -63,11 +67,15 @@ describe('RateLimitedGraphQL', () => {
 
     await expect(firstQuery).resolves.toEqual(response.data);
 
-    nock('https://api.github.com').post('/graphql').reply(200, response);
+    nock('https://api.github.com')
+      .post('/graphql')
+      .reply(200, response);
     jest.advanceTimersByTime(1000);
     await expect(secondQuery).resolves.toEqual(response.data);
 
-    nock('https://api.github.com').post('/graphql').reply(200, response);
+    nock('https://api.github.com')
+      .post('/graphql')
+      .reply(200, response);
     jest.advanceTimersByTime(1000);
     await expect(thirdQuery).resolves.toEqual(response.data);
   });


### PR DESCRIPTION
## Before
```
Error: null is not an object (evaluating 'b.acceleration.x')
    at x (https://raw.githubusercontent.com/ampproject/amphtml/2004030010070/extensions/amp-delight-player/0.1/amp-delight-player.js:421:13)
    at event (https://raw.githubusercontent.com/ampproject/amphtml/2004030010070/src/event-helper-listen.js:58:27)
```


## After

<pre><code>
Error: null is not an object (evaluating 'b.acceleration.x')
    at x (<a href="https://github.com/ampproject/amphtml/blob/2004030010070/extensions/amp-delight-player/0.1/amp-delight-player.js#L421">extensions/amp-delight-player/0.1/amp-delight-player.js:421</a>:13)
    at event (<a href="https://github.com/ampproject/amphtml/blob/2004030010070/src/event-helper-listen.js#L58">src/event-helper-listen.js:58</a>:27)
</code></pre>
