### PR TITLE
[error-issue] Remove extra newline in stacktrace code block

### DIFF
--- a/error-issue/package.json
+++ b/error-issue/package.json
@@ -18,6 +18,7 @@
     "deploy-tag-issue": "git tag 'deploy-error-issue-'`date --utc '+%Y%m%d%H%M%S'`",
     "deploy-tag-monitor": "git tag 'deploy-error-monitor-'`date --utc '+%Y%m%d%H%M%S'`",
     "deploy-tag-list": "git tag 'deploy-error-list-'`date --utc '+%Y%m%d%H%M%S'`",
+    "pretest": "npm run lint",
     "test": "jest",
     "test:watch": "jest --watch --notify --notifyMode=change"
   },

--- a/error-issue/src/error_monitor.ts
+++ b/error-issue/src/error_monitor.ts
@@ -52,6 +52,7 @@ export class ErrorMonitor {
 
   /** Creates a service monitor using the same settings as this monitor. */
   service(serviceName: ServiceName): ServiceErrorMonitor {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new ServiceErrorMonitor(
       this.client,
       serviceName,

--- a/error-issue/src/issue_builder.ts
+++ b/error-issue/src/issue_builder.ts
@@ -84,8 +84,7 @@ export class IssueBuilder {
     return [
       'Stacktrace',
       '---',
-      '<pre><code>',
-      this.message,
+      `<pre><code>${this.message}`,
       ...this.stack.map(indent).map(linkize),
       '</code></pre>',
     ].join('\n');

--- a/error-issue/test/fixtures/created-issue.md
+++ b/error-issue/test/fixtures/created-issue.md
@@ -6,8 +6,7 @@ Details
 
 Stacktrace
 ---
-<pre><code>
-Error: null is not an object (evaluating 'b.acceleration.x')
+<pre><code>Error: null is not an object (evaluating 'b.acceleration.x')
     at x (<a href="https://github.com/ampproject/amphtml/blob/2004030010070/extensions/amp-delight-player/0.1/amp-delight-player.js#L421">extensions/amp-delight-player/0.1/amp-delight-player.js:421</a>:13)
     at event (<a href="https://github.com/ampproject/amphtml/blob/2004030010070/src/event-helper-listen.js#L58">src/event-helper-listen.js:58</a>:27)
 </code></pre>

--- a/error-issue/test/issue_builder.test.ts
+++ b/error-issue/test/issue_builder.test.ts
@@ -145,7 +145,7 @@ describe('IssueBuilder', () => {
   describe('bodyStacktrace', () => {
     it('renders the indented stacktrace in markdown', () => {
       expect(builder.bodyStacktrace).toContain(
-        '<pre><code>\n' +
+        '<pre><code>' +
           "Error: null is not an object (evaluating 'b.acceleration.x')\n" +
           '    at x (<a href="https://github.com/ampproject/amphtml/blob/2004030010070/extensions/amp-delight-player/0.1/amp-delight-player.js#L421">extensions/amp-delight-player/0.1/amp-delight-player.js:421</a>:13)\n' +
           '    at event (<a href="https://github.com/ampproject/amphtml/blob/2004030010070/src/event-helper-listen.js#L58">src/event-helper-listen.js:58</a>:27)\n' +


### PR DESCRIPTION
Because of the `<pre>`, the newline is actually rendered now.

Before: 
![image](https://user-images.githubusercontent.com/6694512/81428179-ea5ef600-9129-11ea-928d-49fa1305ed77.png)

After:
![image](https://user-images.githubusercontent.com/6694512/81428226-fa76d580-9129-11ea-81c2-323e65ccb36a.png)

