### PR TITLE
[error-issue] Allow for overriding frequency threshold

### DIFF
--- a/error-issue/index.ts
+++ b/error-issue/index.ts
@@ -175,7 +175,7 @@ export async function errorList(
     res.json({
       serviceType: serviceType || 'ALL',
       serviceTypeThreshold: Math.ceil(lister.minFrequency),
-      normalizedThreshold: MIN_FREQUENCY,
+      normalizedThreshold: Math.ceil(lister.normalizedMinFrequency),
       errorReports: reports.map(report => {
         const createUrl = createErrorReportUrl(report);
         return {

--- a/error-issue/src/error_monitor.ts
+++ b/error-issue/src/error_monitor.ts
@@ -73,6 +73,11 @@ export class ErrorMonitor {
     );
   }
 
+  /** Provides the frequency equivelent across all services. */
+  get normalizedMinFrequency(): number {
+    return this.minFrequency;
+  }
+
   /** Creates an error monitor with a different frequency threshold. */
   threshold(minFrequency: number): ErrorMonitor {
     return new ErrorMonitor(this.client, minFrequency, this.pageLimit);
@@ -181,6 +186,11 @@ export class ServiceErrorMonitor extends ErrorMonitor {
     pageLimit = 25
   ) {
     super(client, minFrequency, pageLimit);
+  }
+
+  /** Provides the frequency equivelent across all services. */
+  get normalizedMinFrequency(): number {
+    return this.minFrequency * scaleFactor(this.serviceName);
   }
 
   /** Finds top occurring errors in the service group. */

--- a/error-issue/src/error_monitor.ts
+++ b/error-issue/src/error_monitor.ts
@@ -73,6 +73,11 @@ export class ErrorMonitor {
     );
   }
 
+  /** Creates an error monitor with a different frequency threshold. */
+  threshold(minFrequency: number): ErrorMonitor {
+    return new ErrorMonitor(this.client, minFrequency, this.pageLimit);
+  }
+
   /** Tests if an error group already has an associated issue. */
   private hasTrackingIssue(group: Stackdriver.ErrorGroup): boolean {
     return !!group.trackingIssues;
@@ -181,5 +186,15 @@ export class ServiceErrorMonitor extends ErrorMonitor {
   /** Finds top occurring errors in the service group. */
   protected async newErrors(): Promise<Array<Stackdriver.ErrorGroupStats>> {
     return this.client.listServiceGroups(this.serviceName, this.pageLimit);
+  }
+
+  /** Creates an error monitor with a different frequency threshold. */
+  threshold(minFrequency: number): ErrorMonitor {
+    return new ServiceErrorMonitor(
+      this.client,
+      this.serviceName,
+      minFrequency,
+      this.pageLimit
+    );
   }
 }

--- a/error-issue/test/error_monitor.test.ts
+++ b/error-issue/test/error_monitor.test.ts
@@ -45,7 +45,7 @@ describe('ErrorMonitor', () => {
     count: 2000,
     timedCounts: [
       {
-        count: 4,
+        count: 2000,
         startTime: new Date('Feb 25, 2020'),
         endTime: new Date('Feb 26, 2020'),
       },
@@ -219,6 +219,15 @@ describe('ErrorMonitor', () => {
       expect(serviceMonitor).toBeInstanceOf(ServiceErrorMonitor);
     });
   });
+
+  describe('threshold', () => {
+    it('creates a monitor with a different minimum frequency', async () => {
+      const thresholdMonitor = monitor.threshold(1000);
+      const newErrors = await thresholdMonitor.newErrorsToReport();
+      const newErrorIds = newErrors.map(({errorId}) => errorId);
+      expect(newErrorIds).toEqual(['infrequent_id', 'new_id']);
+    });
+  });
 });
 
 describe('ServiceErrorMonitor', () => {
@@ -296,6 +305,15 @@ describe('ServiceErrorMonitor', () => {
         'CDN Development',
         25
       );
+    });
+  });
+
+  describe('threshold', () => {
+    it('creates a monitor with a different minimum frequency', async () => {
+      const thresholdMonitor = monitor.threshold(100);
+      const newErrors = await thresholdMonitor.newErrorsToReport();
+      const newErrorIds = newErrors.map(({errorId}) => errorId);
+      expect(newErrorIds).toEqual(['infrequent_id', 'new_id']);
     });
   });
 });

--- a/error-issue/test/error_monitor.test.ts
+++ b/error-issue/test/error_monitor.test.ts
@@ -240,7 +240,7 @@ describe('ServiceErrorMonitor', () => {
     count: 200,
     timedCounts: [
       {
-        count: 4,
+        count: 200,
         startTime: new Date('Feb 25, 2020'),
         endTime: new Date('Feb 26, 2020'),
       },
@@ -282,13 +282,13 @@ describe('ServiceErrorMonitor', () => {
     monitor = new ServiceErrorMonitor(
       stackdriver,
       ServiceName.DEVELOPMENT,
-      5000
+      500
     );
     mocked(stackdriver.listServiceGroups).mockResolvedValue(errorGroups);
   });
 
   describe('newErrorsToReport', () => {
-    it('ignores infrequent errors, scaled for the service', async () => {
+    it('ignores infrequent errors', async () => {
       const newErrors = await monitor.newErrorsToReport();
       const newErrorIds = newErrors.map(({errorId}) => errorId);
       expect(newErrorIds).toEqual(['new_id']);


### PR DESCRIPTION
This PR:
- allows error monitor frequency thresholds to be overridden
- provides a `threshold` query param to do so for error list views
- computes the resulting "normalized" threshold (ie. 50/day in Nightly --> 9800/day across all services)

Usage (UI in prototype):

![image](https://user-images.githubusercontent.com/6694512/81448495-741fbb00-914c-11ea-9a47-8b2e563c5f60.png)
