### PR TITLE
[owners] Don't exclude reviewers from notification comments

### DIFF
--- a/owners/src/notifier.js
+++ b/owners/src/notifier.js
@@ -178,10 +178,6 @@ class OwnersNotifier {
         });
     });
 
-    Object.keys(this.currentReviewers).forEach(name => {
-      delete notifies[name];
-    });
-
     return notifies;
   }
 }

--- a/owners/test/notifier.test.js
+++ b/owners/test/notifier.test.js
@@ -452,34 +452,5 @@ describe('notifier', () => {
 
       expect(notifies['rando']).toBeUndefined();
     });
-
-    describe('with existing reviewers', () => {
-      let notifier;
-
-      beforeEach(() => {
-        notifier = new OwnersNotifier(
-          pr,
-          {'current_approver': true, 'pending_reviewer': false},
-          tree,
-          ['baz/test.js']
-        );
-
-        sandbox
-          .stub(OwnersTree.prototype, 'getModifiedFileOwners')
-          .returns([
-            new UserOwner('current_approver'),
-            new UserOwner('pending_reviewer'),
-          ]);
-      });
-
-      it('excludes approving reviewers', () => {
-        const notifies = notifier.getOwnersToNotify();
-        expect(notifies['current_approver']).toBeUndefined();
-      });
-      it('excludes pending reviewers', () => {
-        const notifies = notifier.getOwnersToNotify();
-        expect(notifies['pending_reviewer']).toBeUndefined();
-      });
-    });
   });
 });


### PR DESCRIPTION
Necessitated by bugs/quirks in how GitHub handles thread notifications when @ mentioned users add reviews. See issue thread for details.

Closes https://github.com/ampproject/amphtml/issues/28253

/cc @gmajoulet 