### PR TITLE
[error-issue] Simplify issue creation URL

### DIFF
--- a/error-issue/cloud_build.yaml
+++ b/error-issue/cloud_build.yaml
@@ -37,6 +37,13 @@ steps:
       - cp
       - package.json
       - dist/
+  - name: ubuntu
+    dir: error-issue
+    args:
+      - cp
+      - -r
+      - static/
+      - dist/
 
   # Deploy the apps.
   - name: gcr.io/cloud-builders/gcloud

--- a/error-issue/index.ts
+++ b/error-issue/index.ts
@@ -154,11 +154,8 @@ export async function errorMonitor(
   }
 }
 
-function createErrorReportUrl(report: ErrorReport): string {
-  const params = querystring.stringify({
-    ...report,
-    firstSeen: report.firstSeen.toString(),
-  });
+function createErrorReportUrl({errorId}: ErrorReport): string {
+  const params = querystring.stringify({errorId, linkIssue: 1});
   return `${ERROR_ISSUE_ENDPOINT}?${params}`;
 }
 
@@ -215,17 +212,21 @@ function viewData({
         errorId,
         firstSeen,
         dailyOccurrences,
+        message,
         stacktrace,
         seenInVersions,
-      }: ErrorReport): ErrorList.ErrorReportView => ({
+        createUrl,
+      }: ErrorList.ErrorReportWithMeta): ErrorList.ErrorReportView => ({
         errorId,
         firstSeen: formatDate(new Date(firstSeen)),
         dailyOccurrences: dailyOccurrences.toLocaleString('en-US'),
+        message,
         stacktrace: stacktrace
           .split('\n')
           .map(linkifySource)
           .join('\n'),
         seenInVersions,
+        createUrl,
       })
     ),
   };
@@ -263,10 +264,8 @@ export async function errorList(
       serviceTypeThreshold: Math.ceil(lister.minFrequency),
       normalizedThreshold: Math.ceil(lister.normalizedMinFrequency),
       errorReports: reports.map(report => {
-        const createUrl = createErrorReportUrl(report);
         return {
-          createUrl,
-          createAndLinkUrl: `${createUrl}&linkIssue=1`,
+          createUrl: createErrorReportUrl(report),
           message: report.stacktrace.split('\n', 1)[0],
           ...report,
         };

--- a/error-issue/static/error-list.html
+++ b/error-issue/static/error-list.html
@@ -171,7 +171,7 @@
 
       <a target="_blank"
         rel="noopener noreferrer"
-        href="{{createAndLinkUrl}}"
+        href="{{createUrl}}"
         onclick="this.parentNode.classList.add('error-report-done')">
         <button class="button-blue button-create">Create issue</button>
       </a>

--- a/error-issue/types/error-issue-bot.d.ts
+++ b/error-issue/types/error-issue-bot.d.ts
@@ -162,13 +162,14 @@ declare module 'error-issue-bot' {
   }
 
   namespace ErrorList {
-    interface ErrorReportWithMeta extends ErrorReport {
+    interface ErrorReportMeta {
       createUrl: string;
-      createAndLinkUrl: string;
       message: string;
     }
 
-    interface ErrorReportView {
+    type ErrorReportWithMeta = ErrorReport & ErrorReportMeta;
+
+    interface ErrorReportView extends ErrorReportMeta {
       errorId: string;
       firstSeen: string;
       dailyOccurrences: string;


### PR DESCRIPTION
Currently, the "Create Issue" links include all the error report fields: stacktrace, seen versions, frequency, etc. This PR simplifies the link to include only the error ID, allowing the backend to fetch the most up-to-date stats when creating the issue