### PR TITLE
Fix handling of leaf nodes owned by non-reviewers

### DIFF
--- a/owners/test/reviewer_selection.test.js
+++ b/owners/test/reviewer_selection.test.js
@@ -236,6 +236,18 @@ describe('reviewer selection', () => {
       const reviewers = ReviewerSelection._findPotentialReviewers(fileTreeMap);
       expect(reviewers).toEqual(['kid']);
     });
+
+    it('handles non-reviewers at leaf nodes', () => {
+      fileTreeMap = ownersTree.buildFileTreeMap(['foo/bar/baz/other_file.js']);
+      const reviewerTeam = new Team(42, 'ampproject', 'reviewer-set');
+      reviewerTeam.members = ['reviewer', 'child', 'someone'];
+      ownersTree.addRule(
+        new ReviewerSetRule('OWNERS', [new TeamOwner(reviewerTeam)])
+      );
+
+      const reviewers = ReviewerSelection._findPotentialReviewers(fileTreeMap);
+      expect(reviewers).toEqual(['child']);
+    });
   });
 
   describe('filesOwnedByReviewer', () => {


### PR DESCRIPTION
Addresses a subtle bug seen in reviewer assignment on https://github.com/ampproject/amphtml/pull/28489

A key step in prioritizing reviewer selection involves finding the deepest owners rules that apply to each file in a PR. In the case of the above PR, `validator/java/OWNERS` includes two users who are not members of `reviewers-amphtml`. In this case, the algorithm tries to satisfy that rule, then later on when the non-reviewers are eliminated, it has no reviewer suggestions.

This PR adds an automatic backoff to that step of the algorithm. When it fails to find any potential reviewers to satisfy the deepest layer of owners rules, it climbs the tree and tries to satisfy the next-deepest set of rules. 