### PR TITLE
[error-issue] Handle empty list repsonse from stackdriver

### DIFF
--- a/error-issue/src/stackdriver_api.ts
+++ b/error-issue/src/stackdriver_api.ts
@@ -81,7 +81,7 @@ export class StackdriverApi {
     groupId?: string;
     'serviceFilter.service'?: string;
   }): Promise<Array<Stackdriver.ErrorGroupStats>> {
-    const {errorGroupStats} = (await this.request('groupStats', 'GET', {
+    const {errorGroupStats = []} = (await this.request('groupStats', 'GET', {
       'timeRange.period': 'PERIOD_1_DAY',
       timedCountDuration: `${SECONDS_IN_DAY}s`,
       ...opts,

--- a/error-issue/src/stackdriver_api.ts
+++ b/error-issue/src/stackdriver_api.ts
@@ -85,7 +85,7 @@ export class StackdriverApi {
       'timeRange.period': 'PERIOD_1_DAY',
       timedCountDuration: `${SECONDS_IN_DAY}s`,
       ...opts,
-    })) as Record<string, Array<Stackdriver.SerializedErrorGroupStats>>;
+    })) as {errorGroupStats?: Array<Stackdriver.SerializedErrorGroupStats>};
 
     return errorGroupStats.map((stats: Stackdriver.SerializedErrorGroupStats) =>
       this.deserialize(stats)


### PR DESCRIPTION
Since Experiemnt A was turned down, there are no longer errors under the "Experiments" bucket, so that query turns up empty. Because Stackdriver responds with no value, instead of an empty array, this would error when trying to call `.map`. This initializes the field to an empty array.