### PR TITLE
[error-issue] Cache error list API requests in Stackdriver interface

### DIFF
--- a/error-issue/app.yaml
+++ b/error-issue/app.yaml
@@ -1,2 +1,6 @@
 runtime: nodejs
 env: flexible
+
+automatic_scaling:
+  min_num_instances: 1
+  max_num_instances: 1

--- a/error-issue/package-lock.json
+++ b/error-issue/package-lock.json
@@ -896,11 +896,6 @@
         }
       }
     },
-    "@probot/serverless-gcf": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@probot/serverless-gcf/-/serverless-gcf-0.2.0.tgz",
-      "integrity": "sha512-TvrWIjo55ZF3QVaAtgsI2TtC9jGSR85jCXaB5yL6dTP9HfvFu9LS9tfvaqoDbdH17As9JAByeWnBN/tv7GucVQ=="
-    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -2012,6 +2007,11 @@
           }
         }
       }
+    },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "clone-response": {
       "version": "1.0.2",
@@ -5031,6 +5031,14 @@
         "lodash": "^4.17.13",
         "mkdirp": "^0.5.0",
         "propagate": "^2.0.0"
+      }
+    },
+    "node-cache": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.0.tgz",
+      "integrity": "sha512-gFQwYdoOztBuPlwg6DKQEf50G+gkK69aqLnw4djkmlHCzeVrLJfwvg9xl4RCAGviTIMUVoqcyoZ/V/wPEu/VVg==",
+      "requires": {
+        "clone": "2.x"
       }
     },
     "node-fetch": {

--- a/error-issue/package.json
+++ b/error-issue/package.json
@@ -33,6 +33,7 @@
     "google-auth-library": "6.0.0",
     "http-status-codes": "1.4.0",
     "mustache": "4.0.1",
+    "node-cache": "5.1.0",
     "node-fetch": "2.6.0",
     "querystring": "0.2.0"
   },

--- a/error-issue/src/stackdriver_api.ts
+++ b/error-issue/src/stackdriver_api.ts
@@ -22,11 +22,12 @@ import NodeCache from 'node-cache';
 const SERVICE = 'https://clouderrorreporting.googleapis.com';
 const SECONDS_IN_HOUR = 60 * 60;
 const SECONDS_IN_DAY = SECONDS_IN_HOUR * 24;
+const CACHE_TTL = SECONDS_IN_HOUR;
 const GAUTH_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
 
 export class StackdriverApi {
   private auth = new GoogleAuth({scopes: GAUTH_SCOPE});
-  private cache = new NodeCache({stdTTL: SECONDS_IN_HOUR});
+  private cache = new NodeCache({stdTTL: CACHE_TTL});
 
   constructor(private projectId: string) {}
 


### PR DESCRIPTION
Adds a 1-hour cache to the API requests listing error groups. Allows users to quickly jump between different buckets (Production, 1%, Nightly, etc.) without re-issuing API queries each time.