### PR TITLE
[bundle-size] Change type of report_markdown from string to text

### DIFF
--- a/bundle-size/setup-db.js
+++ b/bundle-size/setup-db.js
@@ -34,7 +34,7 @@ function setupDb(db) {
       table.integer('installation_id');
       table.integer('check_run_id');
       table
-        .string('approving_teams')
+        .text('approving_teams')
         .comment(
           'Comma separated list of teams to that can approve a bundle-size increase, in the format `ampproject/wg-runtime,ampproject/wg-performance`'
         );


### PR DESCRIPTION
`table.string` produces a `varchar(255)` column, whereas `table.text` produces a `text` column. We need `text` for the markdown field, in case it's longer than 255 characters.

* https://www.postgresql.org/docs/9.5/datatype-character.html
* http://knexjs.org/#Schema-text