### PR TITLE
[error-monitoring] Flush Stackdriver cache when triggering updates

### DIFF
--- a/error-monitoring/src/stackdriver_api.ts
+++ b/error-monitoring/src/stackdriver_api.ts
@@ -146,6 +146,7 @@ export class StackdriverApi {
     console.info(
       `Updating tracking issue for error group "${groupId}" to "${issueUrl}"`
     );
+    this.cache.flushAll();
     return this.request(`groups/${groupId}`, 'PUT', {
       trackingIssues: [{url: issueUrl}],
     }) as Promise<Stackdriver.ErrorGroup>;


### PR DESCRIPTION
Because of the caching, the list doesn't know to refresh when an issue gets created. This PR causes the Stackdriver interface to flush its cache whenever it updates an error group.