### PR TITLE
[error-monitoring] Use `associatedPullRequests` field in GraphQL query

### DIFF
--- a/error-monitoring/src/blame_finder.ts
+++ b/error-monitoring/src/blame_finder.ts
@@ -21,7 +21,7 @@ import {
   StackFrame,
 } from 'error-monitoring';
 import {RateLimitedGraphQL} from './rate_limited_graphql';
-import {parsePrNumber, parseStacktrace} from './utils';
+import {parseStacktrace} from './utils';
 
 /**
  * Service for looking up Git blame info for lines in a stacktrace.
@@ -63,7 +63,9 @@ export class BlameFinder {
                       commit {
                         changedFiles
                         committedDate
-                        messageHeadline
+                        associatedPullRequests(first: 1) {
+                          nodes { number }
+                        }
                         author {
                           name
                           user { login }
@@ -101,7 +103,7 @@ export class BlameFinder {
           : commit.author.name,
         committedDate: new Date(commit.committedDate),
         changedFiles: commit.changedFiles,
-        prNumber: parsePrNumber(commit.messageHeadline),
+        prNumber: (commit.associatedPullRequests.nodes[0] || {}).number,
       })
     ));
   }

--- a/error-monitoring/test/blame_finder.test.ts
+++ b/error-monitoring/test/blame_finder.test.ts
@@ -212,7 +212,7 @@ describe('BlameFinder', () => {
       ]);
     });
 
-    it('ignores commits without an associated GitHub user', async () => {
+    it('uses name for commits without an associated GitHub user', async () => {
       const stacktrace = `Error: Cannot read property 'getBoundingClientRect' of undefined
         at el (https://raw.githubusercontent.com/ampproject/amphtml/2004172112280/extensions/amp-base-carousel/0.1/dimensions.js:58)
         at getDimension (https://raw.githubusercontent.com/ampproject/amphtml/2004172112280/extensions/amp-base-carousel/0.1/dimensions.js:73)
@@ -248,6 +248,24 @@ describe('BlameFinder', () => {
           committedDate: new Date('2019-01-17T22:56:30Z'),
           changedFiles: 2,
           prNumber: 20389,
+        },
+        {
+          path: 'extensions/amp-base-carousel/0.1/dimensions.js',
+          startingLine: 87,
+          endingLine: 99,
+          author: 'Sepand Parhami',
+          committedDate: new Date('2019-11-07T20:28:53Z'),
+          changedFiles: 5,
+          prNumber: 24944,
+        },
+        {
+          path: 'extensions/amp-base-carousel/0.1/dimensions.js',
+          startingLine: 138,
+          endingLine: 158,
+          author: 'Sepand Parhami',
+          committedDate: new Date('2019-11-07T20:28:53Z'),
+          changedFiles: 5,
+          prNumber: 24944,
         },
       ]);
     });

--- a/error-monitoring/test/fixtures/2004030010070/extensions-amp-delight-player-0_1-amp-delight-player_js.json
+++ b/error-monitoring/test/fixtures/2004030010070/extensions-amp-delight-player-0_1-amp-delight-player_js.json
@@ -9,7 +9,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -23,7 +29,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2020-03-02T20:11:30Z",
-                  "messageHeadline": "✨amp-delight-player: Additional analytics support (#26631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -37,7 +49,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -51,7 +69,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2019-02-20T02:12:43Z",
-                  "messageHeadline": "✨Support <amp-delight-player dock> (#20913)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20913
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -65,7 +89,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2020-03-02T20:11:30Z",
-                  "messageHeadline": "✨amp-delight-player: Additional analytics support (#26631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -79,7 +109,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -93,7 +129,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2019-02-20T02:12:43Z",
-                  "messageHeadline": "✨Support <amp-delight-player dock> (#20913)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20913
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -107,7 +149,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -121,7 +169,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -135,7 +189,13 @@
                 "commit": {
                   "changedFiles": 184,
                   "committedDate": "2018-12-22T19:35:29Z",
-                  "messageHeadline": "Migrate user().assert to userAssert (#20047)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20047
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -149,7 +209,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -163,7 +229,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2020-03-02T20:11:30Z",
-                  "messageHeadline": "✨amp-delight-player: Additional analytics support (#26631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -177,7 +249,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -191,7 +269,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2020-03-02T20:11:30Z",
-                  "messageHeadline": "✨amp-delight-player: Additional analytics support (#26631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -205,7 +289,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -219,7 +309,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2020-03-02T20:11:30Z",
-                  "messageHeadline": "✨amp-delight-player: Additional analytics support (#26631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -233,7 +329,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -247,7 +349,13 @@
                 "commit": {
                   "changedFiles": 75,
                   "committedDate": "2019-11-27T00:43:38Z",
-                  "messageHeadline": "Remove per-element Preconnect wrapper class (#25769)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25769
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -261,7 +369,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -275,7 +389,13 @@
                 "commit": {
                   "changedFiles": 184,
                   "committedDate": "2018-12-22T19:35:29Z",
-                  "messageHeadline": "Migrate user().assert to userAssert (#20047)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20047
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -289,7 +409,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -303,7 +429,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -317,7 +449,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2019-02-20T02:12:43Z",
-                  "messageHeadline": "✨Support <amp-delight-player dock> (#20913)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20913
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -331,7 +469,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -345,7 +489,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2019-02-20T02:12:43Z",
-                  "messageHeadline": "✨Support <amp-delight-player dock> (#20913)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20913
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -359,7 +509,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -373,7 +529,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2019-02-20T02:12:43Z",
-                  "messageHeadline": "✨Support <amp-delight-player dock> (#20913)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20913
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -387,7 +549,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -401,7 +569,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2019-02-20T02:12:43Z",
-                  "messageHeadline": "✨Support <amp-delight-player dock> (#20913)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20913
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -415,7 +589,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -429,7 +609,13 @@
                 "commit": {
                   "changedFiles": 244,
                   "committedDate": "2019-04-10T19:16:07Z",
-                  "messageHeadline": "✨🏗 Upgrade closure compiler to v20190301 (#21618)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21618
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -443,7 +629,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -457,7 +649,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2020-03-02T20:11:30Z",
-                  "messageHeadline": "✨amp-delight-player: Additional analytics support (#26631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -471,7 +669,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -485,7 +689,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2020-03-02T20:11:30Z",
-                  "messageHeadline": "✨amp-delight-player: Additional analytics support (#26631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -499,7 +709,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -513,7 +729,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2020-03-02T20:11:30Z",
-                  "messageHeadline": "✨amp-delight-player: Additional analytics support (#26631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -527,7 +749,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -541,7 +769,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -555,7 +789,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -569,7 +809,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2020-03-02T20:11:30Z",
-                  "messageHeadline": "✨amp-delight-player: Additional analytics support (#26631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -583,7 +829,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -597,7 +849,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2020-03-02T20:11:30Z",
-                  "messageHeadline": "✨amp-delight-player: Additional analytics support (#26631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -611,7 +869,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -625,7 +889,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -639,7 +909,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -653,7 +929,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -667,7 +949,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -681,7 +969,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -695,7 +989,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -709,7 +1009,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -723,7 +1029,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -737,7 +1049,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -751,7 +1069,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -765,7 +1089,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -779,7 +1109,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -793,7 +1129,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -807,7 +1149,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -821,7 +1169,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -835,7 +1189,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -849,7 +1209,13 @@
                 "commit": {
                   "changedFiles": 244,
                   "committedDate": "2019-04-10T19:16:07Z",
-                  "messageHeadline": "✨🏗 Upgrade closure compiler to v20190301 (#21618)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21618
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -863,7 +1229,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -877,7 +1249,13 @@
                 "commit": {
                   "changedFiles": 19,
                   "committedDate": "2019-01-03T21:41:46Z",
-                  "messageHeadline": "🏗✨ Add boilerplate for video `seekTo`, implement for `amp-video` (#19…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19893
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -891,7 +1269,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2020-03-02T20:11:30Z",
-                  "messageHeadline": "✨amp-delight-player: Additional analytics support (#26631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"
@@ -905,7 +1289,13 @@
                 "commit": {
                   "changedFiles": 19,
                   "committedDate": "2019-01-03T21:41:46Z",
-                  "messageHeadline": "🏗✨ Add boilerplate for video `seekTo`, implement for `amp-video` (#19…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19893
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -919,7 +1309,13 @@
                 "commit": {
                   "changedFiles": 15,
                   "committedDate": "2018-11-12T21:22:43Z",
-                  "messageHeadline": "✨ amp-delight-player (#17939)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 17939
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "xymw"

--- a/error-monitoring/test/fixtures/2004030010070/extensions-amp-next-page-1_0-service_js.json
+++ b/error-monitoring/test/fixtures/2004030010070/extensions-amp-next-page-1_0-service_js.json
@@ -9,7 +9,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -23,7 +29,13 @@
                 "commit": {
                   "changedFiles": 20,
                   "committedDate": "2020-01-14T19:35:00Z",
-                  "messageHeadline": "♻️ Rename amp-next-page 0.2 -> 1.0 (#26100)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26100
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -37,7 +49,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2020-01-28T01:23:37Z",
-                  "messageHeadline": "♻️<amp-next-page> v2 minor renaming and fixes (#26468)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26468
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -51,7 +69,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -65,7 +89,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -79,7 +109,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -93,7 +129,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -107,7 +149,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -121,7 +169,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-31T22:17:09Z",
-                  "messageHeadline": "✨ <amp-next-page> v2 default and templated separator elements (#26413)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26413
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -135,7 +189,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -149,7 +209,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -163,7 +229,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -177,7 +249,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -191,7 +269,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -205,7 +289,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -219,7 +309,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -233,7 +329,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -247,7 +349,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -261,7 +369,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -275,7 +389,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -289,7 +409,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -303,7 +429,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-12-19T21:05:38Z",
-                  "messageHeadline": "♻️ Refactors visibility observing in amp-next-page v2 (#26032)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26032
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -317,7 +449,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -331,7 +469,13 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2020-01-13T21:05:56Z",
-                  "messageHeadline": "`amp-next-page-v2`: better manual tests (#26099)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26099
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -345,7 +489,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -359,7 +509,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -373,7 +529,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -387,7 +549,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -401,7 +569,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-12-19T21:05:38Z",
-                  "messageHeadline": "♻️ Refactors visibility observing in amp-next-page v2 (#26032)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26032
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -415,7 +589,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -429,7 +609,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -443,7 +629,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -457,7 +649,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -471,7 +669,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-31T22:17:09Z",
-                  "messageHeadline": "✨ <amp-next-page> v2 default and templated separator elements (#26413)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26413
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -485,7 +689,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -499,7 +709,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -513,7 +729,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -527,7 +749,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -541,7 +769,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -555,7 +789,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -569,7 +809,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -583,7 +829,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -597,7 +849,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-12-19T21:05:38Z",
-                  "messageHeadline": "♻️ Refactors visibility observing in amp-next-page v2 (#26032)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26032
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -611,7 +869,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -625,7 +889,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -639,7 +909,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -653,7 +929,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -667,7 +949,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -681,7 +969,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -695,7 +989,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -709,7 +1009,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -723,7 +1029,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -737,7 +1049,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -751,7 +1069,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -765,7 +1089,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -779,7 +1109,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -793,7 +1129,13 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2020-01-13T21:05:56Z",
-                  "messageHeadline": "`amp-next-page-v2`: better manual tests (#26099)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26099
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -807,7 +1149,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -821,7 +1169,13 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2020-01-13T21:05:56Z",
-                  "messageHeadline": "`amp-next-page-v2`: better manual tests (#26099)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26099
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -835,7 +1189,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -849,7 +1209,13 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2020-01-13T21:05:56Z",
-                  "messageHeadline": "`amp-next-page-v2`: better manual tests (#26099)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26099
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -863,7 +1229,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -877,7 +1249,13 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2020-01-13T21:05:56Z",
-                  "messageHeadline": "`amp-next-page-v2`: better manual tests (#26099)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26099
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -891,7 +1269,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -905,7 +1289,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -919,7 +1309,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -933,7 +1329,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -947,7 +1349,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -961,7 +1369,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -975,7 +1389,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-12-19T21:05:38Z",
-                  "messageHeadline": "♻️ Refactors visibility observing in amp-next-page v2 (#26032)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26032
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -989,7 +1409,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1003,7 +1429,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1017,7 +1449,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1031,7 +1469,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1045,7 +1489,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1059,7 +1509,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1073,7 +1529,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1087,7 +1549,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1101,7 +1569,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1115,7 +1589,13 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2020-01-13T21:05:56Z",
-                  "messageHeadline": "`amp-next-page-v2`: better manual tests (#26099)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26099
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1129,7 +1609,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1143,7 +1629,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1157,7 +1649,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1171,7 +1669,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1185,7 +1689,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1199,7 +1709,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1213,7 +1729,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1227,7 +1749,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1241,7 +1769,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-01-11T10:42:25Z",
-                  "messageHeadline": "✅ Implements unit test for `amp-next-page` v2 (#26269)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26269
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1255,7 +1789,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1269,7 +1809,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1283,7 +1829,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1297,7 +1849,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1311,7 +1869,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-01-11T10:42:25Z",
-                  "messageHeadline": "✅ Implements unit test for `amp-next-page` v2 (#26269)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26269
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1325,7 +1889,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1339,7 +1909,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1353,7 +1929,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1367,7 +1949,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1381,7 +1969,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1395,7 +1989,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1409,7 +2009,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1423,7 +2029,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1437,7 +2049,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1451,7 +2069,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1465,7 +2089,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1479,7 +2109,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1493,7 +2129,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1507,7 +2149,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1521,7 +2169,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1535,7 +2189,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1549,7 +2209,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1563,7 +2229,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1577,7 +2249,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1591,7 +2269,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1605,7 +2289,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1619,7 +2309,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1633,7 +2329,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1647,7 +2349,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1661,7 +2369,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1675,7 +2389,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1689,7 +2409,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1703,7 +2429,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1717,7 +2449,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1731,7 +2469,13 @@
                 "commit": {
                   "changedFiles": 3,
                   "committedDate": "2020-01-21T18:11:03Z",
-                  "messageHeadline": "Implements unit tests for hidden elements (#26389)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26389
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1745,7 +2489,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1759,7 +2509,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1773,7 +2529,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-12-19T21:05:38Z",
-                  "messageHeadline": "♻️ Refactors visibility observing in amp-next-page v2 (#26032)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26032
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1787,7 +2549,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1801,7 +2569,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-12-19T21:05:38Z",
-                  "messageHeadline": "♻️ Refactors visibility observing in amp-next-page v2 (#26032)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26032
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1815,7 +2589,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1829,7 +2609,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1843,7 +2629,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1857,7 +2649,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-12-19T21:05:38Z",
-                  "messageHeadline": "♻️ Refactors visibility observing in amp-next-page v2 (#26032)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26032
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1871,7 +2669,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1885,7 +2689,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-12-19T21:05:38Z",
-                  "messageHeadline": "♻️ Refactors visibility observing in amp-next-page v2 (#26032)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26032
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1899,7 +2709,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1913,7 +2729,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1927,7 +2749,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1941,7 +2769,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1955,7 +2789,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1969,7 +2809,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1983,7 +2829,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -1997,7 +2849,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2011,7 +2869,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2025,7 +2889,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2039,7 +2909,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2053,7 +2929,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2067,7 +2949,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2081,7 +2969,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2095,7 +2989,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2109,7 +3009,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2123,7 +3029,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2137,7 +3049,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2151,7 +3069,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2165,7 +3089,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2179,7 +3109,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2193,7 +3129,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2207,7 +3149,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2221,7 +3169,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2235,7 +3189,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2249,7 +3209,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2263,7 +3229,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2277,7 +3249,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2291,7 +3269,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2305,7 +3289,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2319,7 +3309,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2333,7 +3329,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2347,7 +3349,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T00:31:50Z",
-                  "messageHeadline": "✨amp-next-page v2 history manipulation (#25971)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25971
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2361,7 +3369,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2375,7 +3389,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2389,7 +3409,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2403,7 +3429,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2417,7 +3449,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2431,7 +3469,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2445,7 +3489,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2459,7 +3509,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2473,7 +3529,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2487,7 +3549,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-31T22:17:09Z",
-                  "messageHeadline": "✨ <amp-next-page> v2 default and templated separator elements (#26413)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26413
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2501,7 +3569,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2515,7 +3589,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2529,7 +3609,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2543,7 +3629,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2557,7 +3649,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2571,7 +3669,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2585,7 +3689,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2599,7 +3709,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2613,7 +3729,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2020-01-28T01:23:37Z",
-                  "messageHeadline": "♻️<amp-next-page> v2 minor renaming and fixes (#26468)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26468
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2627,7 +3749,13 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2020-01-13T21:05:56Z",
-                  "messageHeadline": "`amp-next-page-v2`: better manual tests (#26099)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26099
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2641,7 +3769,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2655,7 +3789,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2669,7 +3809,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2683,7 +3829,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2697,7 +3849,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2711,7 +3869,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2725,7 +3889,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2739,7 +3909,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2753,7 +3929,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2767,7 +3949,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2781,7 +3969,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2795,7 +3989,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2809,7 +4009,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2823,7 +4029,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2837,7 +4049,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2851,7 +4069,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2865,7 +4089,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2879,7 +4109,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2893,7 +4129,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2907,7 +4149,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2921,7 +4169,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2935,7 +4189,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2949,7 +4209,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2963,7 +4229,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2977,7 +4249,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -2991,7 +4269,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3005,7 +4289,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3019,7 +4309,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3033,7 +4329,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3047,7 +4349,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3061,7 +4369,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2020-01-28T01:23:37Z",
-                  "messageHeadline": "♻️<amp-next-page> v2 minor renaming and fixes (#26468)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26468
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3075,7 +4389,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3089,7 +4409,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2020-01-28T01:23:37Z",
-                  "messageHeadline": "♻️<amp-next-page> v2 minor renaming and fixes (#26468)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26468
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3103,7 +4429,13 @@
                 "commit": {
                   "changedFiles": 3,
                   "committedDate": "2020-01-21T18:11:03Z",
-                  "messageHeadline": "Implements unit tests for hidden elements (#26389)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26389
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3117,7 +4449,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3131,7 +4469,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2020-01-28T01:23:37Z",
-                  "messageHeadline": "♻️<amp-next-page> v2 minor renaming and fixes (#26468)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26468
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3145,7 +4489,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3159,7 +4509,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2020-01-28T01:23:37Z",
-                  "messageHeadline": "♻️<amp-next-page> v2 minor renaming and fixes (#26468)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26468
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3173,7 +4529,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3187,7 +4549,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2020-01-28T01:23:37Z",
-                  "messageHeadline": "♻️<amp-next-page> v2 minor renaming and fixes (#26468)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26468
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3201,7 +4569,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3215,7 +4589,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2020-01-28T01:23:37Z",
-                  "messageHeadline": "♻️<amp-next-page> v2 minor renaming and fixes (#26468)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26468
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3229,7 +4609,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3243,7 +4629,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2020-01-28T01:23:37Z",
-                  "messageHeadline": "♻️<amp-next-page> v2 minor renaming and fixes (#26468)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26468
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3257,7 +4649,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3271,7 +4669,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2020-01-28T01:23:37Z",
-                  "messageHeadline": "♻️<amp-next-page> v2 minor renaming and fixes (#26468)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26468
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3285,7 +4689,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3299,7 +4709,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3313,7 +4729,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3327,7 +4749,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3341,7 +4769,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3355,7 +4789,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2020-01-13T19:55:12Z",
-                  "messageHeadline": "✨Handling sticky, fixed and hidden elements in `amp-next-page` v2 (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26106
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3369,7 +4809,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3383,7 +4829,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3397,7 +4849,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3411,7 +4869,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-31T22:17:09Z",
-                  "messageHeadline": "✨ <amp-next-page> v2 default and templated separator elements (#26413)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26413
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3425,7 +4889,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3439,7 +4909,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3453,7 +4929,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3467,7 +4949,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3481,7 +4969,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3495,7 +4989,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3509,7 +5009,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3523,7 +5029,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3537,7 +5049,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3551,7 +5069,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3565,7 +5089,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3579,7 +5109,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3593,7 +5129,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-23T17:05:42Z",
-                  "messageHeadline": "✨Implement infinite article loading on `amp-next-page` v2 (#26296)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26296
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3607,7 +5149,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3621,7 +5169,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3635,7 +5189,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3649,7 +5209,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3663,7 +5229,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3677,7 +5249,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3691,7 +5269,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3705,7 +5289,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3719,7 +5309,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3733,7 +5329,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3747,7 +5349,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3761,7 +5369,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3775,7 +5389,13 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2020-01-13T21:05:56Z",
-                  "messageHeadline": "`amp-next-page-v2`: better manual tests (#26099)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26099
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3789,7 +5409,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3803,7 +5429,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3817,7 +5449,13 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2020-01-13T21:05:56Z",
-                  "messageHeadline": "`amp-next-page-v2`: better manual tests (#26099)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26099
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3831,7 +5469,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3845,7 +5489,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3859,7 +5509,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3873,7 +5529,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-31T22:17:09Z",
-                  "messageHeadline": "✨ <amp-next-page> v2 default and templated separator elements (#26413)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26413
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3887,7 +5549,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3901,7 +5569,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3915,7 +5589,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-31T22:17:09Z",
-                  "messageHeadline": "✨ <amp-next-page> v2 default and templated separator elements (#26413)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26413
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3929,7 +5609,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3943,7 +5629,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-31T22:17:09Z",
-                  "messageHeadline": "✨ <amp-next-page> v2 default and templated separator elements (#26413)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26413
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3957,7 +5649,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3971,7 +5669,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3985,7 +5689,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -3999,7 +5709,13 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2020-01-13T21:05:56Z",
-                  "messageHeadline": "`amp-next-page-v2`: better manual tests (#26099)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26099
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4013,7 +5729,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4027,7 +5749,13 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2020-01-13T21:05:56Z",
-                  "messageHeadline": "`amp-next-page-v2`: better manual tests (#26099)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26099
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4041,7 +5769,13 @@
                 "commit": {
                   "changedFiles": 9,
                   "committedDate": "2020-01-28T01:23:37Z",
-                  "messageHeadline": "♻️<amp-next-page> v2 minor renaming and fixes (#26468)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26468
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4055,7 +5789,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4069,7 +5809,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4083,7 +5829,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4097,7 +5849,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4111,7 +5869,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4125,7 +5889,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4139,7 +5909,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2020-02-03T20:14:04Z",
-                  "messageHeadline": "✨ Remote loading of pages for <amp-next-page> v2 (#26470)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26470
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4153,7 +5929,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-31T22:17:09Z",
-                  "messageHeadline": "✨ <amp-next-page> v2 default and templated separator elements (#26413)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26413
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4167,7 +5949,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4181,7 +5969,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-31T22:17:09Z",
-                  "messageHeadline": "✨ <amp-next-page> v2 default and templated separator elements (#26413)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26413
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4195,7 +5989,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4209,7 +6009,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4223,7 +6029,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-31T22:17:09Z",
-                  "messageHeadline": "✨ <amp-next-page> v2 default and templated separator elements (#26413)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26413
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4237,7 +6049,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4251,7 +6069,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-31T22:17:09Z",
-                  "messageHeadline": "✨ <amp-next-page> v2 default and templated separator elements (#26413)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26413
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4265,7 +6089,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4279,7 +6109,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-31T22:17:09Z",
-                  "messageHeadline": "✨ <amp-next-page> v2 default and templated separator elements (#26413)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26413
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4293,7 +6129,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4307,7 +6149,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-01-31T22:17:09Z",
-                  "messageHeadline": "✨ <amp-next-page> v2 default and templated separator elements (#26413)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26413
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4321,7 +6169,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4335,7 +6189,13 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2020-01-13T21:05:56Z",
-                  "messageHeadline": "`amp-next-page-v2`: better manual tests (#26099)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26099
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4349,7 +6209,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4363,7 +6229,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4377,7 +6249,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4391,7 +6269,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4405,7 +6289,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4419,7 +6309,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4433,7 +6329,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4447,7 +6349,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4461,7 +6369,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4475,7 +6389,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4489,7 +6409,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4503,7 +6429,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4517,7 +6449,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4531,7 +6469,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4545,7 +6489,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4559,7 +6509,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4573,7 +6529,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4587,7 +6549,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4601,7 +6569,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4615,7 +6589,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4629,7 +6609,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4643,7 +6629,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4657,7 +6649,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4671,7 +6669,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4685,7 +6689,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4699,7 +6709,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4713,7 +6729,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4727,7 +6749,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4741,7 +6769,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4755,7 +6789,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4769,7 +6809,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4783,7 +6829,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4797,7 +6849,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4811,7 +6869,13 @@
                 "commit": {
                   "changedFiles": 24,
                   "committedDate": "2020-02-28T23:59:08Z",
-                  "messageHeadline": "📖<amp-next-page> documentation and validation (#26841)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26841
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4825,7 +6889,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2020-02-11T21:16:02Z",
-                  "messageHeadline": "✨<amp-next-page> v2 default and templated footers (more articles box)…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26610
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -4839,7 +6909,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2019-12-10T07:48:41Z",
-                  "messageHeadline": "✨ Initial implementation of amp-next-page v2 (#25636)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25636
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"

--- a/error-monitoring/test/fixtures/2004030010070/src-event-helper-listen_js.json
+++ b/error-monitoring/test/fixtures/2004030010070/src-event-helper-listen_js.json
@@ -9,7 +9,13 @@
                 "commit": {
                   "changedFiles": 16,
                   "committedDate": "2017-03-23T18:19:12Z",
-                  "messageHeadline": "Refactor AmpContext dependencies for building (#8258)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 8258
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -23,7 +29,13 @@
                 "commit": {
                   "changedFiles": 340,
                   "committedDate": "2017-12-13T23:56:40Z",
-                  "messageHeadline": "Update gulp-eslint version to 4.0 (#12450)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 12450
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -37,7 +49,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -51,7 +69,13 @@
                 "commit": {
                   "changedFiles": 340,
                   "committedDate": "2017-12-13T23:56:40Z",
-                  "messageHeadline": "Update gulp-eslint version to 4.0 (#12450)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 12450
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -65,7 +89,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-18T00:33:03Z",
-                  "messageHeadline": "Passive event listener wrapper (#10721)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10721
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -79,7 +109,13 @@
                 "commit": {
                   "changedFiles": 3,
                   "committedDate": "2020-03-05T19:57:00Z",
-                  "messageHeadline": "Use { passive: true } on gesture.js (#26876)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26876
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -93,7 +129,13 @@
                 "commit": {
                   "changedFiles": 16,
                   "committedDate": "2017-03-23T18:19:12Z",
-                  "messageHeadline": "Refactor AmpContext dependencies for building (#8258)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 8258
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -107,7 +149,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-18T00:33:03Z",
-                  "messageHeadline": "Passive event listener wrapper (#10721)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10721
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -121,7 +169,13 @@
                 "commit": {
                   "changedFiles": 16,
                   "committedDate": "2017-03-23T18:19:12Z",
-                  "messageHeadline": "Refactor AmpContext dependencies for building (#8258)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 8258
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -135,7 +189,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -149,7 +209,13 @@
                 "commit": {
                   "changedFiles": 340,
                   "committedDate": "2017-12-13T23:56:40Z",
-                  "messageHeadline": "Update gulp-eslint version to 4.0 (#12450)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 12450
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -163,7 +229,13 @@
                 "commit": {
                   "changedFiles": 44,
                   "committedDate": "2018-06-26T20:32:15Z",
-                  "messageHeadline": "Fixing jsdocs in `src` folder (#16312)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16312
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "prateekbh"
@@ -177,7 +249,13 @@
                 "commit": {
                   "changedFiles": 340,
                   "committedDate": "2017-12-13T23:56:40Z",
-                  "messageHeadline": "Update gulp-eslint version to 4.0 (#12450)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 12450
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -191,7 +269,13 @@
                 "commit": {
                   "changedFiles": 37,
                   "committedDate": "2019-08-20T17:49:44Z",
-                  "messageHeadline": "Prefix more AMP window globals (#24054)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24054
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -205,7 +289,13 @@
                 "commit": {
                   "changedFiles": 340,
                   "committedDate": "2017-12-13T23:56:40Z",
-                  "messageHeadline": "Update gulp-eslint version to 4.0 (#12450)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 12450
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -219,7 +309,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -233,7 +329,13 @@
                 "commit": {
                   "changedFiles": 340,
                   "committedDate": "2017-12-13T23:56:40Z",
-                  "messageHeadline": "Update gulp-eslint version to 4.0 (#12450)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 12450
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -247,7 +349,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -261,7 +369,13 @@
                 "commit": {
                   "changedFiles": 340,
                   "committedDate": "2017-12-13T23:56:40Z",
-                  "messageHeadline": "Update gulp-eslint version to 4.0 (#12450)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 12450
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -275,7 +389,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-18T00:33:03Z",
-                  "messageHeadline": "Passive event listener wrapper (#10721)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10721
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -289,7 +409,13 @@
                 "commit": {
                   "changedFiles": 340,
                   "committedDate": "2017-12-13T23:56:40Z",
-                  "messageHeadline": "Update gulp-eslint version to 4.0 (#12450)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 12450
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -303,7 +429,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-18T00:33:03Z",
-                  "messageHeadline": "Passive event listener wrapper (#10721)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10721
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -317,7 +449,13 @@
                 "commit": {
                   "changedFiles": 340,
                   "committedDate": "2017-12-13T23:56:40Z",
-                  "messageHeadline": "Update gulp-eslint version to 4.0 (#12450)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 12450
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -331,7 +469,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-18T00:33:03Z",
-                  "messageHeadline": "Passive event listener wrapper (#10721)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10721
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "wassgha"
@@ -345,7 +489,13 @@
                 "commit": {
                   "changedFiles": 340,
                   "committedDate": "2017-12-13T23:56:40Z",
-                  "messageHeadline": "Update gulp-eslint version to 4.0 (#12450)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 12450
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -359,7 +509,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -373,7 +529,13 @@
                 "commit": {
                   "changedFiles": 340,
                   "committedDate": "2017-12-13T23:56:40Z",
-                  "messageHeadline": "Update gulp-eslint version to 4.0 (#12450)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 12450
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -387,7 +549,13 @@
                 "commit": {
                   "changedFiles": 3,
                   "committedDate": "2020-03-05T19:57:00Z",
-                  "messageHeadline": "Use { passive: true } on gesture.js (#26876)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26876
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"

--- a/error-monitoring/test/fixtures/2004172112280/extensions-amp-base-carousel-0_1-dimensions_js.json
+++ b/error-monitoring/test/fixtures/2004172112280/extensions-amp-base-carousel-0_1-dimensions_js.json
@@ -9,7 +9,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2019-01-10T20:42:35Z",
-                  "messageHeadline": "✨Initial skeleton of amp-carousel v2. (#20228)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20228
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -22,7 +28,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-01-22T21:07:37Z",
-                  "messageHeadline": "Additional logic for carousel v2. (#20439)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20439
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -35,7 +47,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2019-03-05T18:40:35Z",
-                  "messageHeadline": "Make changes to support `<amp-inline-gallery>`. (#21194)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21194
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -48,7 +66,13 @@
                 "commit": {
                   "changedFiles": 3,
                   "committedDate": "2019-01-16T22:58:16Z",
-                  "messageHeadline": "Carousel v2: add logic for spacers for looping. (#20293)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20293
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -61,7 +85,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2019-01-10T20:42:35Z",
-                  "messageHeadline": "✨Initial skeleton of amp-carousel v2. (#20228)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20228
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -74,7 +104,13 @@
                 "commit": {
                   "changedFiles": 3,
                   "committedDate": "2019-01-16T22:58:16Z",
-                  "messageHeadline": "Carousel v2: add logic for spacers for looping. (#20293)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20293
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -87,7 +123,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Raghu Simha",
                     "user": {
@@ -102,7 +144,13 @@
                 "commit": {
                   "changedFiles": 3,
                   "committedDate": "2019-01-16T22:58:16Z",
-                  "messageHeadline": "Carousel v2: add logic for spacers for looping. (#20293)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20293
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -115,7 +163,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-01-17T22:56:30Z",
-                  "messageHeadline": "Add additional carousel v2 logic. (#20389)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20389
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -128,7 +182,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-11-07T20:28:53Z",
-                  "messageHeadline": "🐛♻️Refactor, changes to amp-base-carousel for amp-inline-gallery. (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24944
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -141,7 +201,13 @@
                 "commit": {
                   "changedFiles": 3,
                   "committedDate": "2019-01-16T22:58:16Z",
-                  "messageHeadline": "Carousel v2: add logic for spacers for looping. (#20293)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20293
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -154,7 +220,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-01-17T22:56:30Z",
-                  "messageHeadline": "Add additional carousel v2 logic. (#20389)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20389
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -167,7 +239,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-01-22T21:07:37Z",
-                  "messageHeadline": "Additional logic for carousel v2. (#20439)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20439
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -180,7 +258,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2019-03-05T18:40:35Z",
-                  "messageHeadline": "Make changes to support `<amp-inline-gallery>`. (#21194)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21194
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -193,7 +277,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-01-22T21:07:37Z",
-                  "messageHeadline": "Additional logic for carousel v2. (#20439)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20439
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -206,7 +296,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-11-07T20:28:53Z",
-                  "messageHeadline": "🐛♻️Refactor, changes to amp-base-carousel for amp-inline-gallery. (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24944
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -219,7 +315,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-01-22T21:07:37Z",
-                  "messageHeadline": "Additional logic for carousel v2. (#20439)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20439
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -232,7 +334,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Raghu Simha",
                     "user": {
@@ -247,7 +355,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-11-07T20:28:53Z",
-                  "messageHeadline": "🐛♻️Refactor, changes to amp-base-carousel for amp-inline-gallery. (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24944
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -260,7 +374,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-01-22T21:07:37Z",
-                  "messageHeadline": "Additional logic for carousel v2. (#20439)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20439
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -273,7 +393,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-11-07T20:28:53Z",
-                  "messageHeadline": "🐛♻️Refactor, changes to amp-base-carousel for amp-inline-gallery. (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24944
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -286,7 +412,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-01-22T21:07:37Z",
-                  "messageHeadline": "Additional logic for carousel v2. (#20439)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20439
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -299,7 +431,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-01-17T22:56:30Z",
-                  "messageHeadline": "Add additional carousel v2 logic. (#20389)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20389
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -312,7 +450,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Raghu Simha",
                     "user": {
@@ -327,7 +471,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-01-17T22:56:30Z",
-                  "messageHeadline": "Add additional carousel v2 logic. (#20389)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20389
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -340,7 +490,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Raghu Simha",
                     "user": {
@@ -355,7 +511,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-01-17T22:56:30Z",
-                  "messageHeadline": "Add additional carousel v2 logic. (#20389)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20389
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -368,7 +530,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Raghu Simha",
                     "user": {
@@ -383,7 +551,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-01-17T22:56:30Z",
-                  "messageHeadline": "Add additional carousel v2 logic. (#20389)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20389
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -396,7 +570,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Raghu Simha",
                     "user": {
@@ -411,7 +591,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-01-17T22:56:30Z",
-                  "messageHeadline": "Add additional carousel v2 logic. (#20389)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20389
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -424,7 +610,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-11-07T20:28:53Z",
-                  "messageHeadline": "🐛♻️Refactor, changes to amp-base-carousel for amp-inline-gallery. (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24944
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -437,7 +629,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-01-17T22:56:30Z",
-                  "messageHeadline": "Add additional carousel v2 logic. (#20389)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20389
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -450,7 +648,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-11-07T20:28:53Z",
-                  "messageHeadline": "🐛♻️Refactor, changes to amp-base-carousel for amp-inline-gallery. (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24944
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -463,7 +667,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-01-17T22:56:30Z",
-                  "messageHeadline": "Add additional carousel v2 logic. (#20389)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20389
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -476,7 +686,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-11-07T20:28:53Z",
-                  "messageHeadline": "🐛♻️Refactor, changes to amp-base-carousel for amp-inline-gallery. (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24944
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -489,7 +705,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-01-17T22:56:30Z",
-                  "messageHeadline": "Add additional carousel v2 logic. (#20389)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20389
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -502,7 +724,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Raghu Simha",
                     "user": {
@@ -517,7 +745,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-11-07T20:28:53Z",
-                  "messageHeadline": "🐛♻️Refactor, changes to amp-base-carousel for amp-inline-gallery. (#2…",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24944
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null
@@ -530,7 +764,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-01-17T22:56:30Z",
-                  "messageHeadline": "Add additional carousel v2 logic. (#20389)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 20389
+                      }
+                    ]
+                  },
                   "author": {
                     "name": "Sepand Parhami",
                     "user": null

--- a/error-monitoring/test/fixtures/master/src-log_js.json
+++ b/error-monitoring/test/fixtures/master/src-log_js.json
@@ -9,7 +9,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -23,7 +25,9 @@
                 "commit": {
                   "changedFiles": 45,
                   "committedDate": "2015-09-21T13:20:30Z",
-                  "messageHeadline": "Make linting functional. Yaihh.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -37,7 +41,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2016-07-26T23:01:54Z",
-                  "messageHeadline": "Stricter enforcement of getMode DCE (#4222)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4222
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -51,7 +61,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -65,7 +81,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-10T14:21:23Z",
-                  "messageHeadline": "Provide a way to turn logging on and off.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -79,7 +97,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -93,7 +113,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-07T22:10:26Z",
-                  "messageHeadline": "Exclude errors generated from A4A iframe (#10562)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10562
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "tiendt"
@@ -107,7 +133,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -121,7 +149,13 @@
                 "commit": {
                   "changedFiles": 39,
                   "committedDate": "2018-06-27T17:56:54Z",
-                  "messageHeadline": "Fix js docs in `ads` and `3p` folder (#16377)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16377
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "prateekbh"
@@ -135,7 +169,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -149,7 +185,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-12-17T22:09:44Z",
-                  "messageHeadline": "Report dev error at viewer channel timeout (#25931)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 25931
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "zhouyx"
@@ -163,7 +205,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-07T22:10:26Z",
-                  "messageHeadline": "Exclude errors generated from A4A iframe (#10562)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10562
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "tiendt"
@@ -177,7 +225,13 @@
                 "commit": {
                   "changedFiles": 39,
                   "committedDate": "2018-06-27T17:56:54Z",
-                  "messageHeadline": "Fix js docs in `ads` and `3p` folder (#16377)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16377
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "prateekbh"
@@ -191,7 +245,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-07T22:10:26Z",
-                  "messageHeadline": "Exclude errors generated from A4A iframe (#10562)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10562
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "tiendt"
@@ -205,7 +265,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -219,7 +281,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2017-02-06T21:29:11Z",
-                  "messageHeadline": "Directly report logged errors instead of relying on rethrowing (#7358)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 7358
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -233,7 +301,13 @@
                 "commit": {
                   "changedFiles": 37,
                   "committedDate": "2019-08-20T17:49:44Z",
-                  "messageHeadline": "Prefix more AMP window globals (#24054)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24054
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -247,7 +321,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2017-02-06T21:29:11Z",
-                  "messageHeadline": "Directly report logged errors instead of relying on rethrowing (#7358)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 7358
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -261,7 +341,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -275,7 +357,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2018-07-06T20:17:01Z",
-                  "messageHeadline": "Better debugging for amp-bind, amp-list (#16494)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16494
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -289,7 +377,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -303,7 +397,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -317,7 +417,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -331,7 +437,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -345,7 +457,13 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2019-09-16T17:51:28Z",
-                  "messageHeadline": "🐛 Message extraction: Fallback on unserialize objects (#24500)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24500
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -359,7 +477,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -373,7 +497,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -387,7 +517,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -401,7 +537,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -415,7 +557,13 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2019-09-16T17:51:28Z",
-                  "messageHeadline": "🐛 Message extraction: Fallback on unserialize objects (#24500)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24500
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -429,7 +577,13 @@
                 "commit": {
                   "changedFiles": 1369,
                   "committedDate": "2020-03-30T23:24:53Z",
-                  "messageHeadline": "📦 Update dependency prettier to v2 (#27350)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 27350
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "renovate-bot"
@@ -443,7 +597,13 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2019-09-16T21:20:29Z",
-                  "messageHeadline": "🐛 Logging message toString() blunder fix (#24549)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24549
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -457,7 +617,13 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2019-09-16T17:51:28Z",
-                  "messageHeadline": "🐛 Message extraction: Fallback on unserialize objects (#24500)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24500
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -471,7 +637,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -485,7 +653,13 @@
                 "commit": {
                   "changedFiles": 123,
                   "committedDate": "2018-05-14T21:56:10Z",
-                  "messageHeadline": "🚮 Restrict comments to 80 columns (exempt JSDoc annotations) (#15247)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 15247
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -499,7 +673,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-10T14:21:23Z",
-                  "messageHeadline": "Provide a way to turn logging on and off.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -513,7 +689,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -527,7 +705,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -541,7 +721,13 @@
                 "commit": {
                   "changedFiles": 123,
                   "committedDate": "2018-05-14T21:56:10Z",
-                  "messageHeadline": "🚮 Restrict comments to 80 columns (exempt JSDoc annotations) (#15247)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 15247
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -555,7 +741,13 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2017-07-28T22:26:36Z",
-                  "messageHeadline": "Update comment on use of suffix in Log class (#10683)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10683
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "tiendt"
@@ -569,7 +761,9 @@
                 "commit": {
                   "changedFiles": 3,
                   "committedDate": "2015-09-03T07:38:47Z",
-                  "messageHeadline": "chore: change `Widnow` typo to `Window`",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -583,7 +777,9 @@
                 "commit": {
                   "changedFiles": 27,
                   "committedDate": "2016-06-10T23:59:21Z",
-                  "messageHeadline": "Fix all type errors in alp.js and turn on testing this on Travis. (#3…",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -597,7 +793,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -611,7 +809,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -625,7 +825,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -639,7 +845,9 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2015-09-04T04:58:32Z",
-                  "messageHeadline": "Fix tests broken by recent resource refactoring.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -653,7 +861,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2016-03-17T03:35:25Z",
-                  "messageHeadline": "fix some const declarations",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -667,7 +877,9 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2015-09-04T04:58:32Z",
-                  "messageHeadline": "Fix tests broken by recent resource refactoring.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -681,7 +893,13 @@
                 "commit": {
                   "changedFiles": 37,
                   "committedDate": "2019-08-20T17:49:44Z",
-                  "messageHeadline": "Prefix more AMP window globals (#24054)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24054
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -695,7 +913,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -709,7 +929,9 @@
                 "commit": {
                   "changedFiles": 27,
                   "committedDate": "2016-06-10T23:59:21Z",
-                  "messageHeadline": "Fix all type errors in alp.js and turn on testing this on Travis. (#3…",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -723,7 +945,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -737,7 +961,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2016-03-17T03:35:25Z",
-                  "messageHeadline": "fix some const declarations",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -751,7 +977,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2018-07-06T20:17:01Z",
-                  "messageHeadline": "Better debugging for amp-bind, amp-list (#16494)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16494
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -765,7 +997,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -779,7 +1013,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -793,7 +1033,13 @@
                 "commit": {
                   "changedFiles": 1369,
                   "committedDate": "2020-03-30T23:24:53Z",
-                  "messageHeadline": "📦 Update dependency prettier to v2 (#27350)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 27350
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "renovate-bot"
@@ -807,7 +1053,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -821,7 +1073,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-10T14:21:23Z",
-                  "messageHeadline": "Provide a way to turn logging on and off.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -835,7 +1089,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -849,7 +1105,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2018-07-06T20:17:01Z",
-                  "messageHeadline": "Better debugging for amp-bind, amp-list (#16494)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16494
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -863,7 +1125,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -877,7 +1145,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2018-07-06T20:17:01Z",
-                  "messageHeadline": "Better debugging for amp-bind, amp-list (#16494)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16494
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -891,7 +1165,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -905,7 +1181,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-10T14:21:23Z",
-                  "messageHeadline": "Provide a way to turn logging on and off.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -919,7 +1197,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -933,7 +1213,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-10T14:21:23Z",
-                  "messageHeadline": "Provide a way to turn logging on and off.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -947,7 +1229,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -961,7 +1245,9 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2016-06-27T18:48:54Z",
-                  "messageHeadline": "replace some props on the object returned by getMode during compile t…",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -975,7 +1261,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -989,7 +1277,9 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2016-01-12T00:13:31Z",
-                  "messageHeadline": "Make our integration tests pass reliably on SauceLabs.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1003,7 +1293,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -1017,7 +1309,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2016-07-06T17:07:13Z",
-                  "messageHeadline": "Optimize functions that showed up in profile. (#3905)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 3905
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1031,7 +1329,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -1045,7 +1345,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-10T14:21:23Z",
-                  "messageHeadline": "Provide a way to turn logging on and off.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1059,7 +1361,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -1073,7 +1377,9 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2016-06-27T18:48:54Z",
-                  "messageHeadline": "replace some props on the object returned by getMode during compile t…",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -1087,7 +1393,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -1101,7 +1409,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-10T14:21:23Z",
-                  "messageHeadline": "Provide a way to turn logging on and off.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1115,7 +1425,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -1129,7 +1441,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2016-07-26T23:01:54Z",
-                  "messageHeadline": "Stricter enforcement of getMode DCE (#4222)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4222
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -1143,7 +1461,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1157,7 +1477,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-04T14:50:08Z",
-                  "messageHeadline": "Allow var args in logging and pass them through right to the console.log",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1171,7 +1493,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1185,7 +1509,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-04T14:50:08Z",
-                  "messageHeadline": "Allow var args in logging and pass them through right to the console.log",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1199,7 +1525,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2018-07-06T20:17:01Z",
-                  "messageHeadline": "Better debugging for amp-bind, amp-list (#16494)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16494
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -1213,7 +1545,9 @@
                 "commit": {
                   "changedFiles": 79,
                   "committedDate": "2015-11-10T19:16:45Z",
-                  "messageHeadline": "switch `var` to `let` or `const`",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -1227,7 +1561,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-04T14:50:08Z",
-                  "messageHeadline": "Allow var args in logging and pass them through right to the console.log",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1241,7 +1577,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1255,7 +1593,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -1269,7 +1613,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-08-28T21:12:15Z",
-                  "messageHeadline": "amp-script: Update local script example and FAQs (#24242)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24242
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -1283,7 +1633,9 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2018-01-04T19:02:43Z",
-                  "messageHeadline": "Change default user logging level of AMP runtime from `OFF` to `WARN`…",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -1297,7 +1649,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -1311,7 +1669,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1325,7 +1685,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -1339,7 +1701,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2018-07-06T20:17:01Z",
-                  "messageHeadline": "Better debugging for amp-bind, amp-list (#16494)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16494
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -1353,7 +1721,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -1367,7 +1737,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1381,7 +1753,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-04T14:50:08Z",
-                  "messageHeadline": "Allow var args in logging and pass them through right to the console.log",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1395,7 +1769,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1409,7 +1785,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-04T14:50:08Z",
-                  "messageHeadline": "Allow var args in logging and pass them through right to the console.log",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1423,7 +1801,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2018-07-06T20:17:01Z",
-                  "messageHeadline": "Better debugging for amp-bind, amp-list (#16494)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16494
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -1437,7 +1821,9 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2015-09-24T16:56:57Z",
-                  "messageHeadline": "Gesture and gesture recognizers",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -1451,7 +1837,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1465,7 +1853,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -1479,7 +1869,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1493,7 +1885,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-04T14:50:08Z",
-                  "messageHeadline": "Allow var args in logging and pass them through right to the console.log",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1507,7 +1901,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1521,7 +1917,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-04T14:50:08Z",
-                  "messageHeadline": "Allow var args in logging and pass them through right to the console.log",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1535,7 +1933,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2018-07-06T20:17:01Z",
-                  "messageHeadline": "Better debugging for amp-bind, amp-list (#16494)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16494
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -1549,7 +1953,9 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2015-09-24T16:56:57Z",
-                  "messageHeadline": "Gesture and gesture recognizers",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -1563,7 +1969,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1577,7 +1985,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -1591,7 +2001,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1605,7 +2017,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-04T14:50:08Z",
-                  "messageHeadline": "Allow var args in logging and pass them through right to the console.log",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1619,7 +2033,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1633,7 +2049,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-04T14:50:08Z",
-                  "messageHeadline": "Allow var args in logging and pass them through right to the console.log",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1647,7 +2065,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2018-07-06T20:17:01Z",
-                  "messageHeadline": "Better debugging for amp-bind, amp-list (#16494)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16494
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -1661,7 +2085,9 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2015-09-24T16:56:57Z",
-                  "messageHeadline": "Gesture and gesture recognizers",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -1675,7 +2101,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1689,7 +2117,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -1703,7 +2133,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1717,7 +2149,9 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2015-09-04T14:50:08Z",
-                  "messageHeadline": "Allow var args in logging and pass them through right to the console.log",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1731,7 +2165,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2016-12-20T00:55:01Z",
-                  "messageHeadline": "add expectedError method (#6581)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 6581
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -1745,7 +2185,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -1759,7 +2201,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2016-12-20T00:55:01Z",
-                  "messageHeadline": "add expectedError method (#6581)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 6581
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -1773,7 +2221,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2018-07-06T20:17:01Z",
-                  "messageHeadline": "Better debugging for amp-bind, amp-list (#16494)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16494
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -1787,7 +2241,9 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2015-09-24T16:56:57Z",
-                  "messageHeadline": "Gesture and gesture recognizers",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -1801,7 +2257,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -1815,7 +2273,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -1829,7 +2293,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -1843,7 +2309,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2016-12-20T00:55:01Z",
-                  "messageHeadline": "add expectedError method (#6581)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 6581
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -1857,7 +2329,13 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2017-07-19T21:18:11Z",
-                  "messageHeadline": "user error trigger (#10148)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10148
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "tiendt"
@@ -1871,7 +2349,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2016-12-20T00:55:01Z",
-                  "messageHeadline": "add expectedError method (#6581)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 6581
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -1885,7 +2369,13 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2017-07-19T21:18:11Z",
-                  "messageHeadline": "user error trigger (#10148)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10148
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "tiendt"
@@ -1899,7 +2389,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2016-12-20T00:55:01Z",
-                  "messageHeadline": "add expectedError method (#6581)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 6581
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -1913,7 +2409,13 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2017-07-19T21:18:11Z",
-                  "messageHeadline": "user error trigger (#10148)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10148
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "tiendt"
@@ -1927,7 +2429,13 @@
                 "commit": {
                   "changedFiles": 37,
                   "committedDate": "2019-08-20T17:49:44Z",
-                  "messageHeadline": "Prefix more AMP window globals (#24054)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24054
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -1941,7 +2449,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2016-12-20T00:55:01Z",
-                  "messageHeadline": "add expectedError method (#6581)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 6581
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -1955,7 +2469,13 @@
                 "commit": {
                   "changedFiles": 256,
                   "committedDate": "2017-06-14T19:53:07Z",
-                  "messageHeadline": "Upgrade eslint (#9885)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 9885
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -1969,7 +2489,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2016-12-20T00:55:01Z",
-                  "messageHeadline": "add expectedError method (#6581)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 6581
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -1983,7 +2509,13 @@
                 "commit": {
                   "changedFiles": 256,
                   "committedDate": "2017-06-14T19:53:07Z",
-                  "messageHeadline": "Upgrade eslint (#9885)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 9885
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -1997,7 +2529,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2016-12-20T00:55:01Z",
-                  "messageHeadline": "add expectedError method (#6581)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 6581
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -2011,7 +2549,13 @@
                 "commit": {
                   "changedFiles": 37,
                   "committedDate": "2019-08-20T17:49:44Z",
-                  "messageHeadline": "Prefix more AMP window globals (#24054)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24054
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -2025,7 +2569,9 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2015-09-24T16:56:57Z",
-                  "messageHeadline": "Gesture and gesture recognizers",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2039,7 +2585,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -2053,7 +2601,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2067,7 +2617,9 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2016-03-15T22:56:16Z",
-                  "messageHeadline": "Logging: rethrowAsync facility",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2081,7 +2633,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2095,7 +2649,9 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2016-03-15T22:56:16Z",
-                  "messageHeadline": "Logging: rethrowAsync facility",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2109,7 +2665,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2123,7 +2681,9 @@
                 "commit": {
                   "changedFiles": 91,
                   "committedDate": "2015-09-02T23:06:35Z",
-                  "messageHeadline": "Initial commit",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -2137,7 +2697,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2151,7 +2713,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2016-12-20T00:55:01Z",
-                  "messageHeadline": "add expectedError method (#6581)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 6581
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -2165,7 +2733,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2179,7 +2749,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2019-06-11T21:36:58Z",
-                  "messageHeadline": "fix type narrowing problem so that we can remove casts (#22788)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22788
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -2193,7 +2769,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2207,7 +2785,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -2221,7 +2805,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2235,7 +2821,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2019-06-11T21:36:58Z",
-                  "messageHeadline": "fix type narrowing problem so that we can remove casts (#22788)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22788
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -2249,7 +2841,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2263,7 +2857,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2019-06-11T21:36:58Z",
-                  "messageHeadline": "fix type narrowing problem so that we can remove casts (#22788)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22788
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -2277,7 +2877,13 @@
                 "commit": {
                   "changedFiles": 26,
                   "committedDate": "2019-05-22T23:18:38Z",
-                  "messageHeadline": "🏗✨ Upgrade closure compiler to v20190513 (#22446)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22446
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -2291,7 +2897,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2305,7 +2913,13 @@
                 "commit": {
                   "changedFiles": 42,
                   "committedDate": "2016-06-12T00:59:55Z",
-                  "messageHeadline": "Fix compile errors in 3p and fix all unknown types in amp.js (#3552)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 3552
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -2319,7 +2933,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2333,7 +2949,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -2347,7 +2969,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -2361,7 +2989,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -2375,7 +3009,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2389,7 +3025,13 @@
                 "commit": {
                   "changedFiles": 42,
                   "committedDate": "2016-06-12T00:59:55Z",
-                  "messageHeadline": "Fix compile errors in 3p and fix all unknown types in amp.js (#3552)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 3552
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -2403,7 +3045,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2417,7 +3061,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2018-12-20T15:53:53Z",
-                  "messageHeadline": "Actually make type inference work for asserts. (#19940)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19940
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -2431,7 +3081,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2445,7 +3097,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2018-12-20T15:53:53Z",
-                  "messageHeadline": "Actually make type inference work for asserts. (#19940)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19940
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -2459,7 +3117,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2473,7 +3133,13 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2019-09-16T17:51:28Z",
-                  "messageHeadline": "🐛 Message extraction: Fallback on unserialize objects (#24500)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24500
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -2487,7 +3153,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2501,7 +3169,13 @@
                 "commit": {
                   "changedFiles": 37,
                   "committedDate": "2019-08-20T17:49:44Z",
-                  "messageHeadline": "Prefix more AMP window globals (#24054)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24054
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -2515,7 +3189,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2529,7 +3205,13 @@
                 "commit": {
                   "changedFiles": 17,
                   "committedDate": "2016-09-09T17:50:59Z",
-                  "messageHeadline": "Fix lots of type errors and introduces assertElement. (#4885)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4885
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -2543,7 +3225,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -2557,7 +3245,13 @@
                 "commit": {
                   "changedFiles": 17,
                   "committedDate": "2016-09-09T17:50:59Z",
-                  "messageHeadline": "Fix lots of type errors and introduces assertElement. (#4885)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4885
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -2571,7 +3265,13 @@
                 "commit": {
                   "changedFiles": 26,
                   "committedDate": "2019-05-22T23:18:38Z",
-                  "messageHeadline": "🏗✨ Upgrade closure compiler to v20190513 (#22446)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22446
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -2585,7 +3285,13 @@
                 "commit": {
                   "changedFiles": 17,
                   "committedDate": "2016-09-09T17:50:59Z",
-                  "messageHeadline": "Fix lots of type errors and introduces assertElement. (#4885)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4885
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -2599,7 +3305,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -2613,7 +3325,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -2627,7 +3345,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -2641,7 +3365,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -2655,7 +3385,13 @@
                 "commit": {
                   "changedFiles": 17,
                   "committedDate": "2016-09-09T17:50:59Z",
-                  "messageHeadline": "Fix lots of type errors and introduces assertElement. (#4885)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4885
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -2669,7 +3405,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2683,7 +3421,13 @@
                 "commit": {
                   "changedFiles": 52,
                   "committedDate": "2016-09-10T05:13:06Z",
-                  "messageHeadline": "Fix all type errors in v0.js and turn on type checking on travis (#4908)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4908
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -2697,7 +3441,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2017-01-25T19:23:36Z",
-                  "messageHeadline": "Clarify that assertString/Number allow empty string and zero (#7202)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 7202
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2711,7 +3461,13 @@
                 "commit": {
                   "changedFiles": 52,
                   "committedDate": "2016-09-10T05:13:06Z",
-                  "messageHeadline": "Fix all type errors in v0.js and turn on type checking on travis (#4908)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4908
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -2725,7 +3481,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2017-01-25T19:23:36Z",
-                  "messageHeadline": "Clarify that assertString/Number allow empty string and zero (#7202)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 7202
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2739,7 +3501,13 @@
                 "commit": {
                   "changedFiles": 52,
                   "committedDate": "2016-09-10T05:13:06Z",
-                  "messageHeadline": "Fix all type errors in v0.js and turn on type checking on travis (#4908)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4908
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -2753,7 +3521,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -2767,7 +3541,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2017-01-25T19:23:36Z",
-                  "messageHeadline": "Clarify that assertString/Number allow empty string and zero (#7202)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 7202
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2781,7 +3561,13 @@
                 "commit": {
                   "changedFiles": 26,
                   "committedDate": "2019-05-22T23:18:38Z",
-                  "messageHeadline": "🏗✨ Upgrade closure compiler to v20190513 (#22446)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22446
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -2795,7 +3581,13 @@
                 "commit": {
                   "changedFiles": 52,
                   "committedDate": "2016-09-10T05:13:06Z",
-                  "messageHeadline": "Fix all type errors in v0.js and turn on type checking on travis (#4908)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4908
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -2809,7 +3601,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -2823,7 +3621,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -2837,7 +3641,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -2851,7 +3661,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -2865,7 +3681,13 @@
                 "commit": {
                   "changedFiles": 52,
                   "committedDate": "2016-09-10T05:13:06Z",
-                  "messageHeadline": "Fix all type errors in v0.js and turn on type checking on travis (#4908)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4908
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -2879,7 +3701,13 @@
                 "commit": {
                   "changedFiles": 12,
                   "committedDate": "2016-09-15T08:05:39Z",
-                  "messageHeadline": "fix carousel types (#4989)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4989
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -2893,7 +3721,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2017-01-25T19:23:36Z",
-                  "messageHeadline": "Clarify that assertString/Number allow empty string and zero (#7202)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 7202
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2907,7 +3741,13 @@
                 "commit": {
                   "changedFiles": 12,
                   "committedDate": "2016-09-15T08:05:39Z",
-                  "messageHeadline": "fix carousel types (#4989)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4989
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -2921,7 +3761,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2017-01-25T19:23:36Z",
-                  "messageHeadline": "Clarify that assertString/Number allow empty string and zero (#7202)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 7202
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2935,7 +3781,13 @@
                 "commit": {
                   "changedFiles": 12,
                   "committedDate": "2016-09-15T08:05:39Z",
-                  "messageHeadline": "fix carousel types (#4989)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4989
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -2949,7 +3801,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -2963,7 +3821,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2017-01-25T19:23:36Z",
-                  "messageHeadline": "Clarify that assertString/Number allow empty string and zero (#7202)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 7202
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -2977,7 +3841,13 @@
                 "commit": {
                   "changedFiles": 26,
                   "committedDate": "2019-05-22T23:18:38Z",
-                  "messageHeadline": "🏗✨ Upgrade closure compiler to v20190513 (#22446)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22446
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -2991,7 +3861,13 @@
                 "commit": {
                   "changedFiles": 12,
                   "committedDate": "2016-09-15T08:05:39Z",
-                  "messageHeadline": "fix carousel types (#4989)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4989
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -3005,7 +3881,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3019,7 +3901,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -3033,7 +3921,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3047,7 +3941,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -3061,7 +3961,13 @@
                 "commit": {
                   "changedFiles": 12,
                   "committedDate": "2016-09-15T08:05:39Z",
-                  "messageHeadline": "fix carousel types (#4989)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4989
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -3075,7 +3981,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2018-12-26T23:50:24Z",
-                  "messageHeadline": "Add assertArray function to log.js (#19937)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19937
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cathyxz"
@@ -3089,7 +4001,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3103,7 +4021,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2018-12-26T23:50:24Z",
-                  "messageHeadline": "Add assertArray function to log.js (#19937)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19937
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cathyxz"
@@ -3117,7 +4041,13 @@
                 "commit": {
                   "changedFiles": 26,
                   "committedDate": "2019-05-22T23:18:38Z",
-                  "messageHeadline": "🏗✨ Upgrade closure compiler to v20190513 (#22446)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22446
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -3131,7 +4061,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2018-12-26T23:50:24Z",
-                  "messageHeadline": "Add assertArray function to log.js (#19937)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19937
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cathyxz"
@@ -3145,7 +4081,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3159,7 +4101,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -3173,7 +4121,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2018-12-26T23:50:24Z",
-                  "messageHeadline": "Add assertArray function to log.js (#19937)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19937
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cathyxz"
@@ -3187,7 +4141,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2018-01-30T23:07:16Z",
-                  "messageHeadline": "Layers: Scoring Algorithm (#12958)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 12958
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -3201,7 +4161,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3215,7 +4181,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2018-01-30T23:07:16Z",
-                  "messageHeadline": "Layers: Scoring Algorithm (#12958)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 12958
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -3229,7 +4201,13 @@
                 "commit": {
                   "changedFiles": 26,
                   "committedDate": "2019-05-22T23:18:38Z",
-                  "messageHeadline": "🏗✨ Upgrade closure compiler to v20190513 (#22446)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22446
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -3243,7 +4221,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2018-01-30T23:07:16Z",
-                  "messageHeadline": "Layers: Scoring Algorithm (#12958)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 12958
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -3257,7 +4241,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3271,7 +4261,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -3285,7 +4281,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3299,7 +4301,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -3313,7 +4321,13 @@
                 "commit": {
                   "changedFiles": 6,
                   "committedDate": "2018-01-30T23:07:16Z",
-                  "messageHeadline": "Layers: Scoring Algorithm (#12958)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 12958
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -3327,7 +4341,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -3341,7 +4357,13 @@
                 "commit": {
                   "changedFiles": 123,
                   "committedDate": "2018-05-14T21:56:10Z",
-                  "messageHeadline": "🚮 Restrict comments to 80 columns (exempt JSDoc annotations) (#15247)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 15247
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -3355,7 +4377,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -3369,7 +4393,9 @@
                 "commit": {
                   "changedFiles": 27,
                   "committedDate": "2016-06-10T23:59:21Z",
-                  "messageHeadline": "Fix all type errors in alp.js and turn on testing this on Travis. (#3…",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -3383,7 +4409,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -3397,7 +4425,13 @@
                 "commit": {
                   "changedFiles": 39,
                   "committedDate": "2018-06-27T17:56:54Z",
-                  "messageHeadline": "Fix js docs in `ads` and `3p` folder (#16377)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16377
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "prateekbh"
@@ -3411,7 +4445,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -3425,7 +4461,13 @@
                 "commit": {
                   "changedFiles": 26,
                   "committedDate": "2019-05-22T23:18:38Z",
-                  "messageHeadline": "🏗✨ Upgrade closure compiler to v20190513 (#22446)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22446
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -3439,7 +4481,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -3453,7 +4497,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2016-11-29T20:45:56Z",
-                  "messageHeadline": "A4A amp nameframe (#6099)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 6099
+                      }
+                    ]
+                  },
                   "author": {
                     "user": null
                   }
@@ -3465,7 +4515,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -3479,7 +4531,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -3493,7 +4551,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -3507,7 +4567,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2017-05-03T23:17:30Z",
-                  "messageHeadline": "Duplicate errors that are un-writable (#9046)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 9046
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -3521,7 +4587,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -3535,7 +4603,13 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2017-02-24T01:58:14Z",
-                  "messageHeadline": "A4A: log sampling of errors as dev-expected (#7726)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 7726
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -3549,7 +4623,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -3563,7 +4639,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3577,7 +4659,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3591,7 +4679,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3605,7 +4699,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3619,7 +4719,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3633,7 +4739,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3647,7 +4759,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3661,7 +4779,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3675,7 +4799,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3689,7 +4819,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3703,7 +4839,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3717,7 +4859,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3731,7 +4879,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3745,7 +4899,13 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2019-08-01T19:38:29Z",
-                  "messageHeadline": "🐛 Correctly interpolate expanded log messages (#23631)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 23631
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3759,7 +4919,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3773,7 +4939,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -3787,7 +4955,9 @@
                 "commit": {
                   "changedFiles": 27,
                   "committedDate": "2016-06-10T23:59:21Z",
-                  "messageHeadline": "Fix all type errors in alp.js and turn on testing this on Travis. (#3…",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -3801,7 +4971,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -3815,7 +4987,13 @@
                 "commit": {
                   "changedFiles": 1369,
                   "committedDate": "2020-03-30T23:24:53Z",
-                  "messageHeadline": "📦 Update dependency prettier to v2 (#27350)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 27350
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "renovate-bot"
@@ -3829,7 +5007,13 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2019-09-16T17:51:28Z",
-                  "messageHeadline": "🐛 Message extraction: Fallback on unserialize objects (#24500)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24500
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3843,7 +5027,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2017-04-03T22:01:27Z",
-                  "messageHeadline": "Instrument amp-form at the ampdoc level (#8101)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 8101
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cvializ"
@@ -3857,7 +5047,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -3871,7 +5063,13 @@
                 "commit": {
                   "changedFiles": 1,
                   "committedDate": "2019-09-16T17:51:28Z",
-                  "messageHeadline": "🐛 Message extraction: Fallback on unserialize objects (#24500)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24500
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -3885,7 +5083,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -3899,7 +5099,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2017-05-03T23:17:30Z",
-                  "messageHeadline": "Duplicate errors that are un-writable (#9046)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 9046
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -3913,7 +5119,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2018-10-10T19:50:59Z",
-                  "messageHeadline": "🏗✨ Upgrade to Babel 7 (#18574)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 18574
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -3927,7 +5139,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2017-05-03T23:17:30Z",
-                  "messageHeadline": "Duplicate errors that are un-writable (#9046)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 9046
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -3941,7 +5159,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2018-10-10T19:50:59Z",
-                  "messageHeadline": "🏗✨ Upgrade to Babel 7 (#18574)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 18574
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -3955,7 +5179,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2017-05-03T23:17:30Z",
-                  "messageHeadline": "Duplicate errors that are un-writable (#9046)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 9046
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -3969,7 +5199,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2018-10-10T19:50:59Z",
-                  "messageHeadline": "🏗✨ Upgrade to Babel 7 (#18574)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 18574
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -3983,7 +5219,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2017-05-03T23:17:30Z",
-                  "messageHeadline": "Duplicate errors that are un-writable (#9046)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 9046
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -3997,7 +5239,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -4011,7 +5255,9 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2016-03-15T22:56:16Z",
-                  "messageHeadline": "Logging: rethrowAsync facility",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -4025,7 +5271,13 @@
                 "commit": {
                   "changedFiles": 13,
                   "committedDate": "2018-07-25T21:50:16Z",
-                  "messageHeadline": "🏗🐛 Prevent most async throwing of errors during tests (#16916)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16916
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -4039,7 +5291,9 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2016-03-15T22:56:16Z",
-                  "messageHeadline": "Logging: rethrowAsync facility",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -4053,7 +5307,13 @@
                 "commit": {
                   "changedFiles": 13,
                   "committedDate": "2018-07-25T21:50:16Z",
-                  "messageHeadline": "🏗🐛 Prevent most async throwing of errors during tests (#16916)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16916
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -4067,7 +5327,9 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2016-03-15T22:56:16Z",
-                  "messageHeadline": "Logging: rethrowAsync facility",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -4081,7 +5343,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2017-05-03T23:17:30Z",
-                  "messageHeadline": "Duplicate errors that are un-writable (#9046)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 9046
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -4095,7 +5363,9 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2016-03-15T22:56:16Z",
-                  "messageHeadline": "Logging: rethrowAsync facility",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -4109,7 +5379,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2017-05-03T23:17:30Z",
-                  "messageHeadline": "Duplicate errors that are un-writable (#9046)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 9046
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -4123,7 +5399,9 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2016-03-15T22:56:16Z",
-                  "messageHeadline": "Logging: rethrowAsync facility",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -4137,7 +5415,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2017-02-06T21:29:11Z",
-                  "messageHeadline": "Directly report logged errors instead of relying on rethrowing (#7358)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 7358
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -4151,7 +5435,13 @@
                 "commit": {
                   "changedFiles": 11,
                   "committedDate": "2017-02-16T21:39:09Z",
-                  "messageHeadline": "Fix undefined reportError (#7588)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 7588
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -4165,7 +5455,13 @@
                 "commit": {
                   "changedFiles": 37,
                   "committedDate": "2019-08-20T17:49:44Z",
-                  "messageHeadline": "Prefix more AMP window globals (#24054)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24054
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -4179,7 +5475,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2017-02-06T21:29:11Z",
-                  "messageHeadline": "Directly report logged errors instead of relying on rethrowing (#7358)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 7358
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -4193,7 +5495,9 @@
                 "commit": {
                   "changedFiles": 2,
                   "committedDate": "2016-03-15T22:56:16Z",
-                  "messageHeadline": "Logging: rethrowAsync facility",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -4207,7 +5511,13 @@
                 "commit": {
                   "changedFiles": 161,
                   "committedDate": "2016-08-03T22:35:24Z",
-                  "messageHeadline": "Remove side effect exports (#4261)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4261
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -4221,7 +5531,13 @@
                 "commit": {
                   "changedFiles": 10,
                   "committedDate": "2016-09-13T19:42:05Z",
-                  "messageHeadline": "Make Log DCEable. (#4963)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4963
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -4235,7 +5551,13 @@
                 "commit": {
                   "changedFiles": 161,
                   "committedDate": "2016-08-03T22:35:24Z",
-                  "messageHeadline": "Remove side effect exports (#4261)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4261
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -4249,7 +5571,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-07T22:10:26Z",
-                  "messageHeadline": "Exclude errors generated from A4A iframe (#10562)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10562
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "tiendt"
@@ -4263,7 +5591,13 @@
                 "commit": {
                   "changedFiles": 161,
                   "committedDate": "2016-08-03T22:35:24Z",
-                  "messageHeadline": "Remove side effect exports (#4261)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4261
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -4277,7 +5611,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-08-23T15:32:03Z",
-                  "messageHeadline": "Prefix remaining window globals in src/ (#24147)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24147
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -4291,7 +5631,13 @@
                 "commit": {
                   "changedFiles": 10,
                   "committedDate": "2016-09-13T19:42:05Z",
-                  "messageHeadline": "Make Log DCEable. (#4963)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4963
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -4305,7 +5651,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-07T22:10:26Z",
-                  "messageHeadline": "Exclude errors generated from A4A iframe (#10562)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10562
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "tiendt"
@@ -4319,7 +5671,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -4333,7 +5691,13 @@
                 "commit": {
                   "changedFiles": 10,
                   "committedDate": "2016-09-13T19:42:05Z",
-                  "messageHeadline": "Make Log DCEable. (#4963)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4963
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -4347,7 +5711,13 @@
                 "commit": {
                   "changedFiles": 5,
                   "committedDate": "2019-08-23T15:32:03Z",
-                  "messageHeadline": "Prefix remaining window globals in src/ (#24147)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 24147
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -4361,7 +5731,13 @@
                 "commit": {
                   "changedFiles": 10,
                   "committedDate": "2016-09-13T19:42:05Z",
-                  "messageHeadline": "Make Log DCEable. (#4963)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4963
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -4375,7 +5751,13 @@
                 "commit": {
                   "changedFiles": 20,
                   "committedDate": "2020-01-21T21:06:25Z",
-                  "messageHeadline": "🏗️ Use typeof type where appropriate (#26355)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26355
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -4389,7 +5771,13 @@
                 "commit": {
                   "changedFiles": 10,
                   "committedDate": "2016-09-13T19:42:05Z",
-                  "messageHeadline": "Make Log DCEable. (#4963)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4963
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -4403,7 +5791,13 @@
                 "commit": {
                   "changedFiles": 39,
                   "committedDate": "2018-06-27T17:56:54Z",
-                  "messageHeadline": "Fix js docs in `ads` and `3p` folder (#16377)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16377
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "prateekbh"
@@ -4417,7 +5811,13 @@
                 "commit": {
                   "changedFiles": 20,
                   "committedDate": "2020-01-21T21:06:25Z",
-                  "messageHeadline": "🏗️ Use typeof type where appropriate (#26355)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26355
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -4431,7 +5831,13 @@
                 "commit": {
                   "changedFiles": 39,
                   "committedDate": "2018-06-27T17:56:54Z",
-                  "messageHeadline": "Fix js docs in `ads` and `3p` folder (#16377)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16377
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "prateekbh"
@@ -4445,7 +5851,13 @@
                 "commit": {
                   "changedFiles": 10,
                   "committedDate": "2016-09-13T19:42:05Z",
-                  "messageHeadline": "Make Log DCEable. (#4963)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4963
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -4459,7 +5871,13 @@
                 "commit": {
                   "changedFiles": 3,
                   "committedDate": "2016-09-22T21:37:34Z",
-                  "messageHeadline": "make sure to init instances extensions can use (#5161)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 5161
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -4473,7 +5891,13 @@
                 "commit": {
                   "changedFiles": 123,
                   "committedDate": "2018-05-14T21:56:10Z",
-                  "messageHeadline": "🚮 Restrict comments to 80 columns (exempt JSDoc annotations) (#15247)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 15247
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -4487,7 +5911,13 @@
                 "commit": {
                   "changedFiles": 3,
                   "committedDate": "2016-09-22T21:37:34Z",
-                  "messageHeadline": "make sure to init instances extensions can use (#5161)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 5161
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -4501,7 +5931,13 @@
                 "commit": {
                   "changedFiles": 10,
                   "committedDate": "2016-09-13T19:42:05Z",
-                  "messageHeadline": "Make Log DCEable. (#4963)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4963
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -4515,7 +5951,13 @@
                 "commit": {
                   "changedFiles": 39,
                   "committedDate": "2018-06-27T17:56:54Z",
-                  "messageHeadline": "Fix js docs in `ads` and `3p` folder (#16377)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16377
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "prateekbh"
@@ -4529,7 +5971,13 @@
                 "commit": {
                   "changedFiles": 20,
                   "committedDate": "2020-01-21T21:06:25Z",
-                  "messageHeadline": "🏗️ Use typeof type where appropriate (#26355)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 26355
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -4543,7 +5991,13 @@
                 "commit": {
                   "changedFiles": 39,
                   "committedDate": "2018-06-27T17:56:54Z",
-                  "messageHeadline": "Fix js docs in `ads` and `3p` folder (#16377)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16377
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "prateekbh"
@@ -4557,7 +6011,13 @@
                 "commit": {
                   "changedFiles": 10,
                   "committedDate": "2016-09-13T19:42:05Z",
-                  "messageHeadline": "Make Log DCEable. (#4963)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4963
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -4571,7 +6031,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -4585,7 +6047,13 @@
                 "commit": {
                   "changedFiles": 3,
                   "committedDate": "2018-07-16T19:05:45Z",
-                  "messageHeadline": "Use dev().info for prod logging (#16731)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16731
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -4599,7 +6067,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -4613,7 +6083,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-07T22:10:26Z",
-                  "messageHeadline": "Exclude errors generated from A4A iframe (#10562)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10562
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "tiendt"
@@ -4627,7 +6103,13 @@
                 "commit": {
                   "changedFiles": 161,
                   "committedDate": "2016-08-03T22:35:24Z",
-                  "messageHeadline": "Remove side effect exports (#4261)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4261
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -4641,7 +6123,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -4655,7 +6139,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-07T22:10:26Z",
-                  "messageHeadline": "Exclude errors generated from A4A iframe (#10562)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10562
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "tiendt"
@@ -4669,7 +6159,13 @@
                 "commit": {
                   "changedFiles": 10,
                   "committedDate": "2016-09-13T19:42:05Z",
-                  "messageHeadline": "Make Log DCEable. (#4963)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4963
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -4683,7 +6179,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-07T22:10:26Z",
-                  "messageHeadline": "Exclude errors generated from A4A iframe (#10562)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10562
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "tiendt"
@@ -4697,7 +6199,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -4711,7 +6219,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -4725,7 +6235,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-07T22:10:26Z",
-                  "messageHeadline": "Exclude errors generated from A4A iframe (#10562)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10562
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "tiendt"
@@ -4739,7 +6255,13 @@
                 "commit": {
                   "changedFiles": 85,
                   "committedDate": "2018-05-15T21:21:17Z",
-                  "messageHeadline": "📖 JSDoc: Use `@return` instead of `@returns` (#15320)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 15320
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -4753,7 +6275,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-07T22:10:26Z",
-                  "messageHeadline": "Exclude errors generated from A4A iframe (#10562)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10562
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "tiendt"
@@ -4767,7 +6295,13 @@
                 "commit": {
                   "changedFiles": 10,
                   "committedDate": "2016-09-13T19:42:05Z",
-                  "messageHeadline": "Make Log DCEable. (#4963)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4963
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -4781,7 +6315,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -4795,7 +6335,13 @@
                 "commit": {
                   "changedFiles": 1369,
                   "committedDate": "2020-03-30T23:24:53Z",
-                  "messageHeadline": "📦 Update dependency prettier to v2 (#27350)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 27350
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "renovate-bot"
@@ -4809,7 +6355,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -4823,7 +6375,13 @@
                 "commit": {
                   "changedFiles": 161,
                   "committedDate": "2016-08-03T22:35:24Z",
-                  "messageHeadline": "Remove side effect exports (#4261)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4261
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -4837,7 +6395,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -4851,7 +6411,13 @@
                 "commit": {
                   "changedFiles": 161,
                   "committedDate": "2016-08-03T22:35:24Z",
-                  "messageHeadline": "Remove side effect exports (#4261)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4261
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -4865,7 +6431,13 @@
                 "commit": {
                   "changedFiles": 123,
                   "committedDate": "2018-05-14T21:56:10Z",
-                  "messageHeadline": "🚮 Restrict comments to 80 columns (exempt JSDoc annotations) (#15247)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 15247
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -4879,7 +6451,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -4893,7 +6467,13 @@
                 "commit": {
                   "changedFiles": 3,
                   "committedDate": "2018-07-16T19:05:45Z",
-                  "messageHeadline": "Use dev().info for prod logging (#16731)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 16731
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "choumx"
@@ -4907,7 +6487,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -4921,7 +6503,13 @@
                 "commit": {
                   "changedFiles": 161,
                   "committedDate": "2016-08-03T22:35:24Z",
-                  "messageHeadline": "Remove side effect exports (#4261)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4261
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -4935,7 +6523,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -4949,7 +6539,13 @@
                 "commit": {
                   "changedFiles": 161,
                   "committedDate": "2016-08-03T22:35:24Z",
-                  "messageHeadline": "Remove side effect exports (#4261)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4261
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -4963,7 +6559,13 @@
                 "commit": {
                   "changedFiles": 10,
                   "committedDate": "2016-09-13T19:42:05Z",
-                  "messageHeadline": "Make Log DCEable. (#4963)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4963
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -4977,7 +6579,9 @@
                 "commit": {
                   "changedFiles": 7,
                   "committedDate": "2016-03-12T00:30:30Z",
-                  "messageHeadline": "Separate dev and pub logs. Prepare devlog for DCE.",
+                  "associatedPullRequests": {
+                    "nodes": []
+                  },
                   "author": {
                     "user": {
                       "login": "dvoytenko"
@@ -4991,7 +6595,13 @@
                 "commit": {
                   "changedFiles": 1369,
                   "committedDate": "2020-03-30T23:24:53Z",
-                  "messageHeadline": "📦 Update dependency prettier to v2 (#27350)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 27350
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "renovate-bot"
@@ -5005,7 +6615,13 @@
                 "commit": {
                   "changedFiles": 161,
                   "committedDate": "2016-08-03T22:35:24Z",
-                  "messageHeadline": "Remove side effect exports (#4261)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4261
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -5019,7 +6635,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -5033,7 +6655,13 @@
                 "commit": {
                   "changedFiles": 161,
                   "committedDate": "2016-08-03T22:35:24Z",
-                  "messageHeadline": "Remove side effect exports (#4261)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 4261
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "jridgewell"
@@ -5047,7 +6675,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-07T22:10:26Z",
-                  "messageHeadline": "Exclude errors generated from A4A iframe (#10562)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10562
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "tiendt"
@@ -5061,7 +6695,13 @@
                 "commit": {
                   "changedFiles": 85,
                   "committedDate": "2018-05-15T21:21:17Z",
-                  "messageHeadline": "📖 JSDoc: Use `@return` instead of `@returns` (#15320)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 15320
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -5075,7 +6715,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2017-08-07T22:10:26Z",
-                  "messageHeadline": "Exclude errors generated from A4A iframe (#10562)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 10562
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "tiendt"
@@ -5089,7 +6735,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2018-12-20T15:53:53Z",
-                  "messageHeadline": "Actually make type inference work for asserts. (#19940)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19940
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -5103,7 +6755,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2019-06-11T21:36:58Z",
-                  "messageHeadline": "fix type narrowing problem so that we can remove casts (#22788)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22788
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -5117,7 +6775,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2018-12-20T15:53:53Z",
-                  "messageHeadline": "Actually make type inference work for asserts. (#19940)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19940
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -5131,7 +6795,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -5145,7 +6815,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2018-12-20T15:53:53Z",
-                  "messageHeadline": "Actually make type inference work for asserts. (#19940)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19940
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -5159,7 +6835,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2019-06-11T21:36:58Z",
-                  "messageHeadline": "fix type narrowing problem so that we can remove casts (#22788)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22788
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -5173,7 +6855,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2018-12-20T15:53:53Z",
-                  "messageHeadline": "Actually make type inference work for asserts. (#19940)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19940
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -5187,7 +6875,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2019-06-11T21:36:58Z",
-                  "messageHeadline": "fix type narrowing problem so that we can remove casts (#22788)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22788
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -5201,7 +6895,13 @@
                 "commit": {
                   "changedFiles": 26,
                   "committedDate": "2019-05-22T23:18:38Z",
-                  "messageHeadline": "🏗✨ Upgrade closure compiler to v20190513 (#22446)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22446
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -5215,7 +6915,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2018-12-20T15:53:53Z",
-                  "messageHeadline": "Actually make type inference work for asserts. (#19940)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19940
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -5229,7 +6935,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -5243,7 +6955,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2018-12-20T15:53:53Z",
-                  "messageHeadline": "Actually make type inference work for asserts. (#19940)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19940
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -5257,7 +6975,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -5271,7 +6995,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2018-12-20T15:53:53Z",
-                  "messageHeadline": "Actually make type inference work for asserts. (#19940)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19940
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -5285,7 +7015,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2019-06-11T21:36:58Z",
-                  "messageHeadline": "fix type narrowing problem so that we can remove casts (#22788)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22788
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -5299,7 +7035,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2018-12-20T15:53:53Z",
-                  "messageHeadline": "Actually make type inference work for asserts. (#19940)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19940
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -5313,7 +7055,13 @@
                 "commit": {
                   "changedFiles": 32,
                   "committedDate": "2019-07-23T16:59:03Z",
-                  "messageHeadline": "🏗Extract and indirect log message string (#22146)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22146
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "alanorozco"
@@ -5327,7 +7075,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2018-12-20T15:53:53Z",
-                  "messageHeadline": "Actually make type inference work for asserts. (#19940)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19940
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -5341,7 +7095,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2019-06-11T21:36:58Z",
-                  "messageHeadline": "fix type narrowing problem so that we can remove casts (#22788)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22788
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -5355,7 +7115,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2018-12-20T15:53:53Z",
-                  "messageHeadline": "Actually make type inference work for asserts. (#19940)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19940
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -5369,7 +7135,13 @@
                 "commit": {
                   "changedFiles": 4,
                   "committedDate": "2019-06-11T21:36:58Z",
-                  "messageHeadline": "fix type narrowing problem so that we can remove casts (#22788)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22788
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "erwinmombay"
@@ -5383,7 +7155,13 @@
                 "commit": {
                   "changedFiles": 26,
                   "committedDate": "2019-05-22T23:18:38Z",
-                  "messageHeadline": "🏗✨ Upgrade closure compiler to v20190513 (#22446)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 22446
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -5397,7 +7175,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2018-12-20T15:53:53Z",
-                  "messageHeadline": "Actually make type inference work for asserts. (#19940)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19940
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"
@@ -5411,7 +7195,13 @@
                 "commit": {
                   "changedFiles": 1623,
                   "committedDate": "2019-05-16T14:59:15Z",
-                  "messageHeadline": "🏗✨ Adopt `prettier` for code formatting  (#21212)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 21212
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "rsimha"
@@ -5425,7 +7215,13 @@
                 "commit": {
                   "changedFiles": 8,
                   "committedDate": "2018-12-20T15:53:53Z",
-                  "messageHeadline": "Actually make type inference work for asserts. (#19940)",
+                  "associatedPullRequests": {
+                    "nodes": [
+                      {
+                        "number": 19940
+                      }
+                    ]
+                  },
                   "author": {
                     "user": {
                       "login": "cramforce"

--- a/error-monitoring/types/error-monitoring.d.ts
+++ b/error-monitoring/types/error-monitoring.d.ts
@@ -69,7 +69,9 @@ declare module 'error-monitoring' {
     interface Commit {
       changedFiles: number;
       committedDate: string;
-      messageHeadline: string;
+      associatedPullRequests: {
+        nodes: Array<{number: number}>;
+      };
       author: {
         name: string;
         user: null | User;


### PR DESCRIPTION
Fixes #903

Originally, fetched the commit message and parsed out the PR number to simplify the query/reduce the query "cost" for the GraphQL rate limit, but that failed whenever the commit message headline was too long and got truncated. This adds a join against the `associatedPullRequests` connection, which should directly provide the PR number when available.