### PR TITLE
[test-case-reporting] Add types for Travis test reports

### DIFF
--- a/test-case-reporting/types/test-case-reporting.d.ts
+++ b/test-case-reporting/types/test-case-reporting.d.ts
@@ -76,7 +76,7 @@ declare module 'test-case-reporting' {
     results: Array<TrrTestResult>
   }
 
-  export interface TrrTestResult {
+  export interface TestResult {
     description: string,
     suite: Array<string>,
     success: boolean,

--- a/test-case-reporting/types/test-case-reporting.d.ts
+++ b/test-case-reporting/types/test-case-reporting.d.ts
@@ -61,14 +61,14 @@ declare module 'test-case-reporting' {
     durationMs: number,
   }
 
-  export interface TravisReport {
+  export interface StructuredTestReport {
     successCount: number,
     failedCount: number,
     skippedCount: number,
-    results: Array<Result>,
+    results: Array<TestResultReport>,
   }
 
-  export interface Result {
+  export interface TestResultReport {
     name: string,
     status: TestStatus,
     timeMs: number,

--- a/test-case-reporting/types/test-case-reporting.d.ts
+++ b/test-case-reporting/types/test-case-reporting.d.ts
@@ -61,16 +61,27 @@ declare module 'test-case-reporting' {
     durationMs: number,
   }
 
-  export interface StructuredTestReport {
-    successCount: number,
-    failedCount: number,
-    skippedCount: number,
-    results: Array<TestResultReport>,
+  export interface TestResultReport {
+    summary: TrrSummary,
+    browsers: TrrBrowsers,
   }
 
-  export interface TestResultReport {
-    name: string,
-    status: TestStatus,
-    timeMs: number,
+  export interface TrrSummary {
+    success: number,
+    failed: number,
+    skipped: number,
+  }
+
+  export interface TrrBrowsers {
+    results: Array<TrrTestResult>
+  }
+
+  export interface TrrTestResult {
+    description: string,
+    suite: Array<string>,
+    success: boolean,
+    skipped: boolean,
+    pending: boolean,
+    time: number, // in milliseconds
   }
 }

--- a/test-case-reporting/types/test-case-reporting.d.ts
+++ b/test-case-reporting/types/test-case-reporting.d.ts
@@ -61,27 +61,22 @@ declare module 'test-case-reporting' {
     durationMs: number,
   }
 
-  export interface TestResultReport {
-    summary: TrrSummary,
-    browsers: TrrBrowsers,
-  }
+  namespace KarmaReporter {
+    export interface TestResultReport {
+      browsers: BrowserResultSet,
+    }
 
-  export interface TrrSummary {
-    success: number,
-    failed: number,
-    skipped: number,
-  }
+    export interface BrowserResultSet {
+      results: Array<TestResult>
+    }
 
-  export interface BrowserResultSet {
-    results: Array<TrrTestResult>
-  }
-
-  export interface TestResult {
-    description: string,
-    suite: Array<string>,
-    success: boolean,
-    skipped: boolean,
-    pending: boolean,
-    time: number, // in milliseconds
+    export interface TestResult {
+      description: string,
+      suite: Array<string>,
+      success: boolean,
+      skipped: boolean,
+      pending: boolean,
+      time: number, // in milliseconds
+    }
   }
 }

--- a/test-case-reporting/types/test-case-reporting.d.ts
+++ b/test-case-reporting/types/test-case-reporting.d.ts
@@ -72,7 +72,7 @@ declare module 'test-case-reporting' {
     skipped: number,
   }
 
-  export interface TrrBrowsers {
+  export interface BrowserResultSet {
     results: Array<TrrTestResult>
   }
 

--- a/test-case-reporting/types/test-case-reporting.d.ts
+++ b/test-case-reporting/types/test-case-reporting.d.ts
@@ -60,4 +60,17 @@ declare module 'test-case-reporting' {
     timestamp: Date,
     durationMs: number,
   }
+
+  export interface TravisReport {
+    successCount: number,
+    failedCount: number,
+    skippedCount: number,
+    results: Array<Result>,
+  }
+
+  export interface Result {
+    name: string,
+    status: TestStatus,
+    timeMs: number,
+  }
 }


### PR DESCRIPTION
/cc @rcebulko 
Works toward #884.

Sample of the test result report JSON generated when we run `gulp unit`
```json
    "summary": {
        "success": 10879,
        "failed": 21,
        "skipped": 195,
        "error": false,
        "disconnected": false,
        "exitCode": 1
    },
    "browsers": [
        {
            "browser": {
                "id": "52060",
                "fullName": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36",
                "name": "Chrome 83.0.4103.97 (Linux x86_64)",
                "state": "DISCONNECTED",
                "lastResult": {
                    "startTime": 1592249357208,
                    "total": 11095,
                    "success": 10879,
                    "failed": 21,
                    "skipped": 195,
                    "totalTime": 813363,
                    "netTime": 275545,
                    "error": false,
                    "disconnected": false
                },
                "disconnectsCount": 0,
                "noActivityTimeout": 120000,
                "disconnectDelay": 120000
            },
            "errors": [],
            "results": [
                {
                    "id": "",
                    "description": "generates extensions metadata",
                    "suite": [],
                    "success": true,
                    "skipped": false,
                    "pending": false,
                    "time": 4,
                    "log": [],
                    "assertionErrors": [],
                    "startTime": 1592249357248,
                    "endTime": 1592249357258
                },
                {
                    "id": "",
                    "description": "generates runtime offsets",
                    "suite": [],
                    "success": true,
                    "skipped": false,
                    "pending": false,
                    "time": 2,
                    "log": [],
                    "assertionErrors": [],
                    "startTime": 1592249357264,
                    "endTime": 1592249357271
                },
                {
                    "id": "",
                    "description": "generates json offsets",
                    "suite": [],
                    "success": true,
                    "skipped": false,
                    "pending": false,
                    "time": 1,
                    "log": [],
                    "assertionErrors": [],
                    "startTime": 1592249357271,
                    "endTime": 1592249357275
                },
                ...
            ]
        }
    ]
}
```