### PR TITLE
[error-monitoring] Allow for reporting errors to a separate repo + cron endpoint to do so

### DIFF
--- a/error-monitoring/app.ts
+++ b/error-monitoring/app.ts
@@ -16,7 +16,7 @@
 
 require('dotenv').config();
 
-import {errorIssue, errorList, topIssueList} from '.';
+import {errorIssue, errorList, errorMonitor, topIssueList} from '.';
 import {json, urlencoded} from 'body-parser';
 import express from 'express';
 
@@ -28,6 +28,7 @@ express()
   .get('/error-issue', errorIssue)
   .get(['/', '/error-list'], errorList)
   .get('/top-issues', topIssueList)
+  .get('/_cron/monitor', errorMonitor)
   .listen(PORT, () => {
     console.log(`Listening on port ${PORT}`);
   });

--- a/error-monitoring/cron.yaml
+++ b/error-monitoring/cron.yaml
@@ -1,0 +1,13 @@
+cron:
+- description: "File issues for errors in production"
+  url: /_cron/monitor?serviceType=production
+  schedule: every day at 7:00am
+- description: "File issues for errors in 1%/opt-in"
+  url: /_cron/monitor?serviceType=development
+  schedule: every day at 7:02am
+- description: "File issues for errors in experiments"
+  url: /_cron/monitor?serviceType=experiments
+  schedule: every day at 7:04am
+- description: "File issues for errors in nightly"
+  url: /_cron/monitor?serviceType=nightly
+  schedule: every day at 7:06am

--- a/error-monitoring/index.ts
+++ b/error-monitoring/index.ts
@@ -38,6 +38,7 @@ import statusCodes from 'http-status-codes';
 
 const GITHUB_REPO = process.env.GITHUB_REPO || 'ampproject/amphtml';
 const [GITHUB_REPO_OWNER, GITHUB_REPO_NAME] = GITHUB_REPO.split('/');
+const ISSUE_REPO_NAME = process.env.ISSUE_REPO_NAME || 'amphtml';
 const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
 const PROJECT_ID = process.env.PROJECT_ID || 'amp-error-reporting';
 const MIN_FREQUENCY = Number(process.env.MIN_FREQUENCY || 2500);
@@ -68,7 +69,8 @@ function renderTopIssues(issues: Array<TopIssueView>): string {
 const bot = new ErrorIssueBot(
   GITHUB_ACCESS_TOKEN,
   GITHUB_REPO_OWNER,
-  GITHUB_REPO_NAME
+  GITHUB_REPO_NAME,
+  ISSUE_REPO_NAME
 );
 
 const stackdriver = new StackdriverApi(PROJECT_ID);

--- a/error-monitoring/index.ts
+++ b/error-monitoring/index.ts
@@ -159,19 +159,6 @@ export async function errorIssue(
   }
 }
 
-/** Endpoint to trigger a scan for new frequent errors. */
-export async function errorMonitor(
-  req: express.Request,
-  res: express.Response
-): Promise<void> {
-  try {
-    res.json({issueUrls: await monitor.monitorAndReport()});
-  } catch (error) {
-    res.status(statusCodes.INTERNAL_SERVER_ERROR);
-    res.json({error: error.toString()});
-  }
-}
-
 function createErrorReportUrl({errorId}: ErrorReport): string {
   const params = querystring.stringify({errorId, linkIssue: 1});
   return `${ERROR_ISSUE_ENDPOINT}?${params}`;
@@ -200,6 +187,20 @@ function getLister(
   }
 
   return optThreshold ? lister.threshold(optThreshold) : lister;
+}
+
+/** Endpoint to trigger a scan for new frequent errors. */
+export async function errorMonitor(
+  req: express.Request,
+  res: express.Response
+): Promise<void> {
+  try {
+    const serviceType = (req.query.serviceType || '').toString().toUpperCase();
+    res.json({issueUrls: await getLister(serviceType).monitorAndReport()});
+  } catch (error) {
+    res.status(statusCodes.INTERNAL_SERVER_ERROR);
+    res.json({error: error.toString()});
+  }
 }
 
 function viewData({

--- a/error-monitoring/redacted.env
+++ b/error-monitoring/redacted.env
@@ -1,4 +1,5 @@
 GITHUB_REPO=ampproject/amphtml
+ISSUE_REPO_NAME=amphtml
 GITHUB_ACCESS_TOKEN=[REDACTED]
 PROJECT_ID=amp-error-reporting
 ERROR_ISSUE_ENDPOINT=https://amp-error-monitoring.uc.r.appspot.com/error-issue

--- a/error-monitoring/src/bot.ts
+++ b/error-monitoring/src/bot.ts
@@ -33,7 +33,7 @@ export class ErrorIssueBot {
     token: string,
     private repoOwner: string,
     private repoName: string,
-    private issueRepoName: string | undefined
+    private issueRepoName?: string
   ) {
     this.octokit = new Octokit({auth: `token ${token}`});
     this.blameFinder = new BlameFinder(

--- a/error-monitoring/src/bot.ts
+++ b/error-monitoring/src/bot.ts
@@ -32,7 +32,8 @@ export class ErrorIssueBot {
   constructor(
     token: string,
     private repoOwner: string,
-    private repoName: string
+    private repoName: string,
+    private issueRepoName: string | undefined
   ) {
     this.octokit = new Octokit({auth: `token ${token}`});
     this.blameFinder = new BlameFinder(
@@ -51,7 +52,7 @@ export class ErrorIssueBot {
     const builder = new IssueBuilder(errorReport, blameRanges, RELEASE_ONDUTY);
     return {
       owner: this.repoOwner,
-      repo: this.repoName,
+      repo: this.issueRepoName,
       title: builder.title,
       labels: builder.labels,
       body: builder.body,

--- a/error-monitoring/test/bot.test.ts
+++ b/error-monitoring/test/bot.test.ts
@@ -52,7 +52,7 @@ describe('ErrorIssueBot', () => {
   });
 
   beforeEach(() => {
-    bot = new ErrorIssueBot('__TOKEN__', 'test_org', 'test_repo');
+    bot = new ErrorIssueBot('__TOKEN__', 'test_org', 'test_repo', 'issue_repo');
     nock.cleanAll();
 
     jest.spyOn(BlameFinder.prototype, 'blameForStacktrace').mockResolvedValue([
@@ -106,7 +106,7 @@ describe('ErrorIssueBot', () => {
     it('builds the issue to be created', async () => {
       await expect(bot.buildErrorIssue(errorReport)).resolves.toEqual({
         owner: 'test_org',
-        repo: 'test_repo',
+        repo: 'issue_repo',
         title: 'issue title',
         labels: ['label'],
         body: 'issue body',
@@ -119,7 +119,7 @@ describe('ErrorIssueBot', () => {
 
     it('creates an error issue', async () => {
       nock('https://api.github.com')
-        .post('/repos/test_org/test_repo/issues', body => {
+        .post('/repos/test_org/issue_repo/issues', body => {
           expect(body).toEqual({
             title: 'issue title',
             labels: ['label'],
@@ -134,7 +134,7 @@ describe('ErrorIssueBot', () => {
 
     it('propagates the error when the API call fails', async () => {
       nock('https://api.github.com')
-        .post('/repos/test_org/test_repo/issues')
+        .post('/repos/test_org/issue_repo/issues')
         .reply(401, {name: 'HttpError', status: 401});
 
       await expect(bot.report(errorReport)).rejects.toMatchObject({


### PR DESCRIPTION
This PR:
- allows us to use a dedicated "error-reports" repository to track issues separately from user-created issues, per request of @kristoferbaxter to reduce issue noise for the UI WG
- defines cron endpoints to automatically file issues each morning for newly detected frequent errors in the wild 