### PR TITLE
[error-monitoring] Add instructions for manually linking duplicate errors

### DIFF
--- a/error-monitoring/index.ts
+++ b/error-monitoring/index.ts
@@ -310,7 +310,7 @@ export async function topIssueList(
 ): Promise<void> {
   const n = Number(req.query.n || 10);
   const seenIssues = new Set();
-  const issues = (await monitor.newErrors())
+  const issues = (await monitor.topTrackedErrors())
     .filter(({group}) => !!group.trackingIssues)
     .map(({group: {groupId, trackingIssues}, representative: {message}}) => {
       let [title] = message.split('\n');

--- a/error-monitoring/static/error-list.html
+++ b/error-monitoring/static/error-list.html
@@ -112,6 +112,9 @@
         Starting with <em>All services</em> and moving right, inspect each error in the list
       </li>
       <li>
+        If the error is a duplicate of an error that already has a tracking issue, click the error message to visit the error page in Stackdriver and link the tracking issue manually.
+      </li>
+      <li>
         Verify that no sensitive or personally identifying information is contained in the error message
       </li>
       <li>


### PR DESCRIPTION
Also renames a couple functions

First piece of #931 