### PR TITLE
[error-monitoring] Add option to link existing GitHub issue to errors

### DIFF
--- a/error-monitoring/app.ts
+++ b/error-monitoring/app.ts
@@ -16,7 +16,7 @@
 
 require('dotenv').config();
 
-import {errorIssue, errorList, errorMonitor, topIssueList} from '.';
+import {errorIssue, errorList, errorMonitor, linkIssue, topIssueList} from '.';
 import {json, urlencoded} from 'body-parser';
 import express from 'express';
 
@@ -28,6 +28,7 @@ express()
   .get('/error-issue', errorIssue)
   .get(['/', '/error-list'], errorList)
   .get('/top-issues', topIssueList)
+  .get('/link-issue', linkIssue)
   .get('/_cron/monitor', errorMonitor)
   .listen(PORT, () => {
     console.log(`Listening on port ${PORT}`);

--- a/error-monitoring/index.ts
+++ b/error-monitoring/index.ts
@@ -333,3 +333,29 @@ export async function topIssueList(
 
   res.send(renderTopIssues(issues));
 }
+
+/** Link an existing GitHub issue to an error report. */
+export async function linkIssue(
+  req: express.Request,
+  res: express.Response
+): Promise<void> {
+  const {errorId, serviceType, normalizedThreshold} = req.query;
+  let issueNumber = req.query.issueNumber.toString();
+
+  if (issueNumber.startsWith('#')) {
+    issueNumber = issueNumber.substr(1);
+  }
+
+  try {
+    await stackdriver.setGroupIssue(
+      errorId.toString(),
+      `https://github.com/${GITHUB_REPO_OWNER}/${ISSUE_REPO_NAME}/issues/${issueNumber}`
+    );
+  } catch (e) {
+    console.error(e);
+  } finally {
+    res.redirect(
+      `/?serviceType=${serviceType}&normalizedThreshold=${normalizedThreshold}`
+    );
+  }
+}

--- a/error-monitoring/static/error-list.html
+++ b/error-monitoring/static/error-list.html
@@ -21,8 +21,11 @@
     ul {
       margin: 0;
     }
+    form input {
+      text-align: center;
+    }
     button,
-    .threshold-form input[name=threshold]  {
+    form input {
       background-color: #fff;
       border: 2px solid #d9edff;
       border-radius: 20px;
@@ -41,6 +44,7 @@
     input:focus {
       outline: none;
     }
+
     .onduty-guide {
       text-align: left;
       margin: 20px 100px;
@@ -49,14 +53,28 @@
       display: inline-block;
       margin-bottom: 10px;
     }
-    .threshold-form input[name=threshold] {
-      width: 75px;
-      text-align: center;
+    .button-service[selected] {
+      pointer-events: none;
     }
-    .threshold-form button[type=submit] {
+    .button-service[selected] button,
+    .button-blue {
+      background-color: #339dff;
+      color: white;
+    }
+
+    .split-input, .split-button {
+      width: 50%;
+      padding-left: 0;
+      padding-right: 0;
+    }
+    .split-input {
+      border-radius: 20px 0 0 20px;
+    }
+    .split-button {
       border-radius: 0 20px 20px 0;
       margin-left: -30px;
     }
+
     .error-report {
       border: 2px solid #e7e7e7;
       border-radius: 20px;
@@ -69,18 +87,6 @@
     .error-report-done {
       opacity: 40%;
       pointer-events: none;
-    }
-    .button-service[selected] {
-      pointer-events: none;
-    }
-    .button-service[selected] button,
-    .button-blue {
-      background-color: #339dff;
-      color: white;
-    }
-    .button-create {
-      display: block;
-      width: 100%;
     }
     .message {
       font-family: monospace;
@@ -96,6 +102,20 @@
       max-width: 100%;
       overflow-x: auto;
       padding: 20px;
+    }
+
+    .error-actions {
+      display: block;
+      width: 100%;
+      text-align: center;
+    }
+    .error-actions > * {
+      display: inline-block;
+      width: 48%;
+      margin: 0 1%;
+    }
+    .button-create {
+      width: 100%;
     }
   </style>
 </head>
@@ -128,10 +148,14 @@
     </ol>
 
     <strong>Frequency threshold:</strong>
-    <form method="GET" class="threshold-form">
-      <input type="number" name="threshold" value="{{serviceTypeThreshold}}">
+    <form method="GET" class="threshold-form split-input-button">
+      <input type="number"
+             name="threshold"
+             value="{{serviceTypeThreshold}}"
+             class="split-input"
+             required>
       <input type="hidden" name="serviceType" value="{{currentServiceType.name}}">
-      <button type="submit" class="button-blue">Update</button>
+      <button type="submit" class="button-blue split-button">Update</button>
     </form>
     <a href="?serviceType={{currentServiceType.name}}"><button>Reset</button></a>
     <br>
@@ -172,12 +196,37 @@
 
       <pre class="stacktrace"><code>{{& stacktrace}}</code></pre>
 
-      <a target="_blank"
-        rel="noopener noreferrer"
-        href="{{createUrl}}"
-        onclick="this.parentNode.classList.add('error-report-done')">
-        <button class="button-blue button-create">Create issue</button>
-      </a>
+      <div class="error-actions">
+        <a target="_blank"
+          rel="noopener noreferrer"
+          href="{{createUrl}}"
+          onclick="this.parentNode.classList.add('error-report-done')">
+          <button class="button-blue button-create">
+            Create new issue
+          </button>
+        </a><!--
+
+     --><form method="GET"
+              class="link-issue-form split-input-button"
+              action="/link-issue">
+          <input type="text"
+                 pattern="#?\d+"
+                 name="issueNumber"
+                 class="split-input"
+                 placeholder="#12345"
+                 required>
+          <input type="hidden" name="errorId" value="{{errorId}}">
+          <input type="hidden"
+                 name="serviceType"
+                 value="{{currentServiceType.name}}">
+          <input type="hidden"
+                 name="normalizedThreshold"
+                 value="{{normalizedThreshold}}">
+          <button type="submit" class="button-blue split-button">
+            Link existing issue
+          </button>
+        </form>
+      </div>
     </section>
   {{/errorReports}}
   {{^errorReports}}


### PR DESCRIPTION
This PR adds a simple button/input allowing the release on-duty to link an existing tracking issue to a duplicate error (common when different browsers/module builds report the same error with varying stacktraces). Includes an endpoint which links the tracking issue then returns to the error list.

Before:
![image](https://user-images.githubusercontent.com/6694512/87821485-efcd7080-c83d-11ea-9fb3-75bc3d1e1efb.png)

After:
![image](https://user-images.githubusercontent.com/6694512/87821458-e2b08180-c83d-11ea-9de1-05b2c978360f.png)
