### PR TITLE
[error-monitoring] Prepare for automatic issue filing but do not enable cron tasks yet

### DIFF
--- a/error-monitoring/cloud_build.yaml
+++ b/error-monitoring/cloud_build.yaml
@@ -52,6 +52,12 @@ steps:
       - app
       - deploy
     timeout: 1600s
+  - name: gcr.io/cloud-builders/gcloud
+    dir: error-monitoring
+    args:
+      - app
+      - deploy
+      - cron.yaml
 
 # These secrets are the base64-encoded form of encrypted secret values. They are
 # automatically decrypted and added to the `.env` environment at build time.

--- a/error-monitoring/cloud_build.yaml
+++ b/error-monitoring/cloud_build.yaml
@@ -52,12 +52,6 @@ steps:
       - app
       - deploy
     timeout: 1600s
-  - name: gcr.io/cloud-builders/gcloud
-    dir: error-monitoring
-    args:
-      - app
-      - deploy
-      - cron.yaml
 
 # These secrets are the base64-encoded form of encrypted secret values. They are
 # automatically decrypted and added to the `.env` environment at build time.

--- a/error-monitoring/cron.yaml
+++ b/error-monitoring/cron.yaml
@@ -1,13 +1,1 @@
 cron:
-- description: "File issues for errors in production"
-  url: /_cron/monitor?serviceType=production
-  schedule: every day 7:00
-- description: "File issues for errors in 1%/opt-in"
-  url: /_cron/monitor?serviceType=development
-  schedule: every day 7:02
-- description: "File issues for errors in experiments"
-  url: /_cron/monitor?serviceType=experiments
-  schedule: every day 7:04
-- description: "File issues for errors in nightly"
-  url: /_cron/monitor?serviceType=nightly
-  schedule: every day 7:06

--- a/error-monitoring/cron.yaml
+++ b/error-monitoring/cron.yaml
@@ -1,13 +1,13 @@
 cron:
 - description: "File issues for errors in production"
   url: /_cron/monitor?serviceType=production
-  schedule: every day at 7:00am
+  schedule: every day 7:00
 - description: "File issues for errors in 1%/opt-in"
   url: /_cron/monitor?serviceType=development
-  schedule: every day at 7:02am
+  schedule: every day 7:02
 - description: "File issues for errors in experiments"
   url: /_cron/monitor?serviceType=experiments
-  schedule: every day at 7:04am
+  schedule: every day 7:04
 - description: "File issues for errors in nightly"
   url: /_cron/monitor?serviceType=nightly
-  schedule: every day at 7:06am
+  schedule: every day 7:06

--- a/error-monitoring/index.ts
+++ b/error-monitoring/index.ts
@@ -50,7 +50,7 @@ const MAX_TITLE_LENGTH = 80;
 // the engineer to include which repo they are linking from (which, eventually,
 // will almost always be the new one), we can make an intelligent inference
 // about which repo the issue belongs to based on the issue number.
-const LEGACY_ISSUE_REPO_START = 20000;
+const LEGACY_ISSUE_REPO_START = 10000;
 
 let errorListTemplate = '';
 /** Renders the error list UI. */

--- a/error-monitoring/src/issue_builder.ts
+++ b/error-monitoring/src/issue_builder.ts
@@ -21,6 +21,7 @@ const MAX_CHANGED_FILES = 40;
 const MAX_POSSIBLE_ASSIGNEES = 2;
 const ERROR_HANDLING_FILES = ['src/error.js', 'src/log.js'];
 const ONE_YEAR_MS = 1000 * 60 * 60 * 24 * 365;
+const GITHUB_REPO = process.env.GITHUB_REPO || 'ampproject/amphtml';
 
 /**
  * Builds a GitHub issue for a reported error.
@@ -94,7 +95,7 @@ export class IssueBuilder {
   }: BlameRange): string {
     return (
       `\`${author}\` modified \`${path}:${startingLine}-${endingLine}\`` +
-      ` in #${prNumber} (${formatDate(committedDate)})`
+      ` in ${GITHUB_REPO}#${prNumber} (${formatDate(committedDate)})`
     );
   }
 

--- a/error-monitoring/test/fixtures/created-issue.md
+++ b/error-monitoring/test/fixtures/created-issue.md
@@ -13,8 +13,8 @@ Stacktrace
 
 Notes
 ---
-`@xymw` modified `extensions/amp-delight-player/0.1/amp-delight-player.js:396-439` in #17939 (Nov 12, 2018)
-`@rsimha` modified `src/event-helper-listen.js:57-59` in #12450 (Dec 13, 2017)
+`@xymw` modified `extensions/amp-delight-player/0.1/amp-delight-player.js:396-439` in test_org/test_repo#17939 (Nov 12, 2018)
+`@rsimha` modified `src/event-helper-listen.js:57-59` in test_org/test_repo#12450 (Dec 13, 2017)
 
 **Seen in:**
 - 04-24 Beta (1234)

--- a/error-monitoring/test/issue_builder.test.ts
+++ b/error-monitoring/test/issue_builder.test.ts
@@ -160,10 +160,10 @@ describe('IssueBuilder', () => {
       expect(notes).toContain(
         '`@xymw` modified ' +
           '`extensions/amp-delight-player/0.1/amp-delight-player.js:396-439` ' +
-          'in #17939 (Nov 12, 2018)'
+          'in test_org/test_repo#17939 (Nov 12, 2018)'
       );
       expect(notes).toContain(
-        '`@rsimha` modified `src/event-helper-listen.js:57-59` in #12450 ' +
+        '`@rsimha` modified `src/event-helper-listen.js:57-59` in test_org/test_repo#12450 ' +
           '(Dec 13, 2017)'
       );
     });

--- a/error-monitoring/test/jest-preload.ts
+++ b/error-monitoring/test/jest-preload.ts
@@ -19,3 +19,4 @@ global.console.info = jest.fn();
 global.console.debug = jest.fn();
 // Allow the environment to override if desired.
 process.env.LOG_LEVEL = process.env.LOG_LEVEL || 'warn';
+process.env.GITHUB_REPO = 'test_org/test_repo';


### PR DESCRIPTION
Fixes some configuration around automated error monitoring, filing issues in https://github.com/ampproject/error-reporting 