### PR TITLE
[error-monitoring] Lower threshold for legacy issue repo

### DIFF
--- a/error-monitoring/index.ts
+++ b/error-monitoring/index.ts
@@ -50,7 +50,7 @@ const MAX_TITLE_LENGTH = 80;
 // the engineer to include which repo they are linking from (which, eventually,
 // will almost always be the new one), we can make an intelligent inference
 // about which repo the issue belongs to based on the issue number.
-const LEGACY_ISSUE_REPO_START = 20000;
+const LEGACY_ISSUE_REPO_START = 10000;
 
 let errorListTemplate = '';
 /** Renders the error list UI. */


### PR DESCRIPTION
Threshold determines which repo to link to when providing an issue number. numbers under 10k are clearly new ones from `ampproject/error-reporting`, PR numbers over that belong to `ampproject/amphtml`. First attempt was 20k, which failed when linking really old issues in the 17000s