### PR TITLE
[test-case-reporting] Misc. fixes and updates to make app useful

### DIFF
--- a/test-case-reporting/app.ts
+++ b/test-case-reporting/app.ts
@@ -162,7 +162,7 @@ app.get('/test-cases/stats/:stat', async (req, res) => {
             return {
               id,
               name,
-              nameParts: name.split(' | ').filter(Boolean),
+              nameParts: name.split(' | ').filter(s => s.trim()),
               createdAt,
               stats: {
                 ...stats,

--- a/test-case-reporting/app.ts
+++ b/test-case-reporting/app.ts
@@ -153,7 +153,26 @@ app.get('/test-cases/stats/:stat', async (req, res) => {
       res.send(
         render('test-case-list', {
           title: `Test cases with highest "${stat}"% in the past ${sampleSize} runs`,
-          testCases,
+          testCases: testCases.map(({id, name, createdAt, stats}) => {
+            const {passed, failed, skipped, errored} = stats;
+            const total = passed + failed + skipped + errored;
+            const statPercent = (stat: number): string =>
+              ((100 * stat) / total).toFixed(0);
+
+            return {
+              id,
+              name,
+              createdAt,
+              stats: {
+                ...stats,
+                total,
+                passedPercent: statPercent(passed),
+                failedPercent: statPercent(failed),
+                skippedPercent: statPercent(skipped),
+                erroredPercent: statPercent(errored),
+              },
+            };
+          }),
         })
       );
     }

--- a/test-case-reporting/app.ts
+++ b/test-case-reporting/app.ts
@@ -154,8 +154,8 @@ app.get('/test-cases/stats/:stat', async (req, res) => {
         render('test-case-list', {
           title: `Test cases with highest "${stat}"% in the past ${sampleSize} builds`,
           testCases: testCases.map(({id, name, createdAt, stats}) => {
-            const {passed, failed, skipped, errored} = stats;
-            const total = passed + failed + skipped + errored;
+            const {pass, fail, skip, error} = stats;
+            const total = pass + fail + skip + error;
             const statPercent = (stat: number): string =>
               ((100 * stat) / total).toFixed(0);
 
@@ -167,10 +167,10 @@ app.get('/test-cases/stats/:stat', async (req, res) => {
               stats: {
                 ...stats,
                 total,
-                passedPercent: statPercent(passed),
-                failedPercent: statPercent(failed),
-                skippedPercent: statPercent(skipped),
-                erroredPercent: statPercent(errored),
+                passPercent: statPercent(pass),
+                failPercent: statPercent(fail),
+                skipPercent: statPercent(skip),
+                errorPercent: statPercent(error),
               },
             };
           }),

--- a/test-case-reporting/app.ts
+++ b/test-case-reporting/app.ts
@@ -152,7 +152,7 @@ app.get('/test-cases/stats/:stat', async (req, res) => {
     } else {
       res.send(
         render('test-case-list', {
-          title: `Test cases with highest "${stat}"% in the past ${sampleSize} runs`,
+          title: `Test cases with highest "${stat}"% in the past ${sampleSize} builds`,
           testCases: testCases.map(({id, name, createdAt, stats}) => {
             const {passed, failed, skipped, errored} = stats;
             const total = passed + failed + skipped + errored;

--- a/test-case-reporting/app.ts
+++ b/test-case-reporting/app.ts
@@ -162,6 +162,7 @@ app.get('/test-cases/stats/:stat', async (req, res) => {
             return {
               id,
               name,
+              nameParts: name.split(' | ').filter(Boolean),
               createdAt,
               stats: {
                 ...stats,

--- a/test-case-reporting/cloud_build.yaml
+++ b/test-case-reporting/cloud_build.yaml
@@ -47,7 +47,7 @@ steps:
     args:
       - app
       - deploy
-    timeout: 1600s
+    timeout: 3600s
   - name: gcr.io/cloud-builders/gcloud
     dir: test-case-reporting
     args:

--- a/test-case-reporting/cloud_build.yaml
+++ b/test-case-reporting/cloud_build.yaml
@@ -13,7 +13,7 @@ steps:
     secretEnv:
       - DB_PASSWORD
       - DB_USER
-  
+
   # Install app dependencies
   - name: gcr.io/cloud-builders/npm
     dir: test-case-reporting
@@ -47,6 +47,13 @@ steps:
     args:
       - app
       - deploy
+    timeout: 1600s
+  - name: gcr.io/cloud-builders/gcloud
+    dir: test-case-reporting
+    args:
+      - app
+      - deploy
+      - cron.yaml
 
 # These secrets are the base64-encoded form of encrypted secret values. They are
 # automatically decrypted and added to the `.env` environment at build time.

--- a/test-case-reporting/cron.yaml
+++ b/test-case-reporting/cron.yaml
@@ -1,7 +1,7 @@
 cron:
 - description: "Compute pass/fail % for past 10 runs of each test"
   url: /_cron/compute-stats?count=10
-  schedule: every 60 mins
+  schedule: every 15 mins
 - description: "Compute pass/fail % for past 100 runs of each test"
   url: /_cron/compute-stats?count=100
   schedule: every 60 mins

--- a/test-case-reporting/cron.yaml
+++ b/test-case-reporting/cron.yaml
@@ -1,7 +1,7 @@
 cron:
 - description: "Compute pass/fail % for past 10 runs of each test"
   url: /_cron/compute-stats?count=10
-  schedule: every hour
+  schedule: every 60 mins
 - description: "Compute pass/fail % for past 100 runs of each test"
   url: /_cron/compute-stats?count=100
-  schedule: every hour
+  schedule: every 60 mins

--- a/test-case-reporting/cron.yaml
+++ b/test-case-reporting/cron.yaml
@@ -1,7 +1,7 @@
 cron:
 - description: "Compute pass/fail % for past 10 runs of each test"
   url: /_cron/compute-stats?count=10
-  schedule: every 15 mins
+  schedule: every 5 mins
 - description: "Compute pass/fail % for past 100 runs of each test"
   url: /_cron/compute-stats?count=100
-  schedule: every 60 mins
+  schedule: every 15 mins

--- a/test-case-reporting/src/setup_db.ts
+++ b/test-case-reporting/src/setup_db.ts
@@ -84,10 +84,10 @@ export async function setupDb(db: Database): Promise<unknown> {
       table.increments('id').primary();
       table.specificType('test_case_id', 'char(32)').notNullable();
       table.integer('sample_size').unsigned().notNullable();
-      table.integer('passed').unsigned().notNullable().defaultTo(0);
-      table.integer('failed').unsigned().notNullable().defaultTo(0);
-      table.integer('skipped').unsigned().notNullable().defaultTo(0);
-      table.integer('errored').unsigned().notNullable().defaultTo(0);
+      table.integer('pass').unsigned().notNullable().defaultTo(0);
+      table.integer('fail').unsigned().notNullable().defaultTo(0);
+      table.integer('skip').unsigned().notNullable().defaultTo(0);
+      table.integer('error').unsigned().notNullable().defaultTo(0);
       table.boolean('dirty').defaultTo(false);
 
       table.foreign('test_case_id').references('id').inTable('test_cases');

--- a/test-case-reporting/src/setup_db.ts
+++ b/test-case-reporting/src/setup_db.ts
@@ -27,6 +27,7 @@ export async function setupDb(db: Database): Promise<unknown> {
       table.increments('id').primary();
       table.string('commit_sha', 40);
       table.string('build_number');
+      table.string('url');
       table
         .timestamp('started_at', {precision: TIMESTAMP_PRECISION})
         .defaultTo(db.fn.now())
@@ -36,6 +37,7 @@ export async function setupDb(db: Database): Promise<unknown> {
       table.increments('id').primary();
       table.integer('build_id').unsigned().notNullable();
       table.string('job_number');
+      table.string('url');
       table.string('test_suite_type');
       table
         .timestamp('started_at', {precision: TIMESTAMP_PRECISION})

--- a/test-case-reporting/src/test_case_stats.ts
+++ b/test-case-reporting/src/test_case_stats.ts
@@ -78,7 +78,7 @@ export class TestCaseStats {
     sampleSize: number
   ): Promise<void> {
     await trx('test_case_stats')
-      .where({sample_size: sampleSize, dirty: true})
+      .where({'sample_size': sampleSize, dirty: true})
       .delete();
   }
 

--- a/test-case-reporting/src/test_case_stats.ts
+++ b/test-case-reporting/src/test_case_stats.ts
@@ -13,11 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// require('dotenv').config();
-// const pg = require('pg');
-// pg.types.setTypeParser(20, 'text', parseInt);
-// const db = dbConnect();
-// const limit = 10;
+
 import {Database} from './db';
 import {TestStatus} from 'test-case-reporting';
 import Knex from 'knex';
@@ -64,7 +60,7 @@ export class TestCaseStats {
     sampleSize: number
   ): Promise<void> {
     await trx('test_case_stats')
-      .where({sample_size: sampleSize})
+      .where({'sample_size': sampleSize})
       .update({dirty: true});
   }
 
@@ -99,7 +95,7 @@ export class TestCaseStats {
     // because selecting the first N of a group-by clause is very inefficient,
     // but the subquery here using the jobs table as a proxy has the same effect
     // but with better query performance.
-    const lastNBuilds = this.db('buids')
+    const lastNBuilds = this.db('builds')
       .orderBy('started_at', 'DESC')
       .limit(sampleSize)
       .select('id');

--- a/test-case-reporting/src/test_case_stats.ts
+++ b/test-case-reporting/src/test_case_stats.ts
@@ -128,10 +128,10 @@ export class TestCaseStats {
           'test_case_stats',
           'test_case_id',
           'sample_size',
-          'passed',
-          'failed',
-          'skipped',
-          'errored',
+          'pass',
+          'fail',
+          'skip',
+          'error',
         ])
       )
       .insert(function () {

--- a/test-case-reporting/src/test_result_record.ts
+++ b/test-case-reporting/src/test_result_record.ts
@@ -112,6 +112,7 @@ export class TestResultRecord {
       .insert({
         'commit_sha': build.commitSha,
         'build_number': build.buildNumber,
+        'url': build.url,
       } as DB.Build)
       .returning('id');
 
@@ -126,6 +127,7 @@ export class TestResultRecord {
       .insert({
         'build_id': buildId,
         'job_number': job.jobNumber,
+        'url': job.url,
         'test_suite_type': job.testSuiteType,
       } as DB.Job)
       .returning('id');

--- a/test-case-reporting/src/test_result_record.ts
+++ b/test-case-reporting/src/test_result_record.ts
@@ -319,7 +319,7 @@ export class TestResultRecord {
     stat: string,
     {limit, offset}: PageInfo
   ): Promise<Array<TestCase>> {
-    if (!['passed', 'failed', 'skipped', 'errored'].includes(stat)) {
+    if (!['pass', 'fail', 'skip', 'error'].includes(stat)) {
       throw new TypeError(`Bad stat used for sorting test cases: "${stat}"`);
     }
 
@@ -332,10 +332,10 @@ export class TestResultRecord {
       .select<Array<DB.TestCase & DB.TestCaseStats>>(
         this.db.raw('CAST(?? AS DECIMAL) / (?? + ?? + ?? + ??) AS ??', [
           stat,
-          'passed',
-          'failed',
-          'skipped',
-          'errored',
+          'pass',
+          'fail',
+          'skip',
+          'error',
           `${stat}_percent`,
         ]),
         '*'
@@ -346,25 +346,16 @@ export class TestResultRecord {
 
     /* eslint-disable @typescript-eslint/camelcase */
     return dbTestCases.map(
-      ({
-        id,
-        name,
-        created_at,
-        sample_size,
-        passed,
-        failed,
-        skipped,
-        errored,
-      }) => ({
+      ({id, name, created_at, sample_size, pass, fail, skip, error}) => ({
         id,
         name,
         createdAt: new Date(created_at),
         stats: {
           sampleSize: sample_size,
-          passed,
-          failed,
-          skipped,
-          errored,
+          pass,
+          fail,
+          skip,
+          error,
         },
       })
     );

--- a/test-case-reporting/src/test_result_record.ts
+++ b/test-case-reporting/src/test_result_record.ts
@@ -38,9 +38,11 @@ type QueryFunction = (q: QueryBuilder) => QueryBuilder;
  */
 function getTestRunFromRow({
   build_number,
+  build_url,
   build_started_at,
   commit_sha,
   job_number,
+  job_url,
   test_suite_type,
   name,
   created_at,
@@ -52,11 +54,13 @@ function getTestRunFromRow({
     buildNumber: build_number,
     commitSha: commit_sha,
     startedAt: new Date(build_started_at),
+    url: build_url,
   };
 
   const job: Job = {
     build,
     jobNumber: job_number,
+    url: job_url,
     testSuiteType: test_suite_type,
   };
 
@@ -240,10 +244,12 @@ export class TestResultRecord {
 
     const rows = await fullQuery.select(
       'builds.build_number',
+      'builds.url AS build_url',
       'builds.commit_sha',
-      'builds.started_at as build_started_at',
+      'builds.started_at AS build_started_at',
 
       'jobs.job_number',
+      'jobs.url AS job_url',
       'jobs.test_suite_type',
 
       'test_cases.name',

--- a/test-case-reporting/src/test_result_record.ts
+++ b/test-case-reporting/src/test_result_record.ts
@@ -313,9 +313,10 @@ export class TestResultRecord {
       'test_case_stats'
     )
       .where('test_case_stats.sample_size', sampleSize)
+      .where(stat, '>', 0)
       .join('test_cases', 'test_cases.id', 'test_case_stats.test_case_id')
       .select<Array<DB.TestCase & DB.TestCaseStats>>(
-        this.db.raw('?? / (?? + ?? + ?? + ??) AS ??', [
+        this.db.raw('CAST(?? AS DECIMAL) / (?? + ?? + ?? + ??) AS ??', [
           stat,
           'passed',
           'failed',

--- a/test-case-reporting/src/test_result_record.ts
+++ b/test-case-reporting/src/test_result_record.ts
@@ -163,6 +163,17 @@ export class TestResultRecord {
   }
 
   /**
+   * Helper that isolates the test case name when the error is reported in the
+   * before/after each hook, allowing proper grouping by name.
+   */
+  maybeUnwrapHookMessage(result: {description: string}): void {
+    result.description = result.description.replace(
+      /"(?:before|after) each" hook for "(.*)"$/,
+      '$1'
+    );
+  }
+
+  /**
    * Stores a travis report on the database. This involves inserting
    * a job, a build, many test runs, and many test cases.
    * Duplicate test cases and builds are not inserted.
@@ -176,6 +187,7 @@ export class TestResultRecord {
       .map(({results}) => results)
       .reduce((flattenedArray, array) => flattenedArray.concat(array), [])
       .map(result => {
+        this.maybeUnwrapHookMessage(result);
         const testCaseName = this.testCaseName(result);
         return {
           ...result,

--- a/test-case-reporting/static/css/custom.css
+++ b/test-case-reporting/static/css/custom.css
@@ -29,6 +29,6 @@
 .status-skip { background-color: gray; }
 .status-error { background-color: red; }
 
-.test-run-info {
-  margin: 0.5em 2em 0, 2em;
+.test-run-name {
+  line-height: 1.25em;
 }

--- a/test-case-reporting/static/css/custom.css
+++ b/test-case-reporting/static/css/custom.css
@@ -20,7 +20,6 @@
   font-family: sans-serif;
   font-variant: small-caps;
   color: white;
-  margin-right: 10px;
   text-align: center;
   font-weight: bold;
 }
@@ -31,4 +30,7 @@
 
 .test-run-name {
   line-height: 1.25em;
+}
+.test-run-name td {
+  padding: 0.5em;
 }

--- a/test-case-reporting/static/css/custom.css
+++ b/test-case-reporting/static/css/custom.css
@@ -28,3 +28,7 @@
 .status-fail { background-color: orange; }
 .status-skip { background-color: gray; }
 .status-error { background-color: red; }
+
+.test-run-info {
+  margin: 0.5em 2em 0, 2em;
+}

--- a/test-case-reporting/static/test-case-list.html
+++ b/test-case-reporting/static/test-case-list.html
@@ -26,25 +26,33 @@
       {{#testCases}}
         <div class="tile">
         {{#stats}}
-          <span class="status-badge status-pass"
-                title="Passed: {{passed}}/{{total}} (last {{sampleSize}} builds)">
-            {{passedPercent}}%
-          </span>
+          <a href="/test-cases/stats/pass">
+            <span class="status-badge status-pass"
+                  title="Passed: {{pass}}/{{total}} (last {{sampleSize}} builds)">
+              {{passPercent}}%
+            </span>
+          </a>
 
-          <span class="status-badge status-fail"
-                title="Failed: {{failed}}/{{total}} (last {{sampleSize}} builds)">
-            {{failedPercent}}%
-          </span>
+          <a href="/test-cases/stats/fail">
+            <span class="status-badge status-fail"
+                  title="Failed: {{fail}}/{{total}} (last {{sampleSize}} builds)">
+              {{failPercent}}%
+            </span>
+          </a>
 
-          <span class="status-badge status-error"
-                title="Errored: {{errored}}/{{total}} (last {{sampleSize}} builds)">
-            {{erroredPercent}}%
-          </span>
+          <a href="/test-cases/stats/error">
+            <span class="status-badge status-error"
+                  title="Errored: {{error}}/{{total}} (last {{sampleSize}} builds)">
+              {{errorPercent}}%
+            </span>
+          </a>
 
-          <span class="status-badge status-skip"
-                title="Skipped: {{skipped}}/{{total}} (last {{sampleSize}} builds)">
-            {{skippedPercent}}%
-          </span>
+          <a href="/test-cases/stats/skip">
+            <span class="status-badge status-skip"
+                  title="Skipped: {{skip}}/{{total}} (last {{sampleSize}} builds)">
+              {{skipPercent}}%
+            </span>
+          </a>
         {{/stats}}
 
           <br>

--- a/test-case-reporting/static/test-case-list.html
+++ b/test-case-reporting/static/test-case-list.html
@@ -27,22 +27,22 @@
         <div class="tile">
         {{#stats}}
           <span class="status-badge status-pass"
-                title="Passed: {{passed}}/{{total}} (last {{sampleSize}} jobs)">
+                title="Passed: {{passed}}/{{total}} (last {{sampleSize}} builds)">
             {{passedPercent}}%
           </span>
 
           <span class="status-badge status-fail"
-                title="Failed: {{failed}}/{{total}} (last {{sampleSize}} jobs)">
+                title="Failed: {{failed}}/{{total}} (last {{sampleSize}} builds)">
             {{failedPercent}}%
           </span>
 
           <span class="status-badge status-error"
-                title="Errored: {{errored}}/{{total}} (last {{sampleSize}} jobs)">
+                title="Errored: {{errored}}/{{total}} (last {{sampleSize}} builds)">
             {{erroredPercent}}%
           </span>
 
           <span class="status-badge status-skip"
-                title="Skipped: {{skipped}}/{{total}} (last {{sampleSize}} jobs)">
+                title="Skipped: {{skipped}}/{{total}} (last {{sampleSize}} builds)">
             {{skippedPercent}}%
           </span>
         {{/stats}}

--- a/test-case-reporting/static/test-case-list.html
+++ b/test-case-reporting/static/test-case-list.html
@@ -27,22 +27,22 @@
         <div class="tile">
         {{#stats}}
           <span class="status-badge status-pass"
-                title="{{passed}}/{{total}} (last {{sampleSize}} jobs)">
+                title="Passed: {{passed}}/{{total}} (last {{sampleSize}} jobs)">
             {{passedPercent}}%
           </span>
 
           <span class="status-badge status-fail"
-                title="{{failed}}/{{total}} (last {{sampleSize}} jobs)">
+                title="Failed: {{failed}}/{{total}} (last {{sampleSize}} jobs)">
             {{failedPercent}}%
           </span>
 
           <span class="status-badge status-error"
-                title="{{errored}}/{{total}} (last {{sampleSize}} jobs)">
+                title="Errored: {{errored}}/{{total}} (last {{sampleSize}} jobs)">
             {{erroredPercent}}%
           </span>
 
           <span class="status-badge status-skip"
-                title="{{skipped}}/{{total}} (last {{sampleSize}} jobs)">
+                title="Skipped: {{skipped}}/{{total}} (last {{sampleSize}} jobs)">
             {{skippedPercent}}%
           </span>
         {{/stats}}

--- a/test-case-reporting/static/test-case-list.html
+++ b/test-case-reporting/static/test-case-list.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <!-- Surface style taken from https://github.com/niutech/amp-surface -->
   <link rel="stylesheet" type="text/css" href="/surface.min.css"/>
+  <link rel="stylesheet" type="text/css" href="/custom.css"/>
 </head>
 <body>
   <div class="g--10 m--1">
@@ -13,8 +14,35 @@
       <h1>{{title}}</h1>
       {{#testCases}}
         <div class="tile">
-          <a href="/test-results/history/{{id}}">Test case {{name}}</a>. More info soon.</div>
+        {{#stats}}
+          <span class='status-badge status-pass'
+                title='{{passed}}/{{total}} (last {{sampleSize}} jobs)'>
+            {{passedPercent}}%
+          </span>
+
+          <span class='status-badge status-fail'
+                title='{{failed}}/{{total}} (last {{sampleSize}} jobs)'>
+            {{failedPercent}}%
+          </span>
+
+          <span class='status-badge status-error'
+                title='{{errored}}/{{total}} (last {{sampleSize}} jobs)'>
+            {{erroredPercent}}%
+          </span>
+
+          <span class='status-badge status-skip'
+                title='{{skipped}}/{{total}} (last {{sampleSize}} jobs)'>
+            {{skippedPercent}}%
+          </span>
+        {{/stats}}
+
+          <br>
+          <a href="/test-results/history/{{id}}" title="{{name}}">
+            {{name}}
+          </a>
+        </div>
       {{/testCases}}
+
       {{^testCases}}
           There are no test cases.
       {{/testCases}}

--- a/test-case-reporting/static/test-case-list.html
+++ b/test-case-reporting/static/test-case-list.html
@@ -7,6 +7,17 @@
   <!-- Surface style taken from https://github.com/niutech/amp-surface -->
   <link rel="stylesheet" type="text/css" href="/surface.min.css"/>
   <link rel="stylesheet" type="text/css" href="/custom.css"/>
+  <style>
+    .divider {
+      padding: 0 3px;
+      font-size: 0.75em;
+      font-weight: bold;
+      vertical-align: middle;
+    }
+    .divider:last-of-type {
+      display: none;
+    }
+  </style>
 </head>
 <body>
   <div class="g--10 m--1">
@@ -15,30 +26,32 @@
       {{#testCases}}
         <div class="tile">
         {{#stats}}
-          <span class='status-badge status-pass'
-                title='{{passed}}/{{total}} (last {{sampleSize}} jobs)'>
+          <span class="status-badge status-pass"
+                title="{{passed}}/{{total}} (last {{sampleSize}} jobs)">
             {{passedPercent}}%
           </span>
 
-          <span class='status-badge status-fail'
-                title='{{failed}}/{{total}} (last {{sampleSize}} jobs)'>
+          <span class="status-badge status-fail"
+                title="{{failed}}/{{total}} (last {{sampleSize}} jobs)">
             {{failedPercent}}%
           </span>
 
-          <span class='status-badge status-error'
-                title='{{errored}}/{{total}} (last {{sampleSize}} jobs)'>
+          <span class="status-badge status-error"
+                title="{{errored}}/{{total}} (last {{sampleSize}} jobs)">
             {{erroredPercent}}%
           </span>
 
-          <span class='status-badge status-skip'
-                title='{{skipped}}/{{total}} (last {{sampleSize}} jobs)'>
+          <span class="status-badge status-skip"
+                title="{{skipped}}/{{total}} (last {{sampleSize}} jobs)">
             {{skippedPercent}}%
           </span>
         {{/stats}}
 
           <br>
-          <a href="/test-results/history/{{id}}" title="{{name}}">
-            {{name}}
+          <a href="/test-results/history/{{id}}">
+          {{#nameParts}}
+            {{.}}<small class='divider'>&gt;&gt;</small>
+          {{/nameParts}}
           </a>
         </div>
       {{/testCases}}

--- a/test-case-reporting/static/test-case-list.html
+++ b/test-case-reporting/static/test-case-list.html
@@ -30,29 +30,29 @@
             <span class="status-badge status-pass"
                   title="Passed: {{pass}}/{{total}} (last {{sampleSize}} builds)">
               {{passPercent}}%
-            </span>
-          </a>
+            </span><!--
+       --></a>
 
           <a href="/test-cases/stats/fail">
             <span class="status-badge status-fail"
                   title="Failed: {{fail}}/{{total}} (last {{sampleSize}} builds)">
               {{failPercent}}%
-            </span>
-          </a>
+            </span><!--
+       --></a>
 
           <a href="/test-cases/stats/error">
             <span class="status-badge status-error"
                   title="Errored: {{error}}/{{total}} (last {{sampleSize}} builds)">
               {{errorPercent}}%
-            </span>
-          </a>
+            </span><!--
+       --></a>
 
           <a href="/test-cases/stats/skip">
             <span class="status-badge status-skip"
                   title="Skipped: {{skip}}/{{total}} (last {{sampleSize}} builds)">
               {{skipPercent}}%
-            </span>
-          </a>
+            </span><!--
+       --></a>
         {{/stats}}
 
           <br>

--- a/test-case-reporting/static/test-run-list.html
+++ b/test-case-reporting/static/test-run-list.html
@@ -20,8 +20,22 @@
               <a href="/test-results/history/{{testRun.testCase.id}}">{{testRun.testCase.name}}</a>
             </label>
             <div class="collapsible-{{index}}-area">
-              <p>Job: {{testRun.job.jobNumber}}</p>
-              <p>Build: <a href="/test-results/build/{{testRun.job.build.buildNumber}}">{{testRun.job.build.buildNumber}}</a></p>
+              {{#testRun.job}}
+              <p>
+                Job: {{jobNumber}}
+                {{#url}}(<a href="{{.}}">Travis</a>){{/url}}
+              </p>
+
+              <p>
+                {{#build}}
+                Build:
+                <a href="/test-results/build/{{build.buildNumber}}">
+                  {{buildNumber}}
+                </a>
+                {{#url}}(<a href="{{.}}">Travis</a>){{/url}}
+                {{/build}}
+              </p>
+              {{/testRun.job}}
             </div>
           </div>
         {{/testRuns}}

--- a/test-case-reporting/static/test-run-list.html
+++ b/test-case-reporting/static/test-run-list.html
@@ -16,7 +16,9 @@
           <div class="collapsible-wrap card no-pad">
             <input type="checkbox" id="collapsible-{{index}}">
             <label for="collapsible-{{index}}">
-              <span class='status-badge status-{{testRun.status}}'>{{testRun.status}}</span>&nbsp;
+              <a href="/test-cases/stats/{{testRun.status}}">
+                <span class='status-badge status-{{testRun.status}}'>{{testRun.status}}</span>&nbsp;
+              </a>
               <a href="/test-results/history/{{testRun.testCase.id}}">{{testRun.testCase.name}}</a>
             </label>
             <div class="collapsible-{{index}}-area">

--- a/test-case-reporting/static/test-run-list.html
+++ b/test-case-reporting/static/test-run-list.html
@@ -13,30 +13,28 @@
       <div class="g--8 g-s--12 center">
         <h1>{{title}}</h1>
         {{#testRuns}}
-          <div class="collapsible-wrap card no-pad">
-            <input type="checkbox" id="collapsible-{{index}}">
-            <label for="collapsible-{{index}}">
-              <a href="/test-cases/stats/{{testRun.status}}">
-                <span class='status-badge status-{{testRun.status}}'>{{testRun.status}}</span>&nbsp;
-              </a>
-              <a href="/test-results/history/{{testRun.testCase.id}}">{{testRun.testCase.name}}</a>
-            </label>
-            <div class="collapsible-{{index}}-area">
-              {{#testRun.job}}
-              <p>
-                Job: {{jobNumber}}
-                {{#url}}(<a href="{{.}}">Travis</a>){{/url}}
-              </p>
+          <div class="card">
+            <a href="/test-cases/stats/{{testRun.status}}">
+              <span class='status-badge status-{{testRun.status}}'>{{testRun.status}}</span>&nbsp;
+            </a>
+            <a href="/test-results/history/{{testRun.testCase.id}}">{{testRun.testCase.name}}</a>
 
-              <p>
-                {{#build}}
-                Build:
-                <a href="/test-results/build/{{build.buildNumber}}">
-                  {{buildNumber}}
-                </a>
-                {{#url}}(<a href="{{.}}">Travis</a>){{/url}}
-                {{/build}}
-              </p>
+            <div class="test-run-info">
+              {{#testRun.job}}
+
+              Job: {{jobNumber}}
+              {{#url}}(<a href="{{.}}">Travis</a>){{/url}}
+
+              <br>
+
+              {{#build}}
+              Build:
+              <a href="/test-results/build/{{build.buildNumber}}">
+                {{buildNumber}}
+              </a>
+              {{#url}}(<a href="{{.}}">Travis</a>){{/url}}
+              {{/build}}
+
               {{/testRun.job}}
             </div>
           </div>

--- a/test-case-reporting/static/test-run-list.html
+++ b/test-case-reporting/static/test-run-list.html
@@ -18,8 +18,10 @@
           <tr class="test-run-name">
             <td colspan="2">
               <a href="/test-cases/stats/{{testRun.status}}">
-                <span class='status-badge status-{{testRun.status}}'>{{testRun.status}}</span>&nbsp;
-              </a>
+                <span class='status-badge status-{{testRun.status}}'>
+                  {{testRun.status}}
+                </span><!--
+           --></a>
               <a href="/test-results/history/{{testRun.testCase.id}}">{{testRun.testCase.name}}</a>
             </td>
           </tr>

--- a/test-case-reporting/static/test-run-list.html
+++ b/test-case-reporting/static/test-run-list.html
@@ -12,22 +12,28 @@
     <div class="g--10 m--1">
       <div class="g--8 g-s--12 center">
         <h1>{{title}}</h1>
-        {{#testRuns}}
-          <div class="card">
-            <a href="/test-cases/stats/{{testRun.status}}">
-              <span class='status-badge status-{{testRun.status}}'>{{testRun.status}}</span>&nbsp;
-            </a>
-            <a href="/test-results/history/{{testRun.testCase.id}}">{{testRun.testCase.name}}</a>
 
-            <div class="test-run-info">
+        <table class="card">
+          {{#testRuns}}
+          <tr class="test-run-name">
+            <td colspan="2">
+              <a href="/test-cases/stats/{{testRun.status}}">
+                <span class='status-badge status-{{testRun.status}}'>{{testRun.status}}</span>&nbsp;
+              </a>
+              <a href="/test-results/history/{{testRun.testCase.id}}">{{testRun.testCase.name}}</a>
+            </td>
+          </tr>
+
+          <tr>
+            <td>
               {{#testRun.job}}
 
               Job: {{jobNumber}}
               {{#url}}(<a href="{{.}}">Travis</a>){{/url}}
-
-              <br>
+            </td>
 
               {{#build}}
+            <td>
               Build:
               <a href="/test-results/build/{{build.buildNumber}}">
                 {{buildNumber}}
@@ -36,9 +42,10 @@
               {{/build}}
 
               {{/testRun.job}}
-            </div>
-          </div>
-        {{/testRuns}}
+            </td>
+          </tr>
+          {{/testRuns}}
+        </table>
         {{^testRuns}}
           <h2>
             There are no test runs.

--- a/test-case-reporting/test/test_result_record.test.ts
+++ b/test-case-reporting/test/test_result_record.test.ts
@@ -54,11 +54,13 @@ describe('TestResultRecord', () => {
   const sampleBuild: Travis.Build = {
     buildNumber: '413413',
     commitSha: 'abcdefg123gomugomu',
+    url: 'http://travis.org/build/413413',
   };
 
   const sampleJob: Travis.Job = {
     jobNumber: '413413.612',
     testSuiteType: 'unit',
+    url: 'http://travis.org/job/413413.612',
   };
 
   const sampleKarmaReport: KarmaReporter.TestResultReport = (getFixture(
@@ -103,9 +105,7 @@ describe('TestResultRecord', () => {
       it('adds the build to the database', async () => {
         await testResultRecord.insertTravisBuild(sampleBuild);
 
-        const build = await db<DB.Build>('builds')
-          .select()
-          .first();
+        const build = await db<DB.Build>('builds').select().first();
 
         expect(build).toMatchObject({
           'build_number': '413413',
@@ -124,9 +124,7 @@ describe('TestResultRecord', () => {
       it('adds the job to the database if the build exists in the DB', async () => {
         await testResultRecord.insertTravisJob(sampleJob, buildId);
 
-        const job = await db<DB.Job>('jobs')
-          .select()
-          .first();
+        const job = await db<DB.Job>('jobs').select().first();
 
         expect(job).toMatchObject({
           'job_number': '413413.612',

--- a/test-case-reporting/test/test_result_record.test.ts
+++ b/test-case-reporting/test/test_result_record.test.ts
@@ -60,7 +60,7 @@ describe('TestResultRecord', () => {
   const sampleJob: Travis.Job = {
     jobNumber: '413413.612',
     testSuiteType: 'unit',
-    url: 'http://travis.org/job/413413.612',
+    url: 'http://travis.org/job/413413.6',
   };
 
   const sampleKarmaReport: KarmaReporter.TestResultReport = (getFixture(
@@ -110,6 +110,7 @@ describe('TestResultRecord', () => {
         expect(build).toMatchObject({
           'build_number': '413413',
           'commit_sha': 'abcdefg123gomugomu',
+          url: 'http://travis.org/build/413413',
         });
       });
     });
@@ -129,6 +130,7 @@ describe('TestResultRecord', () => {
         expect(job).toMatchObject({
           'job_number': '413413.612',
           'test_suite_type': 'unit',
+          url: 'http://travis.org/job/413413.6',
         });
       });
 
@@ -205,6 +207,7 @@ describe('TestResultRecord', () => {
         expect(spy).toBeCalledWith({
           buildNumber: '413413',
           commitSha: 'abcdefg123gomugomu',
+          url: 'http://travis.org/build/413413',
         });
       });
 
@@ -216,6 +219,7 @@ describe('TestResultRecord', () => {
           {
             'jobNumber': '413413.612',
             'testSuiteType': 'unit',
+            url: 'http://travis.org/job/413413.6',
           },
           1
         );

--- a/test-case-reporting/types/test-case-reporting.d.ts
+++ b/test-case-reporting/types/test-case-reporting.d.ts
@@ -29,6 +29,7 @@ declare module 'test-case-reporting' {
     // Despite being a *Number, buildNumber is of type string for parity with
     // jobNumber
     buildNumber: string;
+    url?: string;
     startedAt: Date;
   }
 
@@ -40,6 +41,7 @@ declare module 'test-case-reporting' {
     // For the 456th job in the 123rd build,
     // this looks like `123.456`
     jobNumber: string;
+    url?: string;
     testSuiteType: TestSuiteType;
   }
 

--- a/test-case-reporting/types/test-case-reporting.d.ts
+++ b/test-case-reporting/types/test-case-reporting.d.ts
@@ -86,6 +86,7 @@ declare module 'test-case-reporting' {
     export interface Build {
       id?: number;
       commit_sha: string;
+      url?: string;
 
       // Despite being a *_number, build_number is of type string for parity with
       // job_number
@@ -96,6 +97,7 @@ declare module 'test-case-reporting' {
     export interface Job {
       id?: number;
       build_id: number;
+      url?: string;
 
       // Despite being a *_number, job_number is of type string because it includes periods.
       // For the 456th job in the 123rd build,
@@ -128,6 +130,8 @@ declare module 'test-case-reporting' {
         TestCase,
         TestRun {
       build_started_at: number;
+      build_url: string;
+      job_url: string;
     }
 
     export interface TestCaseStats {

--- a/test-case-reporting/types/test-case-reporting.d.ts
+++ b/test-case-reporting/types/test-case-reporting.d.ts
@@ -56,10 +56,10 @@ declare module 'test-case-reporting' {
 
   export interface TestCaseStats {
     sampleSize: number;
-    passed: number;
-    failed: number;
-    skipped: number;
-    errored: number;
+    pass: number;
+    fail: number;
+    skip: number;
+    error: number;
   }
 
   /** An instance of a test being run, with results. */
@@ -134,10 +134,10 @@ declare module 'test-case-reporting' {
       id?: number;
       test_case_id: string;
       sample_size: number;
-      passed: number;
-      failed: number;
-      skipped: number;
-      errored: number;
+      pass: number;
+      fail: number;
+      skip: number;
+      error: number;
       dirty?: boolean;
     }
   }

--- a/test-case-reporting/types/test-case-reporting.d.ts
+++ b/test-case-reporting/types/test-case-reporting.d.ts
@@ -49,6 +49,15 @@ declare module 'test-case-reporting' {
     id: string;
     name: string;
     createdAt: Date;
+    stats?: TestCaseStats;
+  }
+
+  export interface TestCaseStats {
+    sampleSize: number;
+    passed: number;
+    failed: number;
+    skipped: number;
+    errored: number;
   }
 
   /** An instance of a test being run, with results. */

--- a/test-case-reporting/types/test-case-reporting.d.ts
+++ b/test-case-reporting/types/test-case-reporting.d.ts
@@ -173,10 +173,12 @@ declare module 'test-case-reporting' {
     export interface Build {
       buildNumber: string;
       commitSha: string;
+      url: string;
     }
     export interface Job {
       jobNumber: string;
       testSuiteType: TestSuiteType;
+      url: string;
     }
   }
 }


### PR DESCRIPTION
This PR includes a smattering of fixes and small tweaks. Many of these tweaks are only to display extra info (pass/fail stats, Travis links, etc) in the front-end. The current front-end is a bare minimum display of simple info, done this way so Ricardo would have a simple UI to present, but the plan is to build a proper front-end using the JSON endpoints in the server. 

TL;DR - Changes in HTML files and the request handlers in `app.js` are not intended to be perfect, just minimally usable for the purposes of identifying broken/flaky tests and navigating around the app.

This PR:
- fixes the cron configuration and updates it to run frequently-er
- extends the timeout for Cloud Build (so builds don't fail because `gcloud app deploy` takes forever)
- add deployment of cron changes to Cloud Build
- support the now-reported build and job URLs on the backend, and link to them (when available) in the frontend
- standardize some naming (ie. `passed` vs `pass`, `skipped` vs `skip`, etc)
- aggregate stats over the last N builds rather than the last N jobs
- handle cases where Karma reports a failed test as `"before/after each" hook for "do a thing test"`, which breaks grouping by test name

Changes live: http://amp-test-cases.appspot.com/test-cases/stats/fail
![image](https://user-images.githubusercontent.com/6694512/95630375-b9278080-0a4f-11eb-96bf-a9b7b7ceea18.png)
