### PR TITLE
Update Travis API URL from `.org` to `.com`

### DIFF
--- a/project-metrics/metrics_service/apis/travis.py
+++ b/project-metrics/metrics_service/apis/travis.py
@@ -40,7 +40,7 @@ class TravisApi(agithub_base.API):
     }
 
     props = agithub_base.ConnectionProperties(
-        api_url='api.travis-ci.org',
+        api_url='api.travis-ci.com',
         secure_http=True,
         extra_headers=extra_headers)
     self.setClient(agithub_base.Client(*args, **kwargs))


### PR DESCRIPTION
This is in anticipation of the mandatory [migration from `travis-ci.org` to `travis-ci.com`](https://docs.travis-ci.com/user/migrate/open-source-repository-migration#migrating-a-repository) that was announced in 2018, but is being enforced soon. AMP is going to do this migration later today. We'll need to merge the PR after the migration is in place. Since this change is not in the critical path for development, it can be reviewed and merged when convenient.

Companion PR to https://github.com/ampproject/amphtml/pull/30846