### PR TITLE
[build-system] Increase gcloud deploy timeout to 20 minutes for all projects

### DIFF
--- a/bundle-size-chart/cloud_build.yaml
+++ b/bundle-size-chart/cloud_build.yaml
@@ -25,6 +25,7 @@ steps:
     args:
       - app
       - deploy
+    timeout: 1200s
   - name: gcr.io/cloud-builders/gcloud
     dir: bundle-size-chart
     args:

--- a/bundle-size/cloud_build.yaml
+++ b/bundle-size/cloud_build.yaml
@@ -29,6 +29,7 @@ steps:
     args:
       - app
       - deploy
+    timeout: 1200s
 
 # These secrets are the base64-encoded form of encrypted secret values. They are
 # automatically decrypted and added to the `.env` environment at build time.

--- a/checklist/cloud_build.yaml
+++ b/checklist/cloud_build.yaml
@@ -50,6 +50,7 @@ steps:
       - checklist-bot
       - --entry-point
       - probot
+    timeout: 1200s
 
 # These secrets are the base64-encoded form of encrypted secret values. They are
 # automatically decrypted and added to the `.env` environment at build time.

--- a/invite/cloud_build.yaml
+++ b/invite/cloud_build.yaml
@@ -54,6 +54,7 @@ steps:
       - invite-bot
       - --entry-point
       - probot
+    timeout: 1200s
 
 # These secrets are the base64-encoded form of encrypted secret values. They are
 # automatically decrypted and added to the `.env` environment at build time.

--- a/onduty/cloud_build.yaml
+++ b/onduty/cloud_build.yaml
@@ -49,6 +49,7 @@ steps:
       - dist/
       - --entry-point
       - refreshRotation
+    timeout: 1200s
 
 # These secrets are the base64-encoded form of encrypted secret values. They are
 # automatically decrypted and added to the `.env` environment at build time.

--- a/test-status/cloud_build.yaml
+++ b/test-status/cloud_build.yaml
@@ -28,6 +28,7 @@ steps:
     args:
       - app
       - deploy
+    timeout: 1200s
 
 # These secrets are the base64-encoded form of encrypted secret values. They are
 # automatically decrypted and added to the `.env` environment at build time.


### PR DESCRIPTION
Some of these projects fail to deploy because the default 10m timeout is too short