### PR TITLE
[error-monitoring] Comment on existing error issues when a duplicate error is linked

### DIFF
--- a/error-monitoring/index.ts
+++ b/error-monitoring/index.ts
@@ -351,16 +351,21 @@ export async function linkIssue(
   if (issueNumber.startsWith('#')) {
     issueNumber = issueNumber.substr(1);
   }
+  issueNumber = Number(issueNumber);
 
   try {
     const issueRepo =
-      Number(issueNumber) >= LEGACY_ISSUE_REPO_START
+      issueNumber >= LEGACY_ISSUE_REPO_START
         ? GITHUB_REPO_NAME
         : ISSUE_REPO_NAME;
-    await stackdriver.setGroupIssue(
-      errorId.toString(),
-      `https://github.com/${GITHUB_REPO_OWNER}/${issueRepo}/issues/${issueNumber}`
-    );
+
+    await Promise.all([
+      bot.commentWithDupe(errorId.toString(), issueNumber),
+      stackdriver.setGroupIssue(
+        errorId.toString(),
+        `https://github.com/${GITHUB_REPO_OWNER}/${issueRepo}/issues/${issueNumber}`
+      ),
+    ]);
   } catch (e) {
     console.error(e);
   } finally {

--- a/error-monitoring/index.ts
+++ b/error-monitoring/index.ts
@@ -38,7 +38,7 @@ import statusCodes from 'http-status-codes';
 
 const GITHUB_REPO = process.env.GITHUB_REPO || 'ampproject/amphtml';
 const [GITHUB_REPO_OWNER, GITHUB_REPO_NAME] = GITHUB_REPO.split('/');
-const ISSUE_REPO_NAME = process.env.ISSUE_REPO_NAME || 'amphtml';
+const ISSUE_REPO_NAME = process.env.ISSUE_REPO_NAME || GITHUB_REPO_NAME;
 const GITHUB_ACCESS_TOKEN = process.env.GITHUB_ACCESS_TOKEN;
 const PROJECT_ID = process.env.PROJECT_ID || 'amp-error-reporting';
 const MIN_FREQUENCY = Number(process.env.MIN_FREQUENCY || 2500);

--- a/error-monitoring/src/bot.ts
+++ b/error-monitoring/src/bot.ts
@@ -36,6 +36,7 @@ export class ErrorIssueBot {
     private issueRepoName?: string
   ) {
     this.octokit = new Octokit({auth: `token ${token}`});
+    this.issueRepoName = issueRepoName || repoName;
     this.blameFinder = new BlameFinder(
       repoOwner,
       repoName,
@@ -57,6 +58,16 @@ export class ErrorIssueBot {
       labels: builder.labels,
       body: builder.body,
     };
+  }
+
+  /** Comments on an existing issue to link a duplicate error. */
+  async commentWithDupe(errorId: string, issueNumber: number) {
+    await this.octokit.issues.createComment({
+      owner: this.repoOwner,
+      repo: this.issueRepoName,
+      'issue_number': issueNumber,
+      body: `A duplicate error report was linked to this issue ([link](http://go/ampe/${errorId}))`,
+    });
   }
 
   /** Creates an error report issue and returns the issue URL. */

--- a/error-monitoring/src/bot.ts
+++ b/error-monitoring/src/bot.ts
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */()
+ */
 
 import {Octokit} from '@octokit/rest';
 

--- a/error-monitoring/src/bot.ts
+++ b/error-monitoring/src/bot.ts
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ */()
 
 import {Octokit} from '@octokit/rest';
 

--- a/error-monitoring/test/bot.test.ts
+++ b/error-monitoring/test/bot.test.ts
@@ -114,6 +114,20 @@ describe('ErrorIssueBot', () => {
     });
   });
 
+  describe('commentWithDupe', () => {
+    it('creates a comment linking to the duplicate error report', async () => {
+      nock('https://api.github.com')
+        .post('/repos/test_org/issue_repo/issues/1337/comments', body => {
+          expect(body.issue);
+          expect(body.body).toContain('([link](http://go/ampe/a1b2c3d4e5))');
+          return true;
+        })
+        .reply(201);
+
+      await bot.commentWithDupe('a1b2c3d4e5', 1337);
+    });
+  });
+
   describe('report', () => {
     const issueUrl = 'https://github.com/ampproject/amphtml/issues/1337';
 

--- a/error-monitoring/test/bot.test.ts
+++ b/error-monitoring/test/bot.test.ts
@@ -118,7 +118,6 @@ describe('ErrorIssueBot', () => {
     it('creates a comment linking to the duplicate error report', async () => {
       nock('https://api.github.com')
         .post('/repos/test_org/issue_repo/issues/1337/comments', body => {
-          expect(body.issue);
           expect(body.body).toContain('([link](http://go/ampe/a1b2c3d4e5))');
           return true;
         })


### PR DESCRIPTION
Right now, clicking this button links the existing GitHub issue to a duplicate Stackdriver error report. This has become extremely common as a result of ESM changing the stacktraces (and grouping) of pretty much every production error. Currently, there's no way to see all the errors that are related to a certain issue. This PR causes the bot to auto-comment on the existing GitHub issue, linking to the new duplicate.

![image](https://user-images.githubusercontent.com/6694512/100657405-38348900-331c-11eb-8aad-0a132e3429fa.png)
