### PR TITLE
Make pr-deploy bot CI agnostic

### DIFF
--- a/pr-deploy/README.md
+++ b/pr-deploy/README.md
@@ -9,11 +9,11 @@ This app runs on an instance of Google AppEngine and is installed exclusively on
 How the app works
 ----------------
 1. A commit is pushed to a new or existing pull request on ampproject/amphtml.
-2. Travis compiles your changes and uploads the build artifacts and example pages as `amp_dist_<Travis build number>.zip` to a remote storage location. During this step, a check called `ampproject/pr-deploy` is set to `pending`.
-3. a) If there was a compilation error, Travis tells the AMP PR Deploy Bot that there's nothing left to do until the error is fixed. <br>
-   b) If there were no errors, Travis tells the AMP PR Deploy Bot that a test site is ready to be deployed. `ampproject/pr-deploy` is now `netural`
-4. A test site is deployed by clicking the 'Deploy Me' button in the details page of `ampproject/pr-deploy`. The app unzips and writes `amp_dist_<Travis build number>.zip` to the public Google Cloud Storage bucket.
-5. `ampproject/pr-deploy` completes with the website URL. `https://console.cloud.google.com/storage/browser/amp-test-website-1/amp_dist_<Travis build number>`
+2. A CI build compiles your changes and uploads the build artifacts and example pages as `amp_dist_<CI build number>.zip` to a remote storage location. During this step, a check called `ampproject/pr-deploy` is set to `pending`.
+3. a) If there was a compilation error, the CI build tells the AMP PR Deploy Bot that there's nothing left to do until the error is fixed. <br>
+   b) If there were no errors, the CI build tells the AMP PR Deploy Bot that a test site is ready to be deployed. `ampproject/pr-deploy` is now `netural`
+4. A test site is deployed by clicking the 'Deploy Me' button in the details page of `ampproject/pr-deploy`. The app unzips and writes `amp_dist_<CI build number>.zip` to the public Google Cloud Storage bucket.
+5. `ampproject/pr-deploy` completes with the website URL. `https://console.cloud.google.com/storage/browser/amp-test-website-1/amp_dist_<CI build number>`
 
 Here's a quick [demo](https://github.com/ampproject/amphtml/pull/24274) on how to create a test site.
 

--- a/pr-deploy/src/github.ts
+++ b/pr-deploy/src/github.ts
@@ -145,7 +145,7 @@ export class PullRequest {
           'Please click the `Create a test site` button above to ' +
           'deploy the minified build of this PR along with examples from ' +
           '`examples/` and `test/manual/`. It should only take a minute.',
-        text: `Travis build number: ${id}`,
+        text: `CI build number: ${id}`,
       },
       actions: ACTIONS,
     };
@@ -169,7 +169,7 @@ export class PullRequest {
         title: 'Build error.',
         summary:
           'A test site cannot be created because this PR ' +
-          'failed to build. Please check the Travis logs for more information.',
+          'failed to build. Please check the CI logs for more information.',
       },
     };
 
@@ -192,16 +192,16 @@ export class PullRequest {
         title: 'Build skipped.',
         summary:
           'A test site cannot be created because the ' +
-          'compilation step was skipped in Travis. This happens when ' +
+          'compilation step was skipped during CI. This happens when ' +
           'a PR only includes non-code changes, such as documentation. ' +
-          'Please check the Travis logs for more information.',
+          'Please check the CI logs for more information.',
       },
     };
 
     return this.github.checks.update(params);
   }
 
-  async getTravisBuildNumber() {
+  async getCiBuildNumber() {
     const check = await this.getCheck_();
 
     if (!check.output || !check.output.text) {
@@ -224,7 +224,7 @@ export class PullRequest {
       output: {
         title: 'Waiting for the build to finish...',
         summary:
-          'When Travis is finished compiling this PR, ' +
+          'When CI has finished compiling this PR, ' +
           'a "Create a test site!" button will appear here.',
       },
     };

--- a/pr-deploy/src/zipper.ts
+++ b/pr-deploy/src/zipper.ts
@@ -20,7 +20,7 @@ import {Storage} from '@google-cloud/storage';
 
 /**
  * Takes the minified build and test fixtures from the
- * AMP Travis Build Storage bucket, unzips and writes to
+ * AMP CI Build Storage bucket, unzips and writes to
  * a test website bucket that serves the files publicly.
  */
 export async function unzipAndMove(id: number): Promise<string> {

--- a/pr-deploy/test/app.test.ts
+++ b/pr-deploy/test/app.test.ts
@@ -20,7 +20,7 @@ jest.mock('../src/zipper', () => {
     unzipAndMove: jest
       .fn()
       .mockReturnValue(
-        Promise.resolve('gs://serving-bucket/travisBuildNumber')
+        Promise.resolve('gs://serving-bucket/ciBuildNumber')
       ),
   };
 });
@@ -128,7 +128,7 @@ describe('test pr deploy app', () => {
       .reply(200, {
         total_count: 1,
         check_runs: [
-          {id: 12345, output: {text: 'Travis build number: 3'}},
+          {id: 12345, output: {text: 'CI build number: 3'}},
         ],
       }) // make sure a check already exists
       .patch('/repos/test-owner/test-repo/check-runs/12345')


### PR DESCRIPTION
**PR Highlights:**

- Updates all internal implementation to be CI-agnostic
- Adds a HTTP post handler for `/cibuilds/` (`/travisbuilds` will be cleaned up after `amphtml` stops using it)

I'm guessing we cannot merge this PR until the storage location used by CI is updated (coming up separately). Meanwhile, sending this out for preliminary review.

Fixes #1110