### PR TITLE
Make deployment work across Posix platforms

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -68,7 +68,7 @@
     - Under _Build Configuration_, select _Cloud Build configuration file_ and provide the path to your Cloud Build file, ex. `bundle-size/cloud_build.yaml`
 
 10. Add the NPM script `deploy-tag`, which creates a git tag in the proper tag format for your app
-    - Ex. ``git tag 'deploy-your-app-name-'`date --utc '+%Y%m%d%H%M%S'` ``
+    - Ex. ``git tag 'deploy-your-app-name-'`date -u '+%Y%m%d%H%M%S'` ``
 
 ## To store an encrypted secret
 

--- a/bundle-size-chart/package.json
+++ b/bundle-size-chart/package.json
@@ -19,7 +19,7 @@
     "dev": "nodemon",
     "deploy": "gcloud --project amp-bundle-size-chart app deploy",
     "deploy-cron": "gcloud --project amp-bundle-size-chart app deploy cron.yaml",
-    "deploy-tag": "git tag 'deploy-bundle-size-chart-'`date --utc '+%Y%m%d%H%M%S'`",
+    "deploy-tag": "git tag 'deploy-bundle-size-chart-'`date -u '+%Y%m%d%H%M%S'`",
     "prestart": "tsc",
     "start": "node dist/app.js",
     "pretest": "npm run lint",

--- a/bundle-size/package.json
+++ b/bundle-size/package.json
@@ -17,7 +17,7 @@
     "fix": "npm run lint -- --fix",
     "dev": "nodemon",
     "deploy": "gcloud --project amp-bundle-size-bot app deploy",
-    "deploy-tag": "git tag 'deploy-bundle-size-'`date --utc '+%Y%m%d%H%M%S'`",
+    "deploy-tag": "git tag 'deploy-bundle-size-'`date -u '+%Y%m%d%H%M%S'`",
     "setup-db": "node ./setup-db.js",
     "start": "probot run ./app.js",
     "pretest": "npm run lint",

--- a/checklist/package.json
+++ b/checklist/package.json
@@ -16,7 +16,7 @@
     "build:watch": "tsc -w --p tsconfig.json",
     "start": "probot run ./dist/app.js",
     "dev": "nodemon",
-    "deploy-tag": "git tag 'deploy-checklist-'`date --utc '+%Y%m%d%H%M%S'`",
+    "deploy-tag": "git tag 'deploy-checklist-'`date -u '+%Y%m%d%H%M%S'`",
     "test": "echo No tests defined for this app!",
     "test:watch": "jest --watch --notify --notifyMode=change"
   },

--- a/error-monitoring/package.json
+++ b/error-monitoring/package.json
@@ -15,7 +15,7 @@
     "build:watch": "tsc -w --p tsconfig.json",
     "start": "node dist/app.js",
     "dev": "functions-framework --target=app --source=dist",
-    "deploy-tag": "git tag 'deploy-error-monitoring-'`date --utc '+%Y%m%d%H%M%S'`",
+    "deploy-tag": "git tag 'deploy-error-monitoring-'`date -u '+%Y%m%d%H%M%S'`",
     "pretest": "npm run lint",
     "test": "jest",
     "test:watch": "jest --watch --notify --notifyMode=change"

--- a/invite/package.json
+++ b/invite/package.json
@@ -16,7 +16,7 @@
     "setup-db": "node dist/src/setup_db.js",
     "start": "probot run dist/app.js",
     "dev": "nodemon",
-    "deploy-tag": "git tag 'deploy-invite-'`date --utc '+%Y%m%d%H%M%S'`",
+    "deploy-tag": "git tag 'deploy-invite-'`date -u '+%Y%m%d%H%M%S'`",
     "pretest": "npm run lint",
     "test": "jest",
     "test:watch": "jest --watch --notify --notifyMode=change"

--- a/onduty/package.json
+++ b/onduty/package.json
@@ -15,7 +15,7 @@
     "build:watch": "tsc -w --p tsconfig.json",
     "start": "functions-framework --target=dist/app",
     "dev": "nodemon",
-    "deploy-tag": "git tag 'deploy-onduty-'`date --utc '+%Y%m%d%H%M%S'`",
+    "deploy-tag": "git tag 'deploy-onduty-'`date -u '+%Y%m%d%H%M%S'`",
     "pretest": "npm run lint",
     "test": "jest",
     "test:watch": "jest --watch --notify --notifyMode=change"

--- a/owners/package.json
+++ b/owners/package.json
@@ -14,7 +14,7 @@
     "init": "node scripts/warm_cache.js",
     "dev": "node info_server.js",
     "start": "probot run ./index.js",
-    "deploy-tag": "git tag 'deploy-owners-'`date --utc '+%Y%m%d%H%M%S'`",
+    "deploy-tag": "git tag 'deploy-owners-'`date -u '+%Y%m%d%H%M%S'`",
     "pretest": "npm run lint",
     "test": "jest",
     "test:watch": "jest --watch --notify --notifyMode=change"

--- a/test-case-reporting/package.json
+++ b/test-case-reporting/package.json
@@ -19,7 +19,7 @@
     "dev": "nodemon",
     "test": "jest",
     "test:watch": "jest --watch --notify --notifyMode=change",
-    "deploy-tag": "git tag 'deploy-test-case-reporting-'`date --utc '+%Y%m%d%H%M%S'`"
+    "deploy-tag": "git tag 'deploy-test-case-reporting-'`date -u '+%Y%m%d%H%M%S'`"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/test-status/package.json
+++ b/test-status/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "dev": "nodemon",
     "deploy": "gcloud --project amp-test-status-bot app deploy",
-    "deploy-tag": "git tag 'deploy-test-status-'`date --utc '+%Y%m%d%H%M%S'`",
+    "deploy-tag": "git tag 'deploy-test-status-'`date -u '+%Y%m%d%H%M%S'`",
     "lint": "eslint .",
     "fix": "npm run lint -- --fix",
     "setup-db": "node ./setup-db.js",


### PR DESCRIPTION
We use `date --utc` to generate a timestamp while creating a deployment tag for our apps. Turns out that Linux supports `date --utc` and the shorter form `date -u`, but macOS only supports the latter.

![image](https://user-images.githubusercontent.com/26553114/102411359-d16fca80-3fbf-11eb-95a6-57609147cf7b.png)
![image](https://user-images.githubusercontent.com/26553114/102411394-df255000-3fbf-11eb-8820-d84e780ba78b.png)


This PR makes deployment steps work across both Posix platforms.