### PR TITLE
Upgrade date-and-time to 0.14.2 to fix dependabot alert

### DIFF
--- a/bundle-size-chart/package-lock.json
+++ b/bundle-size-chart/package-lock.json
@@ -865,9 +865,9 @@
       "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g=="
     },
     "date-and-time": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.14.1.tgz",
-      "integrity": "sha512-M4RggEH5OF2ZuCOxgOU67R6Z9ohjKbxGvAQz48vj53wLmL0bAgumkBvycR32f30pK+Og9pIR+RFDyChbaE4oLA=="
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.14.2.tgz",
+      "integrity": "sha512-EFTCh9zRSEpGPmJaexg7HTuzZHh6cnJj1ui7IGCFNXzd2QdpsNh05Db5TF3xzJm30YN+A8/6xHSuRcQqoc3kFA=="
     },
     "debug": {
       "version": "4.2.0",

--- a/owners/package-lock.json
+++ b/owners/package-lock.json
@@ -2877,9 +2877,9 @@
       }
     },
     "date-and-time": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.14.1.tgz",
-      "integrity": "sha512-M4RggEH5OF2ZuCOxgOU67R6Z9ohjKbxGvAQz48vj53wLmL0bAgumkBvycR32f30pK+Og9pIR+RFDyChbaE4oLA=="
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.14.2.tgz",
+      "integrity": "sha512-EFTCh9zRSEpGPmJaexg7HTuzZHh6cnJj1ui7IGCFNXzd2QdpsNh05Db5TF3xzJm30YN+A8/6xHSuRcQqoc3kFA=="
     },
     "dateformat": {
       "version": "3.0.3",

--- a/pr-deploy/package-lock.json
+++ b/pr-deploy/package-lock.json
@@ -3184,9 +3184,9 @@
       }
     },
     "date-and-time": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.14.1.tgz",
-      "integrity": "sha512-M4RggEH5OF2ZuCOxgOU67R6Z9ohjKbxGvAQz48vj53wLmL0bAgumkBvycR32f30pK+Og9pIR+RFDyChbaE4oLA=="
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.14.2.tgz",
+      "integrity": "sha512-EFTCh9zRSEpGPmJaexg7HTuzZHh6cnJj1ui7IGCFNXzd2QdpsNh05Db5TF3xzJm30YN+A8/6xHSuRcQqoc3kFA=="
     },
     "dateformat": {
       "version": "3.0.3",


### PR DESCRIPTION
Details of dependabot alert

```
GHSA-r92x-f52r-x54g
high severity
Vulnerable versions: < 0.14.2
Patched version: 0.14.2
This issue may lead to a denial of service.
```