### PR TITLE
Catch error when an OWNERS file has an invalid path

### DIFF
--- a/owners/src/ownership/tree.js
+++ b/owners/src/ownership/tree.js
@@ -72,10 +72,15 @@ module.exports = class OwnersTree {
     const nextDir = rule.dirPath.split(path.sep)[this.depth];
 
     if (!this.get(nextDir)) {
-      this.children[nextDir] = new OwnersTree(
-        path.join(this.dirPath, nextDir),
-        this
-      );
+      try {
+        this.children[nextDir] = new OwnersTree(
+          path.join(this.dirPath, nextDir),
+          this
+        );
+      } catch (e) {
+        console.error(`Error parsing rule path "${rule}"`, e);
+        return this;
+      }
     }
 
     return this.get(nextDir).addRule(rule);

--- a/owners/test/ownership/tree.test.js
+++ b/owners/test/ownership/tree.test.js
@@ -103,6 +103,12 @@ describe('owners tree', () => {
       expect(tree.rules).not.toContain(reviewerSetRule);
       expect(tree.reviewerSetRule).toEqual(reviewerSetRule);
     });
+
+    it('handles broken/invalid paths', () => {
+      const invalidRule = new OwnersRule('/OWNERS', [new UserOwner('coder')]);
+      tree.addRule(invalidRule);
+      expect(tree.rules).not.toContain(invalidRule);
+    });
   });
 
   describe('depth', () => {


### PR DESCRIPTION
The source of this error is unclear (I suspect it's some undocumented change it GitHub APIs response), but this will ensure that errors in owners tree creation don't bubble up and take down the bot.

/cc @Enriqe 