### PR TITLE
[error-monitoring] link to PRs in created issues

### DIFF
--- a/error-monitoring/cron.yaml
+++ b/error-monitoring/cron.yaml
@@ -1,13 +1,1 @@
 cron:
-- description: "File issues for errors in production"
-  url: /_cron/monitor?serviceType=production
-  schedule: every day at 7:00am
-- description: "File issues for errors in 1%/opt-in"
-  url: /_cron/monitor?serviceType=development
-  schedule: every day at 7:02am
-- description: "File issues for errors in experiments"
-  url: /_cron/monitor?serviceType=experiments
-  schedule: every day at 7:04am
-- description: "File issues for errors in nightly"
-  url: /_cron/monitor?serviceType=nightly
-  schedule: every day at 7:06am

--- a/error-monitoring/index.ts
+++ b/error-monitoring/index.ts
@@ -343,12 +343,12 @@ export async function linkIssue(
   res: express.Response
 ): Promise<void> {
   const {errorId, serviceType, normalizedThreshold} = req.query;
-  let issueNumber = req.query.issueNumber.toString();
+  let issueNumberStr = req.query.issueNumber.toString();
 
-  if (issueNumber.startsWith('#')) {
-    issueNumber = issueNumber.substr(1);
+  if (issueNumberStr.startsWith('#')) {
+    issueNumberStr = issueNumberStr.substr(1);
   }
-  issueNumber = Number(issueNumber);
+  const issueNumber = Number(issueNumberStr);
 
   try {
     const issueRepo =

--- a/error-monitoring/src/bot.ts
+++ b/error-monitoring/src/bot.ts
@@ -50,7 +50,12 @@ export class ErrorIssueBot {
   ): Promise<Octokit.IssuesCreateParams> {
     const {stacktrace} = errorReport;
     const blameRanges = await this.blameFinder.blameForStacktrace(stacktrace);
-    const builder = new IssueBuilder(errorReport, blameRanges, RELEASE_ONDUTY);
+    const builder = new IssueBuilder(
+      errorReport,
+      `${this.repoOwner}/${this.repoName}`,
+      blameRanges,
+      RELEASE_ONDUTY
+    );
     return {
       owner: this.repoOwner,
       repo: this.issueRepoName,

--- a/error-monitoring/src/issue_builder.ts
+++ b/error-monitoring/src/issue_builder.ts
@@ -41,6 +41,7 @@ export class IssueBuilder {
       stacktrace,
       seenInVersions,
     }: ErrorReport,
+    private sourceRepo: string,
     private blames: Array<BlameRange>,
     private releaseOnduty?: string
   ) {

--- a/error-monitoring/src/issue_builder.ts
+++ b/error-monitoring/src/issue_builder.ts
@@ -85,6 +85,13 @@ export class IssueBuilder {
     ].join('\n');
   }
 
+  private prLink(prNumber: number): string {
+    return (
+      `[#${prNumber}]` +
+      `(https://github.com/${this.sourceRepo}/pulls/${prNumber})`
+    );
+  }
+
   private blameMessage({
     path,
     startingLine,
@@ -94,8 +101,8 @@ export class IssueBuilder {
     prNumber,
   }: BlameRange): string {
     return (
-      `\`${author}\` modified \`${path}:${startingLine}-${endingLine}\`` +
-      ` in #${prNumber} (${formatDate(committedDate)})`
+      `\`${author}\` modified \`${path}:${startingLine}-${endingLine}\` in ` +
+      `${this.prLink(prNumber)} (${formatDate(committedDate)})`
     );
   }
 

--- a/error-monitoring/test/fixtures/created-issue.md
+++ b/error-monitoring/test/fixtures/created-issue.md
@@ -13,8 +13,8 @@ Stacktrace
 
 Notes
 ---
-`@xymw` modified `extensions/amp-delight-player/0.1/amp-delight-player.js:396-439` in #17939 (Nov 12, 2018)
-`@rsimha` modified `src/event-helper-listen.js:57-59` in #12450 (Dec 13, 2017)
+`@xymw` modified `extensions/amp-delight-player/0.1/amp-delight-player.js:396-439` in [#17939](https://github.com/test_org/test_repo/pulls/17939) (Nov 12, 2018)
+`@rsimha` modified `src/event-helper-listen.js:57-59` in [#12450](https://github.com/test_org/test_repo/pulls/12450) (Dec 13, 2017)
 
 **Seen in:**
 - 04-24 Beta (1234)

--- a/error-monitoring/test/issue_builder.test.ts
+++ b/error-monitoring/test/issue_builder.test.ts
@@ -166,11 +166,12 @@ describe('IssueBuilder', () => {
       expect(notes).toContain(
         '`@xymw` modified ' +
           '`extensions/amp-delight-player/0.1/amp-delight-player.js:396-439` ' +
-          'in https://github.com/test_org/test_repo#17939 (Nov 12, 2018)'
+          'in [#17939](https://github.com/test_org/test_repo/pulls/17939) ' +
+          '(Nov 12, 2018)'
       );
       expect(notes).toContain(
         '`@rsimha` modified `src/event-helper-listen.js:57-59` in ' +
-          'https://github.com/test_org/test_repo#12450 ' +
+          '[#12450](https://github.com/test_org/test_repo/pulls/12450) ' +
           '(Dec 13, 2017)'
       );
     });

--- a/error-monitoring/test/issue_builder.test.ts
+++ b/error-monitoring/test/issue_builder.test.ts
@@ -160,10 +160,11 @@ describe('IssueBuilder', () => {
       expect(notes).toContain(
         '`@xymw` modified ' +
           '`extensions/amp-delight-player/0.1/amp-delight-player.js:396-439` ' +
-          'in #17939 (Nov 12, 2018)'
+          'in https://github.com/test_org/test_repo#17939 (Nov 12, 2018)'
       );
       expect(notes).toContain(
-        '`@rsimha` modified `src/event-helper-listen.js:57-59` in #12450 ' +
+        '`@rsimha` modified `src/event-helper-listen.js:57-59` in ' +
+          'https://github.com/test_org/test_repo#12450 ' +
           '(Dec 13, 2017)'
       );
     });

--- a/error-monitoring/test/issue_builder.test.ts
+++ b/error-monitoring/test/issue_builder.test.ts
@@ -20,6 +20,7 @@ import {getFixtureFile} from './fixtures';
 
 describe('IssueBuilder', () => {
   let builder: IssueBuilder;
+  const sourceRepo = 'test_org/test_repo';
   const now = new Date('Mar 1, 2020');
   const report: ErrorReport = {
     errorId: 'CL6chqbN2-bzBA',
@@ -61,7 +62,12 @@ describe('IssueBuilder', () => {
 
   beforeEach(() => {
     jest.spyOn(Date, 'now').mockReturnValue(now.valueOf());
-    builder = new IssueBuilder(report, blames, 'test_org/onduty-team');
+    builder = new IssueBuilder(
+      report,
+      sourceRepo,
+      blames,
+      'test_org/onduty-team'
+    );
   });
 
   describe('title', () => {
@@ -120,7 +126,7 @@ describe('IssueBuilder', () => {
     ];
 
     it('returns authors of most recent relevant PRs sorted by recency', () => {
-      builder = new IssueBuilder(report, blames);
+      builder = new IssueBuilder(report, sourceRepo, blames);
       expect(builder.possibleAssignees(3)).toEqual([
         '@relevant_author',
         '@older_author',
@@ -129,7 +135,7 @@ describe('IssueBuilder', () => {
     });
 
     it('limits the number of suggestions', () => {
-      builder = new IssueBuilder(report, blames);
+      builder = new IssueBuilder(report, sourceRepo, blames);
       expect(builder.possibleAssignees()).toEqual([
         '@relevant_author',
         '@older_author',
@@ -137,7 +143,7 @@ describe('IssueBuilder', () => {
     });
 
     it('does not try to assign very old errors', () => {
-      builder = new IssueBuilder(oldReport, blames);
+      builder = new IssueBuilder(oldReport, sourceRepo, blames);
       expect(builder.possibleAssignees()).toEqual([]);
     });
   });
@@ -172,12 +178,12 @@ describe('IssueBuilder', () => {
     it('suggests possible assignees, if known', () => {
       expect(builder.bodyNotes).toContain('**Possible assignees:** `@xymw`');
 
-      builder = new IssueBuilder(oldReport, blames);
+      builder = new IssueBuilder(oldReport, sourceRepo, blames);
       expect(builder.bodyNotes).not.toContain('Possible assignees:');
     });
 
     it('returns empty string when there is no blame info', () => {
-      builder = new IssueBuilder(report, []);
+      builder = new IssueBuilder(report, sourceRepo, []);
       expect(builder.bodyNotes).toEqual('');
     });
 
@@ -191,6 +197,7 @@ describe('IssueBuilder', () => {
     it("doesn't try to list versions if none are provided", () => {
       builder = new IssueBuilder(
         Object.assign({}, report, {seenInVersions: []}),
+        sourceRepo,
         blames
       );
       expect(builder.bodyNotes).not.toContain('**Seen in:**');
@@ -203,7 +210,7 @@ describe('IssueBuilder', () => {
     });
 
     it('is undefined when no onduty team is provided', () => {
-      builder = new IssueBuilder(report, blames);
+      builder = new IssueBuilder(report, sourceRepo, blames);
       expect(builder.bodyTag).toBeUndefined();
     });
   });


### PR DESCRIPTION
Originally the issue builder wrote a PR as `#1337`, however now that issues are reported into a separate repo, there's no linking. This updates the issue builder to create full links for referenced PRs in the stacktrace blame.

It also disables cron jobs to autofile issues; that shouldn't have been on, and I'm not sure why I turned it on.