### PR TITLE
Make test case reporting CI-agnostic

### DIFF
--- a/test-case-reporting/README.md
+++ b/test-case-reporting/README.md
@@ -1,19 +1,19 @@
 AMP Test Case Reporting Bot
 ==============
 
-A Google Cloud app that stores the results of tests run by Travis. Used to track flaky tests.
+A Google Cloud app that stores the results of tests run during CI. Used to track flaky tests.
 
 This app runs as a [[something]].
 
 Interface
 ---------
-### API for Travis
+### API for CI
 
-The App has the following API endpoints, which are to be triggered from Travis CI
+The App has the following API endpoints, which are to be triggered during CI
 runs.
 
 * `POST /report`
-  * Accepts a JSON object representing a test result report from Travis. Has 3 fields: `build`, `job`, and `results`, representing build information, job information, and test run information respectively. For the full structure of the object, see [the type declaration module](types/test-case-reporting.d.ts).
+  * Accepts a JSON object representing a test result report from a CI build. Has 3 fields: `build`, `job`, and `results`, representing build information, job information, and test run information respectively. For the full structure of the object, see [the type declaration module](types/test-case-reporting.d.ts).
 
 Setup
 -----

--- a/test-case-reporting/app.ts
+++ b/test-case-reporting/app.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Build, PageInfo, TestRun, Travis} from 'test-case-reporting';
+import {Build, CI, PageInfo, TestRun} from 'test-case-reporting';
 import {TestCaseStats} from './src/test_case_stats';
 import {TestResultRecord} from './src/test_result_record';
 import {dbConnect} from './src/db';
@@ -104,12 +104,12 @@ app.get(['/', '/builds'], async (req, res) => {
 });
 
 app.get('/test-results/build/:buildNumber', async (req, res) => {
-  const {buildNumber} = req.params;
+  const {buildId} = req.params;
   const {json} = req.query;
 
   try {
     const testRuns = await record.getTestRunsOfBuild(
-      buildNumber,
+      buildId,
       extractPageInfo(req)
     );
 
@@ -118,7 +118,7 @@ app.get('/test-results/build/:buildNumber', async (req, res) => {
     } else {
       res.send(
         render('test-run-list', {
-          title: `Test Runs for Build #${buildNumber}`,
+          title: `Test Runs for Build #${buildId}`,
           testRuns: testRuns.map(lowerCaseStatus).map(enumerateTestRun),
         })
       );
@@ -210,8 +210,8 @@ app.get('/test-results/history/:testCaseId', async (req, res) => {
 });
 
 app.post('/report', jsonParser, async (req, res) => {
-  const report: Travis.Report = req.body;
-  const topLevelKeys: Array<keyof Travis.Report> = [
+  const report: CI.Report = req.body;
+  const topLevelKeys: Array<keyof CI.Report> = [
     'job',
     'build',
     'results',
@@ -231,7 +231,7 @@ app.post('/report', jsonParser, async (req, res) => {
       );
     }
 
-    await record.storeTravisReport(report);
+    await record.storeCiReport(report);
     res.sendStatus(statusCodes.CREATED);
   } catch (error) {
     handleError(error, res);

--- a/test-case-reporting/package.json
+++ b/test-case-reporting/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "repository": "http://github.com/ampproject/amp-github-apps",
-  "description": "An app that tracks the pass/fail status of tests run in Travis builds",
+  "description": "An app that tracks the pass/fail status of tests run in CI builds",
   "engines": {
     "node": "12.20.0"
   },

--- a/test-case-reporting/src/setup_db.ts
+++ b/test-case-reporting/src/setup_db.ts
@@ -26,7 +26,7 @@ export async function setupDb(db: Database): Promise<unknown> {
     .createTable('builds', table => {
       table.increments('id').primary();
       table.string('commit_sha', 40);
-      table.string('build_number');
+      table.string('build_id');
       table.string('url');
       table
         .timestamp('started_at', {precision: TIMESTAMP_PRECISION})
@@ -36,7 +36,7 @@ export async function setupDb(db: Database): Promise<unknown> {
     .createTable('jobs', table => {
       table.increments('id').primary();
       table.integer('build_id').unsigned().notNullable();
-      table.string('job_number');
+      table.string('job_id');
       table.string('url');
       table.string('test_suite_type');
       table

--- a/test-case-reporting/static/build-list.html
+++ b/test-case-reporting/static/build-list.html
@@ -13,7 +13,7 @@
       <h1>{{title}}</h1>
       {{#builds}}
         <div class="tile">
-          <a href="/test-results/build/{{buildNumber}}">Build {{buildNumber}}</a>, started at {{startedAt}}
+          <a href="/test-results/build/{{buildId}}">Build {{buildId}}</a>, started at {{startedAt}}
         </div>
       {{/builds}}
       {{^builds}}

--- a/test-case-reporting/static/test-run-list.html
+++ b/test-case-reporting/static/test-run-list.html
@@ -30,17 +30,17 @@
             <td>
               {{#testRun.job}}
 
-              Job: {{jobNumber}}
-              {{#url}}(<a href="{{.}}">Travis</a>){{/url}}
+              Job: {{jobId}}
+              {{#url}}(<a href="{{.}}">CI</a>){{/url}}
             </td>
 
               {{#build}}
             <td>
               Build:
-              <a href="/test-results/build/{{build.buildNumber}}">
-                {{buildNumber}}
+              <a href="/test-results/build/{{build.buildId}}">
+                {{buildId}}
               </a>
-              {{#url}}(<a href="{{.}}">Travis</a>){{/url}}
+              {{#url}}(<a href="{{.}}">CI</a>){{/url}}
               {{/build}}
 
               {{/testRun.job}}

--- a/test-case-reporting/test/e2e.test.ts
+++ b/test-case-reporting/test/e2e.test.ts
@@ -56,11 +56,11 @@ describe('end-to-end', () => {
 
   describe('when one post request is received', () => {
     const build = {
-      buildNumber: '413413',
+      buildId: '413413',
       commitSha: 'abcdefg123gomugomu',
     };
     const job = {
-      jobNumber: '413413.612',
+      jobId: '413413.612',
       testSuiteType: 'unit',
     };
     const results = getFixture('sample-karma-report');
@@ -84,7 +84,7 @@ describe('end-to-end', () => {
       const {testRuns}: {testRuns: Array<TestRun>} = res.body;
       expect(testRuns).toHaveLength(5);
       testRuns.forEach(testRun =>
-        expect(testRun.job.build.buildNumber).toEqual('413413')
+        expect(testRun.job.build.buildId).toEqual('413413')
       );
     });
 

--- a/test-case-reporting/test/testing_utils.ts
+++ b/test-case-reporting/test/testing_utils.ts
@@ -37,7 +37,7 @@ export async function fillDatabase(db: Database): Promise<void> {
   let [buildId] = await db('builds')
     .insert({
       'commit_sha': 'deadbeefdeadbeef123123',
-      'build_number': '12123434',
+      'build_id': '12123434',
     } as DB.Build)
     .returning('id');
 
@@ -50,7 +50,7 @@ export async function fillDatabase(db: Database): Promise<void> {
     for (const suiteType of ['unit', 'integration']) {
       [jobId] = await db('jobs').insert({
         'build_id': buildId,
-        'job_number': `12123434.${i}`,
+        'job_id': `12123434.${i}`,
         'test_suite_type': suiteType,
         'started_at': hoursAgoMs(i),
       } as DB.Job);
@@ -86,12 +86,12 @@ export async function fillDatabase(db: Database): Promise<void> {
 
   [buildId] = await db('builds').insert({
     'commit_sha': 'faefaefae99',
-    'build_number': '12129999',
+    'build_id': '12129999',
   } as DB.Build);
 
   [jobId] = await db('jobs').insert({
     'build_id': buildId,
-    'job_number': '12129999.1',
+    'job_id': '12129999.1',
     'test_suite_type': 'unit',
     'started_at': Date.now(),
   } as DB.Job);

--- a/test-case-reporting/types/test-case-reporting.d.ts
+++ b/test-case-reporting/types/test-case-reporting.d.ts
@@ -16,31 +16,24 @@
 
 declare module 'test-case-reporting' {
   /**
-   * Travis job types for which test results may be reported.
+   * CI job types for which test results may be reported.
    */
   export type TestSuiteType = 'unit' | 'integration' | 'e2e';
 
   export type TestStatus = 'PASS' | 'FAIL' | 'SKIP' | 'ERROR';
 
-  /** A build on Travis. */
+  /** A CI build. */
   export interface Build {
     commitSha: string;
-
-    // Despite being a *Number, buildNumber is of type string for parity with
-    // jobNumber
-    buildNumber: string;
+    buildId: string;
     url?: string;
     startedAt: Date;
   }
 
-  /** A job within a Travis build. */
+  /** A job within a CI build. */
   export interface Job {
     build: Build;
-
-    // Despite being a *Number, this is of type string because it includes periods.
-    // For the 456th job in the 123rd build,
-    // this looks like `123.456`
-    jobNumber: string;
+    jobId: string;
     url?: string;
     testSuiteType: TestSuiteType;
   }
@@ -87,10 +80,7 @@ declare module 'test-case-reporting' {
       id?: number;
       commit_sha: string;
       url?: string;
-
-      // Despite being a *_number, build_number is of type string for parity with
-      // job_number
-      build_number: string;
+      build_id: string;
       started_at?: number;
     }
 
@@ -98,11 +88,7 @@ declare module 'test-case-reporting' {
       id?: number;
       build_id: number;
       url?: string;
-
-      // Despite being a *_number, job_number is of type string because it includes periods.
-      // For the 456th job in the 123rd build,
-      // this looks like `123.456`
-      job_number: string;
+      job_id: string;
       test_suite_type: TestSuiteType;
       started_at?: number;
     }
@@ -168,22 +154,22 @@ declare module 'test-case-reporting' {
     }
   }
 
-  // Types for the JSON reports POSTed by Travis
+  // Types for the JSON reports POSTed during CI
   // Supposed to match the reports exactly.
-  namespace Travis {
+  namespace CI {
     export interface Report {
-      job: Travis.Job;
-      build: Travis.Build;
+      job: CI.Job;
+      build: CI.Build;
       results: KarmaReporter.TestResultReport;
       repository: string;
     }
     export interface Build {
-      buildNumber: string;
+      buildId: string;
       commitSha: string;
       url: string;
     }
     export interface Job {
-      jobNumber: string;
+      jobId: string;
       testSuiteType: TestSuiteType;
       url: string;
     }


### PR DESCRIPTION
**PR Highlights:**

- Updates all internal implementation to be CI-agnostic
- Renames `buildNumber` and `jobNumber` to `buildId` and `jobId` respectively

**WIP Note:** I see there's a numeric `build_id` field in the `Job` interface that's likely causing this PR to fail. Happy to use a different approach if there's a better one.

Fixes #1113
Companion PR to https://github.com/ampproject/amphtml/pull/31982
Migration steps: https://github.com/ampproject/amphtml/pull/31982#issue-555363290 (will they work?)