### PR TITLE
[test-case-reporting] Accept job/build ID fields from CI

### DIFF
--- a/test-case-reporting/app.ts
+++ b/test-case-reporting/app.ts
@@ -231,6 +231,11 @@ app.post('/report', jsonParser, async (req, res) => {
       );
     }
 
+    // TODO(https://github.com/ampproject/amphtml/issues/31996): Migrate types
+    // and database schema if necessary.
+    report.job.jobNumber = report.job.jobNumber || report.job.jobId;
+    report.build.buildNumber = report.build.buildNumber || report.build.buildId;
+
     await record.storeTravisReport(report);
     res.sendStatus(statusCodes.CREATED);
   } catch (error) {

--- a/test-case-reporting/types/test-case-reporting.d.ts
+++ b/test-case-reporting/types/test-case-reporting.d.ts
@@ -179,11 +179,13 @@ declare module 'test-case-reporting' {
     }
     export interface Build {
       buildNumber: string;
+      buildId?: string;
       commitSha: string;
       url: string;
     }
     export interface Job {
       jobNumber: string;
+      jobId?: string;
       testSuiteType: TestSuiteType;
       url: string;
     }


### PR DESCRIPTION
Allows CI to report `jobId` and `buildId` immediately while backend migrations are queued. Part of https://github.com/ampproject/amphtml/issues/31996