### PR TITLE
Make PR deploy bot accept non-numeric build identifiers

### DIFF
--- a/pr-deploy/README.md
+++ b/pr-deploy/README.md
@@ -9,11 +9,11 @@ This app runs on an instance of Google AppEngine and is installed exclusively on
 How the app works
 ----------------
 1. A commit is pushed to a new or existing pull request on ampproject/amphtml.
-2. A CI build compiles your changes and uploads the build artifacts and example pages as `amp_dist_<CI build number>.zip` to a remote storage location. During this step, a check called `ampproject/pr-deploy` is set to `pending`.
+2. A CI build compiles your changes and uploads the build artifacts and example pages as `amp_nomodule_<CI build ID>.zip` to a remote storage location. During this step, a check called `ampproject/pr-deploy` is set to `pending`.
 3. a) If there was a compilation error, the CI build tells the AMP PR Deploy Bot that there's nothing left to do until the error is fixed. <br>
    b) If there were no errors, the CI build tells the AMP PR Deploy Bot that a test site is ready to be deployed. `ampproject/pr-deploy` is now `netural`
-4. A test site is deployed by clicking the 'Deploy Me' button in the details page of `ampproject/pr-deploy`. The app unzips and writes `amp_dist_<CI build number>.zip` to the public Google Cloud Storage bucket.
-5. `ampproject/pr-deploy` completes with the website URL. `https://console.cloud.google.com/storage/browser/amp-test-website-1/amp_dist_<CI build number>`
+4. A test site is deployed by clicking the 'Deploy Me' button in the details page of `ampproject/pr-deploy`. The app unzips and writes `amp_nomodule_<CI build ID>.zip` to the public Google Cloud Storage bucket.
+5. `ampproject/pr-deploy` completes with the website URL. `https://console.cloud.google.com/storage/browser/amp-test-website-1/amp_nomodule_<CI build ID>`
 
 Here's a quick [demo](https://github.com/ampproject/amphtml/pull/24274) on how to create a test site.
 

--- a/pr-deploy/src/app.ts
+++ b/pr-deploy/src/app.ts
@@ -57,7 +57,7 @@ function initializeRouter(app: Application) {
     const pr = new PullRequest(github, headSha);
     switch (result) {
       case 'success':
-        await pr.buildCompleted(Number(ciBuild));
+        await pr.buildCompleted(ciBuild);
         break;
       case 'errored':
         await pr.buildErrored();
@@ -71,8 +71,6 @@ function initializeRouter(app: Application) {
   };
 
   router.post('/cibuilds/:ciBuild/headshas/:headSha/:result', initialize);
-  // TODO(rsimha, #1110): Clean this up once amphtml stops using `/travisBuilds/`
-  router.post('/travisbuilds/:ciBuild/headshas/:headSha/:result', initialize);
 }
 
 /**
@@ -91,11 +89,11 @@ function initializeDeployment(app: Application) {
     );
     try {
       await pr.deploymentInProgress();
-      const ciBuild = await pr.getCiBuildNumber();
-      const bucketUrl = await unzipAndMove(ciBuild);
+      const ciBuildId = await pr.getCiBuildId();
+      const bucketUrl = await unzipAndMove(ciBuildId);
       await pr.deploymentCompleted(
         bucketUrl,
-        `${BASE_URL}amp_dist_${ciBuild}/`
+        `${BASE_URL}amp_nomodule_${ciBuildId}/`
       );
     } catch (e) {
       await pr.deploymentErrored(e);

--- a/pr-deploy/src/github.ts
+++ b/pr-deploy/src/github.ts
@@ -130,7 +130,7 @@ export class PullRequest {
   /**
    * Set check to 'completed' to enable the 'Deploy Me' action.
    */
-  async buildCompleted(id: number) {
+  async buildCompleted(id: string) {
     const check = await this.getCheck_();
 
     const params: ChecksUpdateParams = {
@@ -145,7 +145,7 @@ export class PullRequest {
           'Please click the `Create a test site` button above to ' +
           'deploy the minified build of this PR along with examples from ' +
           '`examples/` and `test/manual/`. It should only take a minute.',
-        text: `CI build number: ${id}`,
+        text: `CI build ID: ${id}`,
       },
       actions: ACTIONS,
     };
@@ -201,14 +201,12 @@ export class PullRequest {
     return this.github.checks.update(params);
   }
 
-  async getCiBuildNumber() {
+  async getCiBuildId() {
     const check = await this.getCheck_();
-
     if (!check.output || !check.output.text) {
-      return -1;
+      return '';
     }
-
-    return Number(check.output.text.replace(/\D/g, ''));
+    return check.output.text;
   }
 
   /**

--- a/pr-deploy/src/zipper.ts
+++ b/pr-deploy/src/zipper.ts
@@ -23,10 +23,10 @@ import {Storage} from '@google-cloud/storage';
  * AMP CI Build Storage bucket, unzips and writes to
  * a test website bucket that serves the files publicly.
  */
-export async function unzipAndMove(id: number): Promise<string> {
+export async function unzipAndMove(id: string): Promise<string> {
   const storage = new Storage({projectId: process.env.PROJECT_ID});
   const serveBucket = storage.bucket(process.env.SERVE_BUCKET);
-  const buildFileName = `amp_dist_${id}`;
+  const buildFileName = `amp_nomodule_${id}`;
   const buildFile =
     storage.bucket(process.env.BUILD_BUCKET).file(`${buildFileName}.zip`);
 

--- a/pr-deploy/test/app.test.ts
+++ b/pr-deploy/test/app.test.ts
@@ -20,7 +20,7 @@ jest.mock('../src/zipper', () => {
     unzipAndMove: jest
       .fn()
       .mockReturnValue(
-        Promise.resolve('gs://serving-bucket/ciBuildNumber')
+        Promise.resolve('gs://serving-bucket/ciBuildId')
       ),
   };
 });
@@ -128,7 +128,7 @@ describe('test pr deploy app', () => {
       .reply(200, {
         total_count: 1,
         check_runs: [
-          {id: 12345, output: {text: 'CI build number: 3'}},
+          {id: 12345, output: {text: 'CI build ID: abc'}},
         ],
       }) // make sure a check already exists
       .patch('/repos/test-owner/test-repo/check-runs/12345')


### PR DESCRIPTION
With the move to CircleCI, build identifiers are no longer guaranteed to be numeric. This PR makes them strings so any kind of identifier can be passed in.

**Side note:** Binary filenames uploaded during CI were renamed to `amp_nomodule_*.zip` and `amp_module_*.zip` in https://github.com/ampproject/amphtml/pull/31940. We'll need to re-deploy #1141 + this PR so the paths can match up again.

Fixes #1110