### PR TITLE
Fix PR Deploy bot build ID extraction

### DIFF
--- a/pr-deploy/src/github.ts
+++ b/pr-deploy/src/github.ts
@@ -206,7 +206,7 @@ export class PullRequest {
     if (!check.output || !check.output.text) {
       return '';
     }
-    return check.output.text;
+    return check.output.text.replace(/CI build ID\:\ /g, '')
   }
 
   /**


### PR DESCRIPTION
The Github check for the PR deploy bot reports a build identifier in the following formats:
```sh
# Travis
CI build ID: 12345

# CircleCI
CI build ID: aaaaaaaa-bbbb-cccc-ddddddddddddddddd
```

In #1196, we removed the code that converted the build ID to a number (desired change), and also removed the code that eliminated the `CI build ID: ` prefix (undesired change). (See [this](https://github.com/ampproject/amp-github-apps/pull/1196/files#diff-87ebe063534f5df9d5ed5227bf7a7112fa26925410573f643c17ad1eda0b5001L211) line.)

This PR restores the prefix removal bit.