### PR TITLE
Switch PR Deploy unique identifier from build ID to commit SHA

### DIFF
--- a/pr-deploy/README.md
+++ b/pr-deploy/README.md
@@ -9,11 +9,11 @@ This app runs on an instance of Google AppEngine and is installed exclusively on
 How the app works
 ----------------
 1. A commit is pushed to a new or existing pull request on ampproject/amphtml.
-2. A CI build compiles your changes and uploads the build artifacts and example pages as `amp_nomodule_<CI build ID>.zip` to a remote storage location. During this step, a check called `ampproject/pr-deploy` is set to `pending`.
+2. A CI build compiles your changes and uploads the build artifacts and example pages as `amp_nomodule_<commit SHA>.zip` to a remote storage location. During this step, a check called `ampproject/pr-deploy` is set to `pending`.
 3. a) If there was a compilation error, the CI build tells the AMP PR Deploy Bot that there's nothing left to do until the error is fixed. <br>
    b) If there were no errors, the CI build tells the AMP PR Deploy Bot that a test site is ready to be deployed. `ampproject/pr-deploy` is now `netural`
-4. A test site is deployed by clicking the 'Deploy Me' button in the details page of `ampproject/pr-deploy`. The app unzips and writes `amp_nomodule_<CI build ID>.zip` to the public Google Cloud Storage bucket.
-5. `ampproject/pr-deploy` completes with the website URL. `https://console.cloud.google.com/storage/browser/amp-test-website-1/amp_nomodule_<CI build ID>`
+4. A test site is deployed by clicking the 'Deploy Me' button in the details page of `ampproject/pr-deploy`. The app unzips and writes `amp_nomodule_<commit SHA>.zip` to the public Google Cloud Storage bucket.
+5. `ampproject/pr-deploy` completes with the website URL. `https://console.cloud.google.com/storage/browser/amp-test-website-1/amp_nomodule_<commit SHA>`
 
 Here's a quick [demo](https://github.com/ampproject/amphtml/pull/24274) on how to create a test site.
 

--- a/pr-deploy/package.json
+++ b/pr-deploy/package.json
@@ -19,7 +19,8 @@
     "dev": "nodemon",
     "start": "probot run ./src/app.js",
     "pretest": "npm run build",
-    "test": "jest --verbose=false"
+    "test": "jest --verbose=false",
+    "deploy-tag": "git tag 'deploy-pr-deploy-'`date -u '+%Y%m%d%H%M%S'`"
   },
   "dependencies": {
     "@google-cloud/storage": "5.3.0",

--- a/pr-deploy/src/app.ts
+++ b/pr-deploy/src/app.ts
@@ -57,7 +57,7 @@ function initializeRouter(app: Application) {
     const pr = new PullRequest(github, headSha);
     switch (result) {
       case 'success':
-        await pr.buildCompleted(ciBuild);
+        await pr.buildCompleted(headSha);
         break;
       case 'errored':
         await pr.buildErrored();
@@ -89,11 +89,11 @@ function initializeDeployment(app: Application) {
     );
     try {
       await pr.deploymentInProgress();
-      const ciBuildId = await pr.getCiBuildId();
-      const bucketUrl = await unzipAndMove(ciBuildId);
+      const commitSha = await pr.getCommitSha();
+      const bucketUrl = await unzipAndMove(commitSha);
       await pr.deploymentCompleted(
         bucketUrl,
-        `${BASE_URL}amp_nomodule_${ciBuildId}/`
+        `${BASE_URL}amp_nomodule_${commitSha}/`
       );
     } catch (e) {
       await pr.deploymentErrored(e);

--- a/pr-deploy/src/app.ts
+++ b/pr-deploy/src/app.ts
@@ -50,7 +50,7 @@ function initializeRouter(app: Application) {
   router.use(express.json());
 
   const initialize = async(request, response) => {
-    const {ciBuild, headSha, result} = request.params;
+    const {headSha, result} = request.params;
     const github = ((await app.auth(
       Number(process.env.INSTALLATION_ID)
     )) as unknown) as Octokit;

--- a/pr-deploy/src/app.ts
+++ b/pr-deploy/src/app.ts
@@ -41,9 +41,9 @@ function initializeCheck(app: Application) {
 }
 
 /**
- * Listens to the HTTP post route from CI to know when dist upload is complete.
- * When received, updates the PR check status to 'complete'
- * so that the check run action to deploy site is enabled.
+ * Listens to the HTTP post route from CI to know when binary upload is
+ * complete. When received, updates the PR check status to 'complete' so that
+ * the check run action to deploy site is enabled.
  */
 function initializeRouter(app: Application) {
   const router: IRouter = app.route('/v0/pr-deploy');
@@ -70,7 +70,7 @@ function initializeRouter(app: Application) {
     response.send({status: 200});
   };
 
-  router.post('/cibuilds/:ciBuild/headshas/:headSha/:result', initialize);
+  router.post('/headshas/:headSha/:result', initialize);
 }
 
 /**

--- a/pr-deploy/src/github.ts
+++ b/pr-deploy/src/github.ts
@@ -145,7 +145,7 @@ export class PullRequest {
           'Please click the `Create a test site` button above to ' +
           'deploy the minified build of this PR along with examples from ' +
           '`examples/` and `test/manual/`. It should only take a minute.',
-        text: `CI build ID: ${id}`,
+        text: `Commit SHA: ${id}`,
       },
       actions: ACTIONS,
     };
@@ -201,12 +201,12 @@ export class PullRequest {
     return this.github.checks.update(params);
   }
 
-  async getCiBuildId() {
+  async getCommitSha() {
     const check = await this.getCheck_();
     if (!check.output || !check.output.text) {
       return '';
     }
-    return check.output.text.replace(/CI build ID\:\ /g, '')
+    return check.output.text.replace(/Commit SHA: /g, '');
   }
 
   /**

--- a/pr-deploy/src/github.ts
+++ b/pr-deploy/src/github.ts
@@ -130,7 +130,7 @@ export class PullRequest {
   /**
    * Set check to 'completed' to enable the 'Deploy Me' action.
    */
-  async buildCompleted(id: string) {
+  async buildCompleted(sha: string) {
     const check = await this.getCheck_();
 
     const params: ChecksUpdateParams = {
@@ -145,7 +145,7 @@ export class PullRequest {
           'Please click the `Create a test site` button above to ' +
           'deploy the minified build of this PR along with examples from ' +
           '`examples/` and `test/manual/`. It should only take a minute.',
-        text: `Commit SHA: ${id}`,
+        text: `Commit SHA: ${sha}`,
       },
       actions: ACTIONS,
     };

--- a/pr-deploy/src/zipper.ts
+++ b/pr-deploy/src/zipper.ts
@@ -23,10 +23,10 @@ import {Storage} from '@google-cloud/storage';
  * AMP CI Build Storage bucket, unzips and writes to
  * a test website bucket that serves the files publicly.
  */
-export async function unzipAndMove(id: string): Promise<string> {
+export async function unzipAndMove(sha: string): Promise<string> {
   const storage = new Storage({projectId: process.env.PROJECT_ID});
   const serveBucket = storage.bucket(process.env.SERVE_BUCKET);
-  const buildFileName = `amp_nomodule_${id}`;
+  const buildFileName = `amp_nomodule_${sha}`;
   const buildFile =
     storage.bucket(process.env.BUILD_BUCKET).file(`${buildFileName}.zip`);
 

--- a/pr-deploy/test/app.test.ts
+++ b/pr-deploy/test/app.test.ts
@@ -20,7 +20,7 @@ jest.mock('../src/zipper', () => {
     unzipAndMove: jest
       .fn()
       .mockReturnValue(
-        Promise.resolve('gs://serving-bucket/ciBuildId')
+        Promise.resolve('gs://serving-bucket/headSha')
       ),
   };
 });

--- a/pr-deploy/test/app.test.ts
+++ b/pr-deploy/test/app.test.ts
@@ -128,7 +128,7 @@ describe('test pr deploy app', () => {
       .reply(200, {
         total_count: 1,
         check_runs: [
-          {id: 12345, output: {text: 'CI build ID: abc'}},
+          {id: 12345, output: {text: 'Commit SHA: abcdefa'}},
         ],
       }) // make sure a check already exists
       .patch('/repos/test-owner/test-repo/check-runs/12345')


### PR DESCRIPTION
This PR updates the PR deploy app to use the commit SHA as the binary file suffix.

Companion to https://github.com/ampproject/amphtml/pull/32083.