### PR TITLE
[error-monitoring] Replace GitHub Access Token and fix URL typo

### DIFF
--- a/error-monitoring/cloud_build.yaml
+++ b/error-monitoring/cloud_build.yaml
@@ -58,4 +58,4 @@ steps:
 secrets:
   - kmsKeyName: projects/amp-error-monitoring/locations/global/keyRings/amp-github-apps-keyring/cryptoKeys/app-env-key
     secretEnv:
-      GITHUB_ACCESS_TOKEN: CiQAyU85iSvJh8HsabAs7Mv5QXXlM1WZoFGw7z5ZLmMlg2ogwKYSUQAshvUdguq5dEzmti0H0dkogWNhg8yVGfRO5BdtF3rdt+/Zne0W7wo8Ytmsd6yKgnP1OBiqBXqETeXAEBBKvJXBiUMThUJSZVaejNeoaiFUMg==
+      GITHUB_ACCESS_TOKEN: CiQAyU85iXTdhpFVRkGbLJn2t87QFrDxplJg10wAbhYzxPMUMm8SUQAshvUdxZpIPKfAslCQ+MQh+yrvr0l22WGuXv4epSX16P6Y1qskuZmOK5YhxjFrWln1L2i4w670VDyumU9bKkAXTBXuMbFpWVhLVs8Ap4jZEw==

--- a/error-monitoring/src/issue_builder.ts
+++ b/error-monitoring/src/issue_builder.ts
@@ -88,7 +88,7 @@ export class IssueBuilder {
   private prLink(prNumber: number): string {
     return (
       `[#${prNumber}]` +
-      `(https://github.com/${this.sourceRepo}/pulls/${prNumber})`
+      `(https://github.com/${this.sourceRepo}/pull/${prNumber})`
     );
   }
 

--- a/error-monitoring/test/fixtures/created-issue.md
+++ b/error-monitoring/test/fixtures/created-issue.md
@@ -13,8 +13,8 @@ Stacktrace
 
 Notes
 ---
-`@xymw` modified `extensions/amp-delight-player/0.1/amp-delight-player.js:396-439` in [#17939](https://github.com/test_org/test_repo/pulls/17939) (Nov 12, 2018)
-`@rsimha` modified `src/event-helper-listen.js:57-59` in [#12450](https://github.com/test_org/test_repo/pulls/12450) (Dec 13, 2017)
+`@xymw` modified `extensions/amp-delight-player/0.1/amp-delight-player.js:396-439` in [#17939](https://github.com/test_org/test_repo/pull/17939) (Nov 12, 2018)
+`@rsimha` modified `src/event-helper-listen.js:57-59` in [#12450](https://github.com/test_org/test_repo/pull/12450) (Dec 13, 2017)
 
 **Seen in:**
 - 04-24 Beta (1234)

--- a/error-monitoring/test/issue_builder.test.ts
+++ b/error-monitoring/test/issue_builder.test.ts
@@ -166,12 +166,12 @@ describe('IssueBuilder', () => {
       expect(notes).toContain(
         '`@xymw` modified ' +
           '`extensions/amp-delight-player/0.1/amp-delight-player.js:396-439` ' +
-          'in [#17939](https://github.com/test_org/test_repo/pulls/17939) ' +
+          'in [#17939](https://github.com/test_org/test_repo/pull/17939) ' +
           '(Nov 12, 2018)'
       );
       expect(notes).toContain(
         '`@rsimha` modified `src/event-helper-listen.js:57-59` in ' +
-          '[#12450](https://github.com/test_org/test_repo/pulls/12450) ' +
+          '[#12450](https://github.com/test_org/test_repo/pull/12450) ' +
           '(Dec 13, 2017)'
       );
     });


### PR DESCRIPTION
Duplicate error issues have been getting filed, and I'm not sure why. I tried revoking the old access token and this re-deploys with a new one, in case some vestige was running jobs somehow and filing error reports. Also, fixes a typo in PR urls.