### PR TITLE
Show commit info in bundle-size check-run details

### DIFF
--- a/bundle-size/api.js
+++ b/bundle-size/api.js
@@ -35,7 +35,7 @@ const DRAFT_TITLE_REGEX = /\b(wip|work in progress|do not (merge|submit|review))
  */
 function failedCheckOutput(approverTeams, reportMarkdown) {
   return {
-    title: `approval required from one of [@${approverTeams.join(', @')}]`,
+    title: `Approval required from one of [@${approverTeams.join(', @')}]`,
     summary:
       'This pull request has increased the bundle size (brotli compressed ' +
       'size) of the following files, and must be approved by a member of one ' +
@@ -58,7 +58,7 @@ function failedCheckOutput(approverTeams, reportMarkdown) {
  */
 function successfulCheckOutput(reportMarkdown) {
   return {
-    title: `no approval necessary`,
+    title: `No approval necessary`,
     summary:
       'This pull request does not change any bundle size (brotli compressed ' +
       'size) by any significant amount, so no special approval is necessary.' +
@@ -94,16 +94,28 @@ function erroredCheckOutput(partialBaseSha) {
 }
 
 /**
- * Return formatted extra changes to append to the check output summary.
+ * Return formatted commit info and extra changes to append to the check output
+ * summary.
  *
+ * @param {string} headSha commit being checked
+ * @param {string} baseSha baseline commit for comparison
  * @param {!Array<string>} bundleSizeDeltas text description of all bundle size
  *   changes.
  * @param {!Array<string>} missingBundleSizes text description of missing bundle
  *   sizes from other `master` or the pull request.
  * @return {string} formatted extra changes;
  */
-function extraBundleSizesSummary(bundleSizeDeltas, missingBundleSizes) {
+function extraBundleSizesSummary(
+  headSha,
+  baseSha,
+  bundleSizeDeltas,
+  missingBundleSizes
+) {
   return (
+    '## Commit details\n' +
+    `**Head commit:** ${headSha}\n` +
+    `**Base commit:** ${baseSha}\n` +
+    `**Code changes:** https://github.com/ampproject/amphtml/compare/${baseSha}..${headSha}\n` +
     '## Bundle size changes\n' +
     bundleSizeDeltas.concat(missingBundleSizes).join('\n')
   );
@@ -339,6 +351,8 @@ exports.installApiRouter = (app, router, db, githubUtils) => {
     }
 
     const reportMarkdown = extraBundleSizesSummary(
+      check.head_sha,
+      baseSha,
       bundleSizeDeltas,
       missingBundleSizes
     );
@@ -404,7 +418,7 @@ exports.installApiRouter = (app, router, db, githubUtils) => {
       conclusion: 'neutral',
       completed_at: new Date().toISOString(),
       output: {
-        title: 'check skipped because PR contains no runtime changes',
+        title: 'Check skipped because PR contains no runtime changes',
         summary:
           'An automated check has determined that the bundle size ' +
           '(brotli compressed size of `v0.js`) could not be affected by ' +

--- a/bundle-size/api.js
+++ b/bundle-size/api.js
@@ -227,6 +227,8 @@ exports.installApiRouter = (app, router, db, githubUtils) => {
    * @return {boolean} true if succeeded; false otherwise.
    */
   async function tryReport(check, baseSha, prBundleSizes, lastAttempt = false) {
+    const partialHeadSha = check.head_sha.substr(0, 7);
+    const partialBaseSha = baseSha.substr(0, 7);
     const github = await app.auth(check.installation_id);
     const githubOptions = {
       owner: check.owner,
@@ -256,8 +258,6 @@ exports.installApiRouter = (app, router, db, githubUtils) => {
       );
     } catch (error) {
       const fileNotFound = 'status' in error && error.status === 404;
-      const partialHeadSha = check.head_sha.substr(0, 7);
-      const partialBaseSha = baseSha.substr(0, 7);
 
       if (fileNotFound) {
         app.log.warn(
@@ -351,8 +351,8 @@ exports.installApiRouter = (app, router, db, githubUtils) => {
     }
 
     const reportMarkdown = extraBundleSizesSummary(
-      check.head_sha,
-      baseSha,
+      partialHeadSha,
+      partialBaseSha,
       bundleSizeDeltas,
       missingBundleSizes
     );

--- a/bundle-size/test/api.test.js
+++ b/bundle-size/test/api.test.js
@@ -339,9 +339,9 @@ describe('bundle-size api', () => {
         approving_teams: 'ampproject/wg-performance,ampproject/wg-runtime',
         report_markdown:
           '## Commit details\n' +
-          '**Head commit:** 26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa\n' +
-          '**Base commit:** 5f27002526a808c5c1ad5d0f1ab1cec471af0a33\n' +
-          '**Code changes:** https://github.com/ampproject/amphtml/compare/5f27002526a808c5c1ad5d0f1ab1cec471af0a33..26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa\n' +
+          '**Head commit:** 26ddec3\n' +
+          '**Base commit:** 5f27002\n' +
+          '**Code changes:** https://github.com/ampproject/amphtml/compare/5f27002..26ddec3\n' +
           '## Bundle size changes\n' +
           '* `dist/v0.js`: Δ +0.34KB\n' +
           '* `dist/amp4ads-v0.js`: (11.22 KB) missing in `master`\n' +
@@ -484,9 +484,9 @@ describe('bundle-size api', () => {
         approving_teams: 'ampproject/wg-performance,ampproject/wg-runtime',
         report_markdown:
           '## Commit details\n' +
-          '**Head commit:** 26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa\n' +
-          '**Base commit:** 5f27002526a808c5c1ad5d0f1ab1cec471af0a33\n' +
-          '**Code changes:** https://github.com/ampproject/amphtml/compare/5f27002526a808c5c1ad5d0f1ab1cec471af0a33..26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa\n' +
+          '**Head commit:** 26ddec3\n' +
+          '**Base commit:** 5f27002\n' +
+          '**Code changes:** https://github.com/ampproject/amphtml/compare/5f27002..26ddec3\n' +
           '## Bundle size changes\n' +
           '* `dist/v0.js`: Δ +0.34KB\n' +
           '* `dist/amp4ads-v0.js`: (11.22 KB) missing in `master`\n' +
@@ -622,9 +622,9 @@ describe('bundle-size api', () => {
         approving_teams: 'ampproject/wg-performance,ampproject/wg-runtime',
         report_markdown:
           '## Commit details\n' +
-          '**Head commit:** 26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa\n' +
-          '**Base commit:** 5f27002526a808c5c1ad5d0f1ab1cec471af0a33\n' +
-          '**Code changes:** https://github.com/ampproject/amphtml/compare/5f27002526a808c5c1ad5d0f1ab1cec471af0a33..26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa\n' +
+          '**Head commit:** 26ddec3\n' +
+          '**Base commit:** 5f27002\n' +
+          '**Code changes:** https://github.com/ampproject/amphtml/compare/5f27002..26ddec3\n' +
           '## Bundle size changes\n' +
           '* `dist/v0.js`: Δ +0.11KB\n' +
           '* `dist/amp4ads-v0.js`: (11.22 KB) missing in `master`\n' +

--- a/bundle-size/test/api.test.js
+++ b/bundle-size/test/api.test.js
@@ -138,7 +138,7 @@ describe('bundle-size api', () => {
           check_run_id: 555555,
           conclusion: 'neutral',
           output: expect.objectContaining({
-            title: 'check skipped because PR contains no runtime changes',
+            title: 'Check skipped because PR contains no runtime changes',
           }),
         })
       );
@@ -187,9 +187,9 @@ describe('bundle-size api', () => {
     });
 
     test.each([
-      [12.44, 'no approval necessary'],
-      [12.34, 'no approval necessary'],
-      [12.24, 'no approval necessary'],
+      [12.44, 'No approval necessary'],
+      [12.34, 'No approval necessary'],
+      [12.24, 'No approval necessary'],
     ])(
       'update a check on bundle-size report (report/base = 12.34KB/%dKB)',
       async (baseSize, message) => {
@@ -289,7 +289,7 @@ describe('bundle-size api', () => {
           check_run_id: 555555,
           conclusion: 'success',
           output: expect.objectContaining({
-            title: 'no approval necessary',
+            title: 'No approval necessary',
             summary: expect.stringContaining(
               '* `dist/v0/amp-ad-0.1.js`: Δ +0.03KB\n' +
                 '* `dist/v0/amp-anim-0.1.js`: missing in pull request\n' +
@@ -338,6 +338,10 @@ describe('bundle-size api', () => {
         check_run_id: 555555,
         approving_teams: 'ampproject/wg-performance,ampproject/wg-runtime',
         report_markdown:
+          '## Commit details\n' +
+          '**Head commit:** 26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa\n' +
+          '**Base commit:** 5f27002526a808c5c1ad5d0f1ab1cec471af0a33\n' +
+          '**Code changes:** https://github.com/ampproject/amphtml/compare/5f27002526a808c5c1ad5d0f1ab1cec471af0a33..26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa\n' +
           '## Bundle size changes\n' +
           '* `dist/v0.js`: Δ +0.34KB\n' +
           '* `dist/amp4ads-v0.js`: (11.22 KB) missing in `master`\n' +
@@ -351,7 +355,7 @@ describe('bundle-size api', () => {
           conclusion: 'action_required',
           output: expect.objectContaining({
             title:
-              'approval required from one of [@ampproject/wg-performance, @ampproject/wg-runtime]',
+              'Approval required from one of [@ampproject/wg-performance, @ampproject/wg-runtime]',
           }),
         })
       );
@@ -432,7 +436,7 @@ describe('bundle-size api', () => {
           conclusion: 'action_required',
           output: expect.objectContaining({
             title:
-              'approval required from one of [@ampproject/wg-performance, @ampproject/wg-runtime]',
+              'Approval required from one of [@ampproject/wg-performance, @ampproject/wg-runtime]',
           }),
         })
       );
@@ -479,6 +483,10 @@ describe('bundle-size api', () => {
         check_run_id: 555555,
         approving_teams: 'ampproject/wg-performance,ampproject/wg-runtime',
         report_markdown:
+          '## Commit details\n' +
+          '**Head commit:** 26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa\n' +
+          '**Base commit:** 5f27002526a808c5c1ad5d0f1ab1cec471af0a33\n' +
+          '**Code changes:** https://github.com/ampproject/amphtml/compare/5f27002526a808c5c1ad5d0f1ab1cec471af0a33..26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa\n' +
           '## Bundle size changes\n' +
           '* `dist/v0.js`: Δ +0.34KB\n' +
           '* `dist/amp4ads-v0.js`: (11.22 KB) missing in `master`\n' +
@@ -554,7 +562,7 @@ describe('bundle-size api', () => {
         expect.objectContaining({
           conclusion: 'success',
           output: expect.objectContaining({
-            title: 'no approval necessary',
+            title: 'No approval necessary',
           }),
         })
       );
@@ -613,6 +621,10 @@ describe('bundle-size api', () => {
         check_run_id: 555555,
         approving_teams: 'ampproject/wg-performance,ampproject/wg-runtime',
         report_markdown:
+          '## Commit details\n' +
+          '**Head commit:** 26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa\n' +
+          '**Base commit:** 5f27002526a808c5c1ad5d0f1ab1cec471af0a33\n' +
+          '**Code changes:** https://github.com/ampproject/amphtml/compare/5f27002526a808c5c1ad5d0f1ab1cec471af0a33..26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa\n' +
           '## Bundle size changes\n' +
           '* `dist/v0.js`: Δ +0.11KB\n' +
           '* `dist/amp4ads-v0.js`: (11.22 KB) missing in `master`\n' +
@@ -628,7 +640,7 @@ describe('bundle-size api', () => {
           conclusion: 'action_required',
           output: expect.objectContaining({
             title:
-              'approval required from one of [@ampproject/wg-performance, @ampproject/wg-runtime]',
+              'Approval required from one of [@ampproject/wg-performance, @ampproject/wg-runtime]',
           }),
         })
       );


### PR DESCRIPTION
This will help debug corner cases like older PR branches (with newer commits on `master`) and unexpected bundle-size changes. Extra markdown will look like this:
## Commit details
**Head commit:** 0cbb639
**Base commit:** 0d927f7
**Code changes:** https://github.com/ampproject/amp-github-apps/compare/0d927f7..0cbb639
