### PR TITLE
[test-status] Change checkRunId's data type from integer to bigint

### DIFF
--- a/test-status/db.js
+++ b/test-status/db.js
@@ -45,7 +45,7 @@ exports.getCheckRunId = async (db, headSha, type, subType) => {
   if (existingCheck === undefined) {
     return null;
   } else {
-    return existingCheck.checkRunId;
+    return Number(existingCheck.checkRunId);
   }
 };
 
@@ -88,6 +88,9 @@ exports.getCheckRunResults = async (db, headSha, type, subType) => {
   } else {
     if (typeof existingCheck.errored === 'number') {
       existingCheck.errored = Boolean(existingCheck.errored);
+    }
+    if (typeof existingCheck.checkRunId === 'string') {
+      existingCheck.checkRunId = Number(existingCheck.checkRunId);
     }
     return existingCheck;
   }

--- a/test-status/setup-db.js
+++ b/test-status/setup-db.js
@@ -44,7 +44,7 @@ function setupDb(db) {
       table.string('headSha', 40);
       table.string('type', 255);
       table.string('subType', 255);
-      table.integer('checkRunId');
+      table.bigInteger('checkRunId');
       table.integer('passed');
       table.integer('failed');
       table.boolean('errored');


### PR DESCRIPTION
* I already changed the database type directly to fix the integer overflow error from the db engine
* knex [returns `bigint`s as strings](http://knexjs.org/#Schema-bigInteger) because it might overflow the safe JavaScript max number value, but we can probably safely assume it won't go over [9,007,199,254,740,991](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER), so explicitly cast all of them to Numbers after the db returns