### PR TITLE
Rename links in test reporting page from Travis to CircleCI

### DIFF
--- a/test-case-reporting/static/test-run-list.html
+++ b/test-case-reporting/static/test-run-list.html
@@ -31,7 +31,7 @@
               {{#testRun.job}}
 
               Job: {{jobNumber}}
-              {{#url}}(<a href="{{.}}">Travis</a>){{/url}}
+              {{#url}}(<a href="{{.}}">CircleCI</a>){{/url}}
             </td>
 
               {{#build}}
@@ -40,7 +40,7 @@
               <a href="/test-results/build/{{build.buildNumber}}">
                 {{buildNumber}}
               </a>
-              {{#url}}(<a href="{{.}}">Travis</a>){{/url}}
+              {{#url}}(<a href="{{.}}">CircleCI</a>){{/url}}
               {{/build}}
 
               {{/testRun.job}}


### PR DESCRIPTION
In #1194, I attempted transplant surgery on the test case reporting backend to make its database CI agnostic for the switch from Travis to CircleCI. This turned out to be a bad idea due to https://github.com/ampproject/amp-github-apps/pull/1194#pullrequestreview-569405440, so the effort was abandoned.

This PR applies a band-aid to the top-level HTML report page to make the links read "CircleCI" instead of "Travis". This should fix the visible UI until we think it's worth the engineering effort to go in and update the backend by adding a new CI service type.

Related PR: https://github.com/ampproject/amphtml/pull/33389
Closes #1113 (can reopen if / when we think it's worth a bigger rewrite)