### PR TITLE
[bundle-size] Change checkRunId's data type from integer to bigint

### DIFF
--- a/bundle-size/common.js
+++ b/bundle-size/common.js
@@ -20,11 +20,11 @@
  *
  * @param {!Knex} db database connection.
  * @param {string} headSha commit SHA of the head commit of a pull request.
- * @return {!object} GitHub Check object.
+ * @return {?object} GitHub Check object.
  */
 exports.getCheckFromDatabase = async (db, headSha) => {
-  const results = await db('checks')
-    .select(
+  const check = await db('checks')
+    .first(
       'head_sha',
       'pull_request_id',
       'installation_id',
@@ -35,11 +35,10 @@ exports.getCheckFromDatabase = async (db, headSha) => {
       'report_markdown'
     )
     .where('head_sha', headSha);
-  if (results.length > 0) {
-    return results[0];
-  } else {
-    return null;
+  if (check) {
+    check.check_run_id = Number(check.check_run_id);
   }
+  return check;
 };
 
 /**

--- a/bundle-size/setup-db.js
+++ b/bundle-size/setup-db.js
@@ -32,7 +32,7 @@ function setupDb(db) {
       table.string('repo');
       table.integer('pull_request_id');
       table.integer('installation_id');
-      table.integer('check_run_id');
+      table.bigInteger('check_run_id');
       table
         .text('approving_teams')
         .comment(


### PR DESCRIPTION
Same as #1242 but for bundle-size

> * I already changed the database type directly to fix the integer overflow error from the db engine
> * knex [returns `bigint`s as strings](http://knexjs.org/#Schema-bigInteger) because it might overflow the safe JavaScript max number value, but we can probably safely assume it won't go over [9,007,199,254,740,991](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER), so explicitly cast all of them to Numbers after the db returns