### PR TITLE
Replace all mentions of `build cop` with `build on-duty`

### DIFF
--- a/onduty/README.md
+++ b/onduty/README.md
@@ -1,7 +1,7 @@
 AMP On-Duty Bot
 ==============
 
-A GitHub App that updates the teams `@ampproject/release-onduty` and `@ampproject/build-cop` according to the current rotation.
+A GitHub App that updates the teams `@ampproject/release-onduty` and `@ampproject/build-on-duty` according to the current rotation.
 
 This app runs as a Google Cloud Functions deployment.
 
@@ -14,7 +14,7 @@ The bot receives reports of the form:
 
 ```
 {
-  "build-cop": {
+  "build-on-duty": {
     "primary": "<username>",
     "secondary": "<username>"|null
   },

--- a/onduty/index.ts
+++ b/onduty/index.ts
@@ -27,12 +27,12 @@ const {
   GITHUB_ACCESS_TOKEN,
   GITHUB_ORG,
   RELEASE_ONDUTY_TEAM,
-  BUILD_COP_TEAM,
+  BUILD_ON_DUTY_TEAM,
 } = process.env;
 
 const ROTATION_TEAMS: RotationTeamMap = {
   'release-on-duty': RELEASE_ONDUTY_TEAM,
-  'build-cop': BUILD_COP_TEAM,
+  'build-on-duty': BUILD_ON_DUTY_TEAM,
 };
 
 const octokit = new Octokit({auth: `token ${GITHUB_ACCESS_TOKEN}`});

--- a/onduty/index.ts
+++ b/onduty/index.ts
@@ -26,12 +26,12 @@ import statusCodes from 'http-status-codes';
 const {
   GITHUB_ACCESS_TOKEN,
   GITHUB_ORG,
-  RELEASE_ONDUTY_TEAM,
+  RELEASE_ON_DUTY_TEAM,
   BUILD_ON_DUTY_TEAM,
 } = process.env;
 
 const ROTATION_TEAMS: RotationTeamMap = {
-  'release-on-duty': RELEASE_ONDUTY_TEAM,
+  'release-on-duty': RELEASE_ON_DUTY_TEAM,
   'build-on-duty': BUILD_ON_DUTY_TEAM,
 };
 

--- a/onduty/redacted.env
+++ b/onduty/redacted.env
@@ -2,5 +2,5 @@
 GITHUB_ACCESS_TOKEN=[REDACTED]
 GITHUB_ORG=ampproject
 RELEASE_ONDUTY_TEAM=release-on-duty
-BUILD_COP_TEAM=build-cop
+BUILD_ON_DUTY_TEAM=build-on-duty
 BOT_USERNAME=ampprojectbot

--- a/onduty/redacted.env
+++ b/onduty/redacted.env
@@ -1,6 +1,6 @@
 # Note: Access token is also used to authenticate rotation update requests.
 GITHUB_ACCESS_TOKEN=[REDACTED]
 GITHUB_ORG=ampproject
-RELEASE_ONDUTY_TEAM=release-on-duty
+RELEASE_ON_DUTY_TEAM=release-on-duty
 BUILD_ON_DUTY_TEAM=build-on-duty
 BOT_USERNAME=ampprojectbot

--- a/onduty/test/bot.test.ts
+++ b/onduty/test/bot.test.ts
@@ -31,11 +31,11 @@ describe('OndutyBot', () => {
 
   let bot: OndutyBot;
   const rotationTeams: RotationTeamMap = {
-    'build-cop': 'build-team',
+    'build-on-duty': 'build-team',
     'release-on-duty': 'release-team',
   };
   const rotations: RotationUpdate = {
-    'build-cop': {
+    'build-on-duty': {
       primary: 'builder-primary',
       secondary: 'builder-secondary',
     },
@@ -63,12 +63,12 @@ describe('OndutyBot', () => {
     });
 
     it('fetches current team members', async () => {
-      await bot.updateRotation('build-cop', rotations['build-cop']);
+      await bot.updateRotation('build-on-duty', rotations['build-on-duty']);
       expect(github.getTeamMembers).toHaveBeenCalledWith('build-team');
     });
 
     it('adds new team members', async () => {
-      await bot.updateRotation('build-cop', rotations['build-cop']);
+      await bot.updateRotation('build-on-duty', rotations['build-on-duty']);
       expect(github.addToTeam).toHaveBeenCalledWith(
         'build-team',
         'builder-secondary'
@@ -76,7 +76,7 @@ describe('OndutyBot', () => {
     });
 
     it('removes old team members', async () => {
-      await bot.updateRotation('build-cop', rotations['build-cop']);
+      await bot.updateRotation('build-on-duty', rotations['build-on-duty']);
       expect(github.removeFromTeam).toHaveBeenCalledWith(
         'build-team',
         'builder-old-primary'
@@ -84,7 +84,7 @@ describe('OndutyBot', () => {
     });
 
     it('ignores the bot user', async () => {
-      await bot.updateRotation('build-cop', rotations['build-cop']);
+      await bot.updateRotation('build-on-duty', rotations['build-on-duty']);
       expect(github.removeFromTeam).not.toHaveBeenCalledWith(
         'build-team',
         'bot-user'
@@ -103,7 +103,7 @@ describe('OndutyBot', () => {
       jest.spyOn(bot, 'updateRotation');
       await bot.handleUpdate(rotations);
 
-      expect(bot.updateRotation).toHaveBeenCalledWith('build-cop', {
+      expect(bot.updateRotation).toHaveBeenCalledWith('build-on-duty', {
         primary: 'builder-primary',
         secondary: 'builder-secondary',
       });

--- a/onduty/test/e2e.test.ts
+++ b/onduty/test/e2e.test.ts
@@ -69,7 +69,7 @@ describe('On-Duty Bot', () => {
 
     await refreshRotation(
       request({
-        'build-cop': {
+        'build-on-duty': {
           primary: 'builder-primary',
           secondary: 'builder-secondary',
         },
@@ -88,7 +88,7 @@ describe('On-Duty Bot', () => {
   it('returns 401 Unauthorized for an invalid token', async () => {
     await refreshRotation(
       request({
-        'build-cop': {
+        'build-on-duty': {
           primary: 'builder-primary',
           secondary: 'builder-secondary',
         },
@@ -111,7 +111,7 @@ describe('On-Duty Bot', () => {
 
     await refreshRotation(
       request({
-        'build-cop': {
+        'build-on-duty': {
           primary: 'builder-primary',
           secondary: 'builder-secondary',
         },

--- a/onduty/test/jest-preload.ts
+++ b/onduty/test/jest-preload.ts
@@ -20,6 +20,6 @@ process.env.LOG_LEVEL = process.env.LOG_LEVEL || 'warn';
 process.env.GITHUB_ACCESS_TOKEN = '_TOKEN_';
 process.env.GITHUB_ORG = 'test_org';
 process.env.RELEASE_ONDUTY_TEAM = 'release-team';
-process.env.BUILD_COP_TEAM = 'build-team';
+process.env.BUILD_ON_DUTY_TEAM = 'build-team';
 process.env.BOT_USERNAME = 'bot-user';
 process.env.AMP_RATE_LIMIT_MS = '1';

--- a/onduty/test/jest-preload.ts
+++ b/onduty/test/jest-preload.ts
@@ -19,7 +19,7 @@ process.env.LOG_LEVEL = process.env.LOG_LEVEL || 'warn';
 
 process.env.GITHUB_ACCESS_TOKEN = '_TOKEN_';
 process.env.GITHUB_ORG = 'test_org';
-process.env.RELEASE_ONDUTY_TEAM = 'release-team';
+process.env.RELEASE_ON_DUTY_TEAM = 'release-team';
 process.env.BUILD_ON_DUTY_TEAM = 'build-team';
 process.env.BOT_USERNAME = 'bot-user';
 process.env.AMP_RATE_LIMIT_MS = '1';

--- a/onduty/types/index.d.ts
+++ b/onduty/types/index.d.ts
@@ -28,7 +28,7 @@ declare module 'onduty' {
     secondary: null | string;
   }
 
-  export type RotationType = 'build-cop' | 'release-on-duty';
+  export type RotationType = 'build-on-duty' | 'release-on-duty';
   export type RotationUpdate = Record<RotationType, Rotation>;
   export type RotationTeamMap = Record<RotationType, string>;
 


### PR DESCRIPTION
This is something we've been meaning to do for a while.

**Companion PR:** https://github.com/ampproject/amphtml/pull/33465

**Next steps:**

- [ ] Merge and deploy this PR
- [ ] Update the rotation tool to reflect this name
- [ ] Update the name of the GitHub team
- [ ] Merge https://github.com/ampproject/amphtml/pull/33465