### PR TITLE
Prepare to rename the default branch of `amp-github-apps` to `main`

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -2,10 +2,12 @@ name: GitHub Actions
 on:
   push:
     branches:
-      - master
+      - main
+      - master # TODO(rsimha, ampproject/amphtml#32195): Remove this line.
   pull_request:
     branches:
-      - master
+      - main
+      - master # TODO(rsimha, ampproject/amphtml#32195): Remove this line.
 
 jobs:
   pr_check:

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -22,16 +22,11 @@
 const {getStdout} = require('./exec');
 
 /**
- * TODO(rsimha, ampproject/amphtml#32195): Change this to main.
- */
-const mainBranch = 'master';
-
-/**
  * Returns the merge base of the PR branch and the main branch.
  * @return {string}
  */
 function gitMergeBaseMain() {
-  return getStdout(`git merge-base ${mainBranch} HEAD`).trim();
+  return getStdout(`git merge-base main HEAD`).trim();
 }
 
 /**

--- a/checklist/README.md
+++ b/checklist/README.md
@@ -72,6 +72,6 @@ After setting up the app locally, use `gcloud` to deploy the app and cron tasks:
      --trigger-http
    ```
    - When deploying after the first time, the `--runtime` and `--trigger-http` flags may be omitted
-3. To configure Cloud Build auto-deployment, follow [this guide](https://github.com/ampproject/amp-github-apps/blob/master/DEPLOYMENT.md)
+3. To configure Cloud Build auto-deployment, follow [this guide](https://github.com/ampproject/amp-github-apps/blob/main/DEPLOYMENT.md)
 
 This GitHub App is deployed as a [Google Cloud Function](https://cloud.google.com/functions/docs/) at the endpoint: https://ampproject-checklist-bot.cloudfunctions.net/ (**TODO:** URL unavailable, this will be deployed)

--- a/error-monitoring/README.md
+++ b/error-monitoring/README.md
@@ -1,17 +1,14 @@
-AMP Error Monitoring
-==============
+# AMP Error Monitoring
 
 A GitHub App that files issues for new production errors surfaced by AMP Error Reporting.
 
 This app runs as a Google App Engine deployment. It can be configured for deployment to any organization using Stackdriver error reporting.
 
-Interface
----------
+## Interface
 
 This app exposes a view listing frequent untracked errors seen in AMP releases. Within the resulting list, a button is provided to automatically file a tracking issue for the errror. It looks at the stacktrace, attempts to identify recent editors of lines in the stacktrace, and files a GitHub issue with information about the error.
 
-Setup
------
+## Setup
 
 1. Clone this repository and `cd` into the `error-monitoring` directory.
 2. `npm install`
@@ -20,23 +17,22 @@ Setup
 5. Create a new GitHub Personal Access Token with `public_repo` permissions and note the created access token.
 6. Enable the [App Engine](https://pantheon.corp.google.com/flows/enableapi?apiid=appengine) API
 7. Copy the `redacted.env` file to `.env` and modify the fields based the values from the GitHub App page:
-   * The value for the `GITHUB_ACCESS_TOKEN` field is the token from Step 4.
+   - The value for the `GITHUB_ACCESS_TOKEN` field is the token from Step 4.
 
-Local Development
------------------
+## Local Development
 
 To compile the TypeScript to JavaScript, run `npm run build`.
+
 > To automatically compile as files are changed, run `npm run build:watch`.
 
 To run tests, run `npm test`.
 
-Deployment
-----------
+## Deployment
 
 After setting up the app locally, use `gcloud` to deploy the app:
 
 1. Configure the project for the first time: `gcloud init`
 2. Deploy the function for the first time: `gcloud app deploy`
-3. To configure Cloud Build auto-deployment, follow [this guide](https://github.com/ampproject/amp-github-apps/blob/master/DEPLOYMENT.md)
+3. To configure Cloud Build auto-deployment, follow [this guide](https://github.com/ampproject/amp-github-apps/blob/main/DEPLOYMENT.md)
 
 This GitHub App is deployed as a [Google Cloud Function](https://cloud.google.com/functions/docs/) at the endpoint: https://amp-error-monitoring.appspot.com/

--- a/invite/README.md
+++ b/invite/README.md
@@ -1,82 +1,77 @@
-AMP Invite Bot
-==============
+# AMP Invite Bot
 
 A GitHub App that invites GitHub users to the an organization based
 on GitHub comment macros (ie. `/invite` and `/tryassign`).
 
 This app runs as a Google Cloud Functions deployment. It can be configured for deployment to any organization.
 
-Interface
----------
+## Interface
 
 The AMP Invite Bot watches for all new comments and checks each one for trigger
 commands. The known trigger commands are as follows:
 
 - `/invite @user`: Sends an organization invite to `@user`; when the invite is accepted, the bot adds a comment to the original thread indicating as much
 - `/tryassign @user`: Performs the same actions as above; when the invite is
-accepted, the bot will also attempt to assign the user to the PR or issue
-thread the invite was triggered on
+  accepted, the bot will also attempt to assign the user to the PR or issue
+  thread the invite was triggered on
 
-Webhooks
---------
+## Webhooks
 
 The app subscribes to the following GitHub Webhooks:
 
 > Note: This app does not attempt to catch comments which are edited to add an invite macro; this allows simpler stateless processing without potentially re-issuing invitations if comments are edited
 
-* [`IssueCommentEvent`](https://developer.github.com/v3/activity/events/types/#issuecommentevent)
-  * `created`: check the comment for trigger macros
-* [`IssueEvent`](https://developer.github.com/v3/activity/events/types/#issueevent)
-  * `opened`: check the issue body for trigger macros
-* [`PullRequestEvent`](https://developer.github.com/v3/activity/events/types/#pullrequestevent)
-  * `created`: check the PR description for trigger macros
-* [`PullRequestReviewEvent`](https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent)
-  * `submitted`: check the review body for trigger macros
-* [`PullRequestReviewCommentEvent`](https://developer.github.com/v3/activity/events/types/#pullrequestreviewcommentevent)
-  * `created`: check the review comment for trigger macros
-* [`OrganizationEvent`](https://developer.github.com/v3/activity/events/types/#organizationevent)
-  * `member_added`: comment on the original invite comment, and possibly assign a corresponding issue, to a member who accepts her invitation
+- [`IssueCommentEvent`](https://developer.github.com/v3/activity/events/types/#issuecommentevent)
+  - `created`: check the comment for trigger macros
+- [`IssueEvent`](https://developer.github.com/v3/activity/events/types/#issueevent)
+  - `opened`: check the issue body for trigger macros
+- [`PullRequestEvent`](https://developer.github.com/v3/activity/events/types/#pullrequestevent)
+  - `created`: check the PR description for trigger macros
+- [`PullRequestReviewEvent`](https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent)
+  - `submitted`: check the review body for trigger macros
+- [`PullRequestReviewCommentEvent`](https://developer.github.com/v3/activity/events/types/#pullrequestreviewcommentevent)
+  - `created`: check the review comment for trigger macros
+- [`OrganizationEvent`](https://developer.github.com/v3/activity/events/types/#organizationevent)
+  - `member_added`: comment on the original invite comment, and possibly assign a corresponding issue, to a member who accepts her invitation
 
-Setup
------
+## Setup
 
 1. Clone this repository and `cd` into the `invite` directory.
 2. `npm install`
 3. Start a new [Smee channel](https://smee.io/). This can be used to proxy
    GitHub webhooks to your local machine.
 4. Create a new [GitHub App](https://github.com/settings/apps/new) with the following settings:
-   * General
-     * Set _Homepage URL_ to the repository URL
-     * Set _Webhook URL_ to the Smee channel (development) or the Google Cloud Function URL `https://[REGION]-[PROJECT_NAME].cloudfunctions.net/[FUNCTION_NAME]` (production)
-     * Set _Webhook Secret_ to any high-entropy string of your choice
-   * Permissions and Events
-     * Repository permissions
-       * Set _Issues_ to Read & write
-       * Set _Pull requests_ to Read & write
-     * Organization permissions
-       * Set _Members_ to Read & write
-     * Subscribe to events: _Issues_, _Issue comment_, _Organization_, _Pull request_, _Pull request review_, and _Pull request review comment_
+   - General
+     - Set _Homepage URL_ to the repository URL
+     - Set _Webhook URL_ to the Smee channel (development) or the Google Cloud Function URL `https://[REGION]-[PROJECT_NAME].cloudfunctions.net/[FUNCTION_NAME]` (production)
+     - Set _Webhook Secret_ to any high-entropy string of your choice
+   - Permissions and Events
+     - Repository permissions
+       - Set _Issues_ to Read & write
+       - Set _Pull requests_ to Read & write
+     - Organization permissions
+       - Set _Members_ to Read & write
+     - Subscribe to events: _Issues_, _Issue comment_, _Organization_, _Pull request_, _Pull request review_, and _Pull request review comment_
 5. After creating the application, generate and download a private key. Also
    take note of the App ID and app Client Secret.
 6. Install the application on a GitHub repository that you want to use for
    testing. You might want to fork the [ampproject/amphtml](https://github.com/ampproject/amphtml) repository or create a new repository for this purpose.
 7. Run a local instance of PostgreSQL, or use the [Cloud SQL Proxy](https://cloud.google.com/sql/docs/postgres/sql-proxy) to connect to a [Cloud SQL instance](https://pantheon.corp.google.com/sql/choose-instance-engine?project=ampproject-invite-bot)
-   * While other database engines might work, we have only tested this on `pg`
-   * Take note of the instance ID and default user password.
+   - While other database engines might work, we have only tested this on `pg`
+   - Take note of the instance ID and default user password.
 8. Enable the [Cloud SQL Admin](https://pantheon.corp.google.com/flows/enableapi?apiid=sqladmin) and [Cloud Functions](https://pantheon.corp.google.com/flows/enableapi?apiid=cloudfunctions) APIs
 9. Copy the `redacted.env` file to `.env` and modify the fields based the values from the GitHub App page:
-   * The value for the `APP_ID` field is the App ID from Step 5.
-   * The value for `WEBHOOK_SECRET` is the secret you set when creating the GitHub app.
-   * The value for the `PRIVATE_KEY` field is a base64 representation of the
+   - The value for the `APP_ID` field is the App ID from Step 5.
+   - The value for `WEBHOOK_SECRET` is the secret you set when creating the GitHub app.
+   - The value for the `PRIVATE_KEY` field is a base64 representation of the
      `.pem` file you downloaded from the GitHub App page in Step 5. On Linux/Mac you can convert that file by running `cat private-key-file.pem | base64` in a command line.
-   * The value for `GITHUB_ACCESS_TOKEN` is the Client Secret obtained in Step 5.
-   * The value for `GITHUB_ORG` to the name of the GitHub organization the bot will be inviting users to.
-   * The values for `DB_USER`, `DB_PASSWORD`, and `DB_NAME` will be the values used or created during step 7.
-   * The value for `DB_UNIX_SOCKET` will be `/cloudsql/[CLOUD_SQL_INSTANCE_NAME]`; the instance name can be found on the [Instances page](https://pantheon.corp.google.com/sql/instances) and is of the form `project-name:region:database-instance-name`
+   - The value for `GITHUB_ACCESS_TOKEN` is the Client Secret obtained in Step 5.
+   - The value for `GITHUB_ORG` to the name of the GitHub organization the bot will be inviting users to.
+   - The values for `DB_USER`, `DB_PASSWORD`, and `DB_NAME` will be the values used or created during step 7.
+   - The value for `DB_UNIX_SOCKET` will be `/cloudsql/[CLOUD_SQL_INSTANCE_NAME]`; the instance name can be found on the [Instances page](https://pantheon.corp.google.com/sql/instances) and is of the form `project-name:region:database-instance-name`
 10. Create the database tables by running `npm run setup-db`
 
-Local Development
------------------
+## Local Development
 
 If you need to receive webhooks locally, make sure the app in GitHub is configured to use the Smee channel as the webhook URL. Set the env variable `WEBHOOK_PROXY_URL` to the Smee channel URL.
 
@@ -84,20 +79,19 @@ You will also need to either set up a local PostgresQL instance or a Cloud SQL i
 
 To run the app locally, run `npm run start`.
 
-Deployment
-----------
+## Deployment
 
 After setting up the app locally, use `gcloud` to deploy the app and cron tasks:
 
 1. Configure the project for the first time: `gcloud init`
 2. Deploy the function for the first time:
-    ```
-    gcloud functions deploy [FUNCTION_NAME] \
-      --entry-point probot \
-      --runtime nodejs10 \
-      --trigger-http
-    ```
-    * When deploying after the first time, the `--runtime` and `--trigger-http` flags may be omitted
-3. To configure Cloud Build auto-deployment, follow [this guide](https://github.com/ampproject/amp-github-apps/blob/master/DEPLOYMENT.md)
+   ```
+   gcloud functions deploy [FUNCTION_NAME] \
+     --entry-point probot \
+     --runtime nodejs10 \
+     --trigger-http
+   ```
+   - When deploying after the first time, the `--runtime` and `--trigger-http` flags may be omitted
+3. To configure Cloud Build auto-deployment, follow [this guide](https://github.com/ampproject/amp-github-apps/blob/main/DEPLOYMENT.md)
 
 This GitHub App is deployed as a [Google Cloud Function](https://cloud.google.com/functions/docs/) at the endpoint: https://ampproject-invite-bot.cloudfunctions.net/

--- a/onduty/README.md
+++ b/onduty/README.md
@@ -1,12 +1,10 @@
-AMP On-Duty Bot
-==============
+# AMP On-Duty Bot
 
 A GitHub App that updates the teams `@ampproject/release-onduty` and `@ampproject/build-on-duty` according to the current rotation.
 
 This app runs as a Google Cloud Functions deployment.
 
-Interface
----------
+## Interface
 
 The AMP On-Duty bot listens for reports from an internal tool containing the rotation details. Whenever the rotation changes, it updates a corresponding GitHub team to contain the primary and secondary for each rotation.
 
@@ -25,8 +23,7 @@ The bot receives reports of the form:
 }
 ```
 
-Setup
------
+## Setup
 
 1. Clone this repository and `cd` into the `onduty` directory.
 2. `npm install`
@@ -34,32 +31,31 @@ Setup
 4. Create a new Personal Access Token with `public_repo` permissions and note the created access token.
 5. Enable the [Cloud Functions](https://pantheon.corp.google.com/flows/enableapi?apiid=cloudfunctions) API
 6. Copy the `redacted.env` file to `.env` and modify the fields based the values from the GitHub App page:
-   * The value for the `GITHUB_ACCESS_TOKEN` field is the token from Step 4.
+   - The value for the `GITHUB_ACCESS_TOKEN` field is the token from Step 4.
 
-Local Development
------------------
+## Local Development
 
 To compile the TypeScript to JavaScript, run `npm run build`.
-> To automatically compile as files are changed, run `npm run build:watch`.
-To run the app locally, run `npm run start`.
-> To automatically reload as files are changed, run `npm run dev`.
-To run tests, run `npm test`.
 
-Deployment
-----------
+> To automatically compile as files are changed, run `npm run build:watch`.
+> To run the app locally, run `npm run start`.
+> To automatically reload as files are changed, run `npm run dev`.
+> To run tests, run `npm test`.
+
+## Deployment
 
 After setting up the app locally, use `gcloud` to deploy the app and cron tasks:
 
 1. Configure the project for the first time: `gcloud init`
 2. Deploy the function for the first time:
-    ```
-    gcloud functions deploy [FUNCTION_NAME] \
-      --source dist/ \
-      --entry-point app \
-      --runtime nodejs10 \
-      --trigger-http
-    ```
-    * When deploying after the first time, the `--runtime` and `--trigger-http` flags may be omitted
-3. To configure Cloud Build auto-deployment, follow [this guide](https://github.com/ampproject/amp-github-apps/blob/master/DEPLOYMENT.md)
+   ```
+   gcloud functions deploy [FUNCTION_NAME] \
+     --source dist/ \
+     --entry-point app \
+     --runtime nodejs10 \
+     --trigger-http
+   ```
+   - When deploying after the first time, the `--runtime` and `--trigger-http` flags may be omitted
+3. To configure Cloud Build auto-deployment, follow [this guide](https://github.com/ampproject/amp-github-apps/blob/main/DEPLOYMENT.md)
 
 This GitHub App is deployed as a [Google Cloud Function](https://cloud.google.com/functions/docs/) at the endpoint: https://us-central1-amp-onduty-bot.cloudfunctions.net/

--- a/owners/src/repo/local_repo.js
+++ b/owners/src/repo/local_repo.js
@@ -54,7 +54,7 @@ module.exports = class LocalRepository extends Repository {
   }
 
   /**
-   * Checks out the master branch.
+   * Checks out the main branch.
    */
   async sync() {
     await this.checkout();
@@ -75,7 +75,7 @@ module.exports = class LocalRepository extends Repository {
    *
    * @param {?string} branch git branch to checkout.
    */
-  async checkout(branch = 'master') {
+  async checkout(branch = 'main') {
     await this._runCommands(
       `git fetch ${this.remote} ${branch}`,
       `git checkout -B ${branch} ${this.remote}/${branch}`

--- a/owners/test/repo/local_repo.test.js
+++ b/owners/test/repo/local_repo.test.js
@@ -71,13 +71,13 @@ describe('local repository', () => {
       done();
     });
 
-    it('defaults to master', async done => {
+    it('defaults to main', async done => {
       await repo.checkout();
 
       sandbox.assert.calledWith(
         repo._runCommands,
-        'git fetch origin master',
-        'git checkout -B master origin/master'
+        'git fetch origin main',
+        'git checkout -B main origin/main'
       );
       done();
     });

--- a/test-case-reporting/README.md
+++ b/test-case-reporting/README.md
@@ -1,22 +1,20 @@
-AMP Test Case Reporting Bot
-==============
+# AMP Test Case Reporting Bot
 
 A Google Cloud app that stores the results of tests run by Travis. Used to track flaky tests.
 
 This app runs as a [[something]].
 
-Interface
----------
+## Interface
+
 ### API for Travis
 
 The App has the following API endpoints, which are to be triggered from Travis CI
 runs.
 
-* `POST /report`
-  * Accepts a JSON object representing a test result report from Travis. Has 3 fields: `build`, `job`, and `results`, representing build information, job information, and test run information respectively. For the full structure of the object, see [the type declaration module](types/test-case-reporting.d.ts).
+- `POST /report`
+  - Accepts a JSON object representing a test result report from Travis. Has 3 fields: `build`, `job`, and `results`, representing build information, job information, and test run information respectively. For the full structure of the object, see [the type declaration module](types/test-case-reporting.d.ts).
 
-Setup
------
+## Setup
 
 Follow these setup instructions to start developing for this App locally:
 
@@ -27,32 +25,32 @@ Follow these setup instructions to start developing for this App locally:
 5. Initialize an App Engine app with `gcloud app create`.
 6. Run a local instance of PostgreSQL, or use the
    [Cloud SQL Proxy](https://cloud.google.com/sql/docs/postgres/sql-proxy)
-   * While other database engines might work, this is developed using pg
+   - While other database engines might work, this is developed using pg
 7. Run `npm run setup-db` to set up the database.
 8. Copy the `redacted.env` file to `.env` and modify the fields based on the username and password
    used for the database
    * Do not set DB_INSTANCE_CONNECTION_NAME or DB_SOCKET_PATH if using a local database instance.
 
-Local Development
------------------
+## Local Development
 
 To compile the TypeScript to JavaScript, run `npm run build`.
+
 > To automatically compile as files are changed, run `npm run build:watch`.
 
 To run the app locally, run `npm run start`.
+
 > To automatically reload as files are changed, run `npm run dev`.
 
 To run tests, run `npm test`.
 
 To generate fake build data run `npm run generate-build-data`
 
-Deployment
-----------
+## Deployment
 
 After setting up the app locally, use `gcloud` to deploy the app:
 
 1. Configure the project for the first time: `gcloud init`
 2. Deploy the app for the first time: `gcloud app deploy`
-3. To configure Cloud Build auto-deployment, follow [this guide](https://github.com/ampproject/amp-github-apps/blob/master/DEPLOYMENT.md)
+3. To configure Cloud Build auto-deployment, follow [this guide](https://github.com/ampproject/amp-github-apps/blob/main/DEPLOYMENT.md)
 
 This GitHub App is deployed at the endpoint: https://amp-test-cases.appspot.com/

--- a/test-case-reporting/test/e2e.test.ts
+++ b/test-case-reporting/test/e2e.test.ts
@@ -74,7 +74,7 @@ describe('end-to-end', () => {
 
       // TODO(#914): Replace `db('table_name').select()` calls with more readable
       // functions for getting builds, jobs, and invites.
-      // See https://github.com/ampproject/amp-github-apps/blob/master/invite/src/invitation_record.ts
+      // See https://github.com/ampproject/amp-github-apps/blob/main/invite/src/invitation_record.ts
       // for an example of what I'm thinking of.
 
       res = await request(app).get(

--- a/test-status/api.js
+++ b/test-status/api.js
@@ -184,7 +184,7 @@ function createErroredCheckParams(
         'If you believe that this pull request was not the cause of this ' +
         'error, please try the following steps:\n' +
         `1. Restart the failed [CI job](${ciJobUrl})\n` +
-        '2. Rebase your pull request on the latest `master` branch\n' +
+        '2. Rebase your pull request on the main branch\n' +
         `3. Contact the weekly build on-duty (@${BUILD_ON_DUTY_TEAM}), who can ` +
         'advise you on how to proceed.',
     },


### PR DESCRIPTION
**PR Highlights:**
- Sets the stage to change the default branch of `amp-github-apps` to `main`
- The only instances of `master` that will remain in this repo are links to [`meta`](https://github.com/ampproject/meta/tree/master), [`amphtml-build-artifacts`](https://github.com/ampproject/amphtml-build-artifacts/tree/master), [`amphtml`](https://github.com/ampproject/amphtml/tree/master), and [`error-tracker`](https://github.com/ampproject/error-tracker/tree/master). They'll need to be updated separately.

**Note:** Looks like `prettier` auto-formatting kicked in for the `.md` files I updated. I'm going to leave those changes in.

**Next steps:** Soon after this PR is merged, we can rename the default branch to `main`. After review, I'll coordinate this action manually. This will serve as a practice run for the more involved switch for `amphtml` 😃 

![image](https://user-images.githubusercontent.com/26553114/113773158-a25aa180-96f3-11eb-8415-db23956f948a.png)

Partial fix for https://github.com/ampproject/amphtml/issues/32195
Accompanying PR to https://github.com/ampproject/amphtml/pull/33571