### PR TITLE
Sort bundle size output by delta instead of binary

### DIFF
--- a/bundle-size/api.js
+++ b/bundle-size/api.js
@@ -339,7 +339,14 @@ exports.installApiRouter = (app, router, db, githubUtils) => {
     const bundleSizeDeltasAutoApproved = [];
     const missingBundleSizes = [];
     const allPotentialApproverTeams = new Set();
-    for (const [file, baseBundleSize] of Object.entries(mainBundleSizes)) {
+
+    // When examining bundle-size check output for a PR, it's helpful to see
+    // sizes at the extremes, so we sort from largest increase to largest
+    // decrease. This ordering is reflected in the ordering of each subsection.
+    const sortedBundleSizes = Object.entries(mainBundleSizes).sort(
+      (a, b) => a[1] - b[1]
+    );
+    for (const [file, baseBundleSize] of sortedBundleSizes) {
       if (!(file in prBundleSizes)) {
         missingBundleSizes.push(`* \`${file}\`: missing in pull request`);
         continue;

--- a/bundle-size/package-lock.json
+++ b/bundle-size/package-lock.json
@@ -7871,7 +7871,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -8610,7 +8610,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },

--- a/bundle-size/test/api.test.js
+++ b/bundle-size/test/api.test.js
@@ -257,7 +257,7 @@ describe('bundle-size api', () => {
       });
 
       baseBundleSizeFixture.content = Buffer.from(
-        '{"dist/v0.js":12.34,"dist/v0/amp-accordion-0.1.js":1.11,"dist/v0/amp-ad-0.1.js":4.53,"dist/v0/amp-anim-0.1.js":5.65}'
+        '{"dist/v0.js": 12.34,"dist/v0/amp-accordion-0.1.js":1.11,"dist/v0/amp-ad-0.1.js": 4.53,"dist/v0/amp-anim-0.1.js": 5.65}'
       ).toString('base64');
 
       await request(probot.server)
@@ -296,6 +296,68 @@ describe('bundle-size api', () => {
                 '## Bundle sizes missing from this PR\n' +
                 '* `dist/v0/amp-anim-0.1.js`: missing in pull request\n' +
                 '* `dist/amp4ads-v0.js`: (11.22 KB) missing on the main branch'
+            ),
+          }),
+        })
+      );
+    });
+
+    test('sort files by bundle size delta in check update', async () => {
+      await db('checks').insert({
+        head_sha: '26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa',
+        owner: 'ampproject',
+        repo: 'amphtml',
+        pull_request_id: 19603,
+        installation_id: 123456,
+        check_run_id: 555555,
+        approving_teams: null,
+        report_markdown: null,
+      });
+
+      jsonPayload = {
+        baseSha: '5f27002526a808c5c1ad5d0f1ab1cec471af0a33',
+        bundleSizes: {
+          'dist/v0.js': 12.34,
+          'dist/amp4ads-v0.js': 11.22,
+          'dist/v0/amp-accordion-0.1.js': 1.11,
+          'dist/v0/amp-ad-0.1.js': 4.56,
+          'dist/v0/amp-date-display-0.1.js': 7.32,
+          'dist/v0/amp-truncate-text-0.1.js': 2.4,
+        },
+      };
+
+      baseBundleSizeFixture.content = Buffer.from(
+        `{
+          "dist/v0.js": 12.34,
+          "dist/v0/amp-accordion-0.1.js":1.11,
+          "dist/v0/amp-ad-0.1.js": 4.53,
+          "dist/v0/amp-anim-0.1.js": 5.65,
+          "dist/v0/amp-date-display-0.1.js": 8.99,
+          "dist/v0/amp-truncate-text-0.1.js": 2.12
+        }`
+      ).toString('base64');
+
+      await request(probot.server)
+        .post('/v0/commit/26ddec3fbbd3c7bd94e05a701c8b8c3ea8826faa/report')
+        .send(jsonPayload)
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      expect(github.checks.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          check_run_id: 555555,
+          conclusion: 'success',
+          output: expect.objectContaining({
+            title: 'No approval necessary',
+            summary: expect.stringContaining(
+              '## Auto-approved bundle size changes\n' +
+                '* `dist/v0/amp-truncate-text-0.1.js`: Δ +0.28KB\n' +
+                '* `dist/v0/amp-ad-0.1.js`: Δ +0.03KB\n' +
+                '* `dist/v0/amp-date-display-0.1.js`: Δ -1.67KB\n' +
+                '## Bundle sizes missing from this PR\n' +
+                '* `dist/v0/amp-anim-0.1.js`: missing in pull request\n' +
+                '* `dist/amp4ads-v0.js`: (11.22 KB) missing in `master`'
             ),
           }),
         })

--- a/bundle-size/test/api.test.js
+++ b/bundle-size/test/api.test.js
@@ -327,14 +327,14 @@ describe('bundle-size api', () => {
       };
 
       baseBundleSizeFixture.content = Buffer.from(
-        `{
-          "dist/v0.js": 12.34,
-          "dist/v0/amp-accordion-0.1.js":1.11,
-          "dist/v0/amp-ad-0.1.js": 4.53,
-          "dist/v0/amp-anim-0.1.js": 5.65,
-          "dist/v0/amp-date-display-0.1.js": 8.99,
-          "dist/v0/amp-truncate-text-0.1.js": 2.12
-        }`
+        JSON.stringify({
+          'dist/v0.js': 12.34,
+          'dist/v0/amp-accordion-0.1.js': 1.11,
+          'dist/v0/amp-ad-0.1.js': 4.53,
+          'dist/v0/amp-anim-0.1.js': 5.65,
+          'dist/v0/amp-date-display-0.1.js': 8.99,
+          'dist/v0/amp-truncate-text-0.1.js': 2.12,
+        })
       ).toString('base64');
 
       await request(probot.server)
@@ -357,7 +357,7 @@ describe('bundle-size api', () => {
                 '* `dist/v0/amp-date-display-0.1.js`: Δ -1.67KB\n' +
                 '## Bundle sizes missing from this PR\n' +
                 '* `dist/v0/amp-anim-0.1.js`: missing in pull request\n' +
-                '* `dist/amp4ads-v0.js`: (11.22 KB) missing in `master`'
+                '* `dist/amp4ads-v0.js`: (11.22 KB) missing on the main branch'
             ),
           }),
         })


### PR DESCRIPTION
Was going to make a feature request, but figured it would be easier to just offer the change as a PR. Sorts bundle-size output by delta, so it's easy to scan the list for the files with the largest/smallest relative changes.