### PR TITLE
[pr-deploy] Add gcp-build step to package.json

### DIFF
--- a/pr-deploy/package.json
+++ b/pr-deploy/package.json
@@ -14,8 +14,8 @@
     "fix": "npm run lint -- --fix",
     "build": "tsc -p . --esModuleInterop",
     "dev": "nodemon",
+    "gcp-build": "npm run build",
     "start": "probot run ./dist/src/app.js",
-    "prestart": "npm run build",
     "pretest": "npm run build",
     "test": "jest dist/test/*.js --reporters=jest-silent-reporter",
     "deploy-tag": "git tag 'deploy-pr-deploy-'`date -u '+%Y%m%d%H%M%S'`"


### PR DESCRIPTION
Turns out that `devDependencies` are [deleted before GCP saves the Docker image](https://cloud.google.com/appengine/docs/standard/nodejs/specifying-dependencies) that will be used for deploying the app. This PR attempts to fix this so that the [app gets compiled in that step](https://cloud.google.com/appengine/docs/standard/nodejs/running-custom-build-step), and `npm start` literally only starts the aleady-compiled app