### PR TITLE
[pr-deploy] Code cleanup and fix description-too-long error

### DIFF
--- a/pr-deploy/src/github.ts
+++ b/pr-deploy/src/github.ts
@@ -24,7 +24,7 @@ type ChecksUpdateParams = Types['checks']['update']['parameters'];
 const ACTIONS: ChecksUpdateParams['actions'] = [
   {
     label: 'Create a test site',
-    description: 'Serves the nomodule minified output of this PR.',
+    description: 'Serves nomodule minified build from PR.',
     identifier: 'deploy-me-action',
   },
 ];


### PR DESCRIPTION
* the description field for a GitHub check's action can be at most 40 characters, shorten it
* split up the handlers for success/errored/skipped
* move common code to middleware
* it's no longer necessary to explicitly cast Octokit instances from Probot