### PR TITLE
Fix test-case-reporting landing page.

### DIFF
--- a/test-case-reporting/static/index.html
+++ b/test-case-reporting/static/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>{{title}}</title>
+    <meta
+      name="viewport"
+      content="width=device-width,minimum-scale=1,initial-scale=1"
+    />
+    <!-- Surface style taken from https://github.com/niutech/amp-surface -->
+    <link rel="stylesheet" type="text/css" href="/surface.min.css" />
+    <link rel="stylesheet" type="text/css" href="/custom.css" />
+  </head>
+
+  <body>
+    <div class="g--10 m--1">
+      <div class="g--8 g-s--12 center">
+        <h1>{{title}}</h1>
+        <div class="tile">
+          <a href="/builds">
+            <h2>Latest Builds</h2>
+          </a>
+          {{#builds}}
+          <div class="tile">
+            <a href="/test-results/build/{{buildNumber}}"
+              >Build {{buildNumber}}</a
+            >, started at {{startedAt}}
+          </div>
+          {{/builds}}
+        </div>
+        <div class="tile">
+          <a href="/stats">
+            <h2>Test Case Stats</h2>
+            <ul>
+              {{#stats}}
+              <li>
+                <a href="/test-cases/stats/{{stat}}">{{title}}</a>
+              </li>
+              {{/stats}}
+            </ul>
+          </a>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
In https://github.com/ampproject/amp-github-apps/pull/1258 I changed the default landing page of the test-case-reporting page to `index.html`. Somehow throughout the process that file didn't end up as part of the commit.

Hmm...
![image](https://user-images.githubusercontent.com/78179109/116139701-28329280-a68b-11eb-83ca-5e8fc5a379d1.png)

![image](https://user-images.githubusercontent.com/78179109/116139671-2072ee00-a68b-11eb-915f-03a02d50bc95.png)


I swear it works now:
![image](https://user-images.githubusercontent.com/78179109/116139614-0f29e180-a68b-11eb-903f-b19f76aad714.png)
