### PR TITLE
[owners] Support `reviewerPool` of users and/or teams in place of `reviewerTeam` property

### DIFF
--- a/owners/OWNERS.example
+++ b/owners/OWNERS.example
@@ -135,7 +135,7 @@
   // users/teams. If present, the owners check will require that at least one
   // member of this team has given approval. It is possible that one reviewer
   // is both a member of this reviewer team and provides owners coverage.
-  reviewerPool: ["ampproject/reviewers-amphtml", "renovate-approve"]
+  reviewerPool: ["ampproject/reviewers-amphtml", "approver-bot"]
 }
 
 // The result of parsing this file would be a tree with these rules:

--- a/owners/OWNERS.example
+++ b/owners/OWNERS.example
@@ -131,10 +131,10 @@
   ],
 
   // The root-level owners file--and ONLY the root-level owners file--may
-  // specify an optional `reviewerPool` property, providing the name of a GitHub
-  // team. If present, the owners check will require that at least one member of
-  // this team has given approval. It is possible that one reviewer is both a
-  // member of this reviewer team and provides owners coverage.
+  // specify an optional `reviewerPool` property, providing a list of GitHub
+  // users/teams. If present, the owners check will require that at least one
+  // member of this team has given approval. It is possible that one reviewer
+  // is both a member of this reviewer team and provides owners coverage.
   reviewerPool: ["ampproject/reviewers-amphtml", "renovate-approve"]
 }
 

--- a/owners/OWNERS.example
+++ b/owners/OWNERS.example
@@ -131,11 +131,11 @@
   ],
 
   // The root-level owners file--and ONLY the root-level owners file--may
-  // specify an optional `reviewerTeam` property, providing the name of a GitHub
+  // specify an optional `reviewerPool` property, providing the name of a GitHub
   // team. If present, the owners check will require that at least one member of
   // this team has given approval. It is possible that one reviewer is both a
   // member of this reviewer team and provides owners coverage.
-  reviewerTeam: 'ampproject/reviewers-amphtml'
+  reviewerPool: ["ampproject/reviewers-amphtml", "renovate-approve"]
 }
 
 // The result of parsing this file would be a tree with these rules:

--- a/owners/src/ownership/schema.json
+++ b/owners/src/ownership/schema.json
@@ -8,7 +8,16 @@
   "additionalProperties": false,
 
   "properties": {
-    "reviewerTeam": {"$ref": "#/definitions/Team"},
+    "reviewerPool": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {"$ref": "#/definitions/User"},
+          {"$ref": "#/definitions/Team"}
+        ]
+      }
+    },
     "rules": {
       "type": "array",
       "minItems": 1,

--- a/owners/test/ownership/parser.test.js
+++ b/owners/test/ownership/parser.test.js
@@ -454,7 +454,7 @@ describe('owners parser', () => {
         const rule = rules.reviewerPool;
         expect(rule.owners.map(owner => owner.name)).toEqual([
           'ampproject/reviewers-amphtml',
-          'renovate-approve',
+          'approver-bot',
         ]);
       });
 
@@ -539,14 +539,14 @@ describe('owners parser', () => {
         it('records the reviewer set from "reviewerPool', () => {
           const fileDef = {
             rules,
-            reviewerPool: ['ampproject/reviewers-amphtml', 'renovate-approve'],
+            reviewerPool: ['ampproject/reviewers-amphtml', 'approver-bot'],
           };
           const {result} = parser.parseOwnersFileDefinition('OWNERS', fileDef);
 
           expect(result[0]).toEqual(
             new ReviewerSetRule('OWNERS', [
               new TeamOwner(reviewerTeam),
-              new UserOwner('renovate-approve'),
+              new UserOwner('approver-bot'),
             ])
           );
         });

--- a/owners/test/ownership/parser.test.js
+++ b/owners/test/ownership/parser.test.js
@@ -441,7 +441,7 @@ describe('owners parser', () => {
 
         errors = fileParse.errors;
         Object.assign(rules, {
-          reviewerSet: fileParse.result[0],
+          reviewerPool: fileParse.result[0],
           basic: fileParse.result[1],
           filename: fileParse.result[2],
           pattern: fileParse.result[3],
@@ -451,9 +451,10 @@ describe('owners parser', () => {
       });
 
       it('parses the reviewer team', () => {
-        const rule = rules.reviewerSet;
+        const rule = rules.reviewerPool;
         expect(rule.owners.map(owner => owner.name)).toEqual([
           'ampproject/reviewers-amphtml',
+          'renovate-approve',
         ]);
       });
 
@@ -535,15 +536,18 @@ describe('owners parser', () => {
       const rules = [{owners: [{name: 'someone'}]}];
 
       describe('in the repository root OWNERS file', () => {
-        it('records the reviewer set from "reviewerTeam', () => {
+        it('records the reviewer set from "reviewerPool', () => {
           const fileDef = {
             rules,
-            reviewerTeam: 'ampproject/reviewers-amphtml',
+            reviewerPool: ['ampproject/reviewers-amphtml', 'renovate-approve'],
           };
           const {result} = parser.parseOwnersFileDefinition('OWNERS', fileDef);
 
           expect(result[0]).toEqual(
-            new ReviewerSetRule('OWNERS', [new TeamOwner(reviewerTeam)])
+            new ReviewerSetRule('OWNERS', [
+              new TeamOwner(reviewerTeam),
+              new UserOwner('renovate-approve'),
+            ])
           );
         });
       });
@@ -551,7 +555,7 @@ describe('owners parser', () => {
       describe('specified outside the repository root OWNERS file', () => {
         const fileDef = {
           rules,
-          reviewerTeam: 'ampproject/reviewers-amphtml',
+          reviewerPool: ['ampproject/reviewers-amphtml'],
         };
 
         it('reports an error', () => {
@@ -573,16 +577,16 @@ describe('owners parser', () => {
         });
       });
 
-      describe('for a non-string "reviewerTeam" property', () => {
+      describe('for a non-array "reviewerPool" property', () => {
         const fileDef = {
           rules,
-          reviewerTeam: {name: 'ampproject/reviewers-amphtml'},
+          reviewerPool: {name: 'ampproject/reviewers-amphtml'},
         };
 
         it('reports an error', () => {
           const {errors} = parser.parseOwnersFileDefinition('OWNERS', fileDef);
           expect(errors[0].message).toEqual(
-            '`OWNERS.reviewerTeam` should be string'
+            '`OWNERS.reviewerPool` should be array'
           );
         });
 
@@ -595,7 +599,7 @@ describe('owners parser', () => {
       describe('for an unknown team namyname', () => {
         const fileDef = {
           rules,
-          reviewerTeam: 'ampproject/unknown-team',
+          reviewerPool: ['ampproject/unknown-team'],
         };
 
         it('reports an error', () => {

--- a/owners/test/ownership/parser.test.js
+++ b/owners/test/ownership/parser.test.js
@@ -450,7 +450,7 @@ describe('owners parser', () => {
         });
       });
 
-      it('parses the reviewer team', () => {
+      it('parses the reviewer pool', () => {
         const rule = rules.reviewerPool;
         expect(rule.owners.map(owner => owner.name)).toEqual([
           'ampproject/reviewers-amphtml',

--- a/owners/test/reviewer_selection.test.js
+++ b/owners/test/reviewer_selection.test.js
@@ -240,9 +240,12 @@ describe('reviewer selection', () => {
     it('handles non-reviewers at leaf nodes', () => {
       fileTreeMap = ownersTree.buildFileTreeMap(['foo/bar/baz/other_file.js']);
       const reviewerTeam = new Team(42, 'ampproject', 'reviewer-set');
-      reviewerTeam.members = ['reviewer', 'child', 'someone'];
+      reviewerTeam.members = ['reviewer', 'someone'];
       ownersTree.addRule(
-        new ReviewerSetRule('OWNERS', [new TeamOwner(reviewerTeam)])
+        new ReviewerSetRule('OWNERS', [
+          new TeamOwner(reviewerTeam),
+          new UserOwner('child'),
+        ])
       );
 
       const reviewers = ReviewerSelection._findPotentialReviewers(fileTreeMap);


### PR DESCRIPTION
Closes https://github.com/ampproject/amp-github-apps/issues/1283
Requires an update to amphtml's root OWNERS file, but this should not fail any PRs on that repo in the interim unless they trigger OWNERS build target. Will require pushing an updated deploy tag to trigger a build.

Before: `reviewerTeam` allowed only in repo root `OWNERS` file, must be a string representing a team
Now: `reviewerPool` allowed only in repo root `OWNERShi file, must be an array of strings representing teams or usernames