### PR TITLE
[owners] Fix double-call to path helper

### DIFF
--- a/owners/src/repo/virtual_repo.js
+++ b/owners/src/repo/virtual_repo.js
@@ -70,8 +70,7 @@ module.exports = class VirtualRepository extends Repository {
 
     // Force-invalidate any files that we know should exist but didn't come back
     // in the GitHub search results.
-    for (const filename of ownersFilesKnown) {
-      const repoPath = this.repoPath(filename);
+    for (const repoPath of ownersFilesKnown) {
       // File has been updated and needs to be re-fetched.
       this.logger.info(
         `Updating SHA and clearing cache for file "${repoPath}"`


### PR DESCRIPTION
A recent change to the owners cache introduced an accidental double-call to a helper that prepends the repo root to a filepath, resulting in the cache system trying to delete a nonexistent file at `amphtml/amphtml/...` and crashing each time the bot tried to refresh. This PR fixes that, and wraps the cache so errors are logged but do not blow up tree parsing/refreshing.

![image](https://user-images.githubusercontent.com/6694512/116935175-fc3b8200-ac33-11eb-8c6e-3de0b773bcb4.png)
