### PR TITLE
Update main branch name used during CI

### DIFF
--- a/build-system/ci.js
+++ b/build-system/ci.js
@@ -32,6 +32,14 @@ function env(key) {
 }
 
 /**
+ * Returns true if this is a CI build.
+ * @return {boolean}
+ */
+function isCiBuild() {
+  return !!env('CI');
+}
+
+/**
  * Returns true if this is a PR build.
  * @return {boolean}
  */
@@ -48,6 +56,7 @@ function isPushBuild() {
 }
 
 module.exports = {
+  isCiBuild,
   isPullRequestBuild,
   isPushBuild,
 };

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -20,13 +20,16 @@
  */
 
 const {getStdout} = require('./exec');
+const {isCiBuild} = require('./ci');
 
 /**
- * Returns the merge base of the PR branch and the main branch.
+ * Returns the merge base of the PR branch and the main branch. During CI on
+ * GH actions, the main branch identifier is "origin/main".
  * @return {string}
  */
 function gitMergeBaseMain() {
-  return getStdout(`git merge-base origin/main HEAD`).trim();
+  const mainBranch = isCiBuild() ? 'origin/main' : 'main';
+  return getStdout(`git merge-base ${mainBranch} HEAD`).trim();
 }
 
 /**

--- a/build-system/git.js
+++ b/build-system/git.js
@@ -26,7 +26,7 @@ const {getStdout} = require('./exec');
  * @return {string}
  */
 function gitMergeBaseMain() {
-  return getStdout(`git merge-base main HEAD`).trim();
+  return getStdout(`git merge-base origin/main HEAD`).trim();
 }
 
 /**


### PR DESCRIPTION
During build target computation, we look at the set of files changed by a PR when compared with the common ancestor commit with the `main` branch. On Travis, it was sufficient to use `main`, but on GH actions, we need to use `origin/main`.

For evidence, see this screenshot from an `amphtml` GH Actions [build](https://github.com/ampproject/amphtml/runs/2503804538?check_suite_focus=true#step:4:23):

![image](https://user-images.githubusercontent.com/26553114/117069459-7c2c1f80-acfa-11eb-88ee-72d6765794d9.png)

Addresses https://github.com/ampproject/amp-github-apps/pull/1284#issuecomment-831404707