### PR TITLE
Change wording of bundle size blurb

### DIFF
--- a/bundle-size/webhooks.js
+++ b/bundle-size/webhooks.js
@@ -35,9 +35,8 @@ exports.installGitHubWebhooks = (app, db, githubUtils) => {
       output: {
         title: 'Calculating new bundle size for this PR…',
         summary:
-          'The bundle size (brotli compressed size of `v0.js`) ' +
-          'of this pull request is being calculated. Look for the ' +
-          'shard that contains "Bundle Size" in its title.',
+          'Calculating bundle sizes (brotli compressed) with the changes from this pull request. ' +
+          'Look for the shard that contains "Bundle Size" in its title.',
       },
     });
     const check = await context.octokit.checks.create(params);


### PR DESCRIPTION
1. We now check multiple bundles, not just one (`v0`).
2. We check both `.mjs` and `.js`