### PR TITLE
Disable auto-rebasing of update PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,7 @@
   "packageRules": [{
     "matchFiles": ["package.json"],
     "groupName": "core packages",
+    "rebaseWhen": "never",
     "automerge": true,
     "assignAutomerge": true
   }, {
@@ -23,6 +24,7 @@
     "labels": ["Category: Bundle Size"],
     "groupName": "bundle-size packages",
     "reviewers": ["danielrozenberg"],
+    "rebaseWhen": "never",
     "automerge": true,
     "assignAutomerge": true
   }, {
@@ -30,6 +32,7 @@
     "labels": ["Category: Bundle Size Chart"],
     "groupName": "bundle-size-chart packages",
     "reviewers": ["danielrozenberg"],
+    "rebaseWhen": "never",
     "automerge": true,
     "assignAutomerge": true
   }, {
@@ -37,6 +40,7 @@
     "labels": ["Category: Error Monitoring"],
     "groupName": "error-monitoring packages",
     "reviewers": ["rcebulko"],
+    "rebaseWhen": "never",
     "automerge": true,
     "assignAutomerge": true
   }, {
@@ -44,12 +48,14 @@
     "labels": ["Category: Invite"],
     "groupName": "invite packages",
     "reviewers": ["rileyajones"],
+    "rebaseWhen": "never",
     "automerge": true,
     "assignAutomerge": true
   }, {
     "matchPaths": ["onduty/**"],
     "groupName": "onduty packages",
     "reviewers": ["rcebulko"],
+    "rebaseWhen": "never",
     "automerge": true,
     "assignAutomerge": true
   }, {
@@ -57,6 +63,7 @@
     "labels": ["Category: Owners"],
     "groupName": "owners packages",
     "reviewers": ["rcebulko"],
+    "rebaseWhen": "never",
     "automerge": true,
     "assignAutomerge": true
   }, {
@@ -64,6 +71,7 @@
     "labels": ["Category: PR Deploy"],
     "groupName": "pr-deploy packages",
     "reviewers": ["estherkim"],
+    "rebaseWhen": "never",
     "automerge": true,
     "assignAutomerge": true
   }, {
@@ -71,6 +79,7 @@
     "labels": ["Category: Project Metrics"],
     "groupName": "project-metrics packages",
     "reviewers": ["rileyajones"],
+    "rebaseWhen": "never",
     "automerge": true,
     "assignAutomerge": true
   }, {
@@ -78,6 +87,7 @@
     "labels": ["Category: Release Calendar"],
     "groupName": "release-calendar packages",
     "reviewers": ["estherkim"],
+    "rebaseWhen": "never",
     "automerge": true,
     "assignAutomerge": true
   }, {
@@ -85,6 +95,7 @@
     "labels": ["Category: Test Cases"],
     "groupName": "test-case-reporting packages",
     "reviewers": ["rileyajones"],
+    "rebaseWhen": "never",
     "automerge": true,
     "assignAutomerge": true
   }, {
@@ -92,6 +103,7 @@
     "labels": ["Category: Test Status"],
     "groupName": "test-status packages",
     "reviewers": ["danielrozenberg"],
+    "rebaseWhen": "never",
     "automerge": true,
     "assignAutomerge": true
   }]


### PR DESCRIPTION
This PR temporarily sets the renovate setting `rebaseWhen` to `never` so there's less noise while the [initial backlog](https://github.com/ampproject/amp-github-apps/pulls?q=is%3Apr+is%3Aopen+author%3Aapp%2Frenovate+sort%3Aupdated-desc) of updates is cleared. If an upgrade PR needs accompanying code changes, the PR branch will have to be manually rebased after the code is fixed.

Once we're caught up, it may be possible to restore `rebsaeWhen` to the default of `conflicted` and still avoid PR noise. Can revisit this bit later.

**Reference:** https://docs.renovatebot.com/configuration-options/#rebasewhen