### PR TITLE
Don't hide repo-wide lint behind test during CI

### DIFF
--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -18,7 +18,7 @@
 const {APPS_TO_TEST, determineBuildTargets} = require('./build-targets');
 const {cyan} = require('kleur/colors');
 const {isCiBuild, isPushBuild} = require('./ci');
-const {log} = require('./log');
+const {log, logWithoutTimestamp} = require('./log');
 const {printChangeSummary, timedExecOrDie} = require('./utils');
 
 /**
@@ -27,20 +27,20 @@ const {printChangeSummary, timedExecOrDie} = require('./utils');
  * @param {string} appName
  */
 function runAppTests(appName) {
-  log('Running tests for the', cyan(appName), 'app...');
+  log('Testing the', cyan(appName), 'app...');
   const npmCmd = isCiBuild() ? 'npm ci --silent' : 'npm install';
   timedExecOrDie(`cd ${appName} && ${npmCmd}`);
   timedExecOrDie(`cd ${appName} && npm test -u`);
-  log('Done running tests for the', cyan(appName), 'app\n\n');
+  logWithoutTimestamp('\n\n');
 }
 
 /**
- * Execute root-level tests for all apps.
+ * Run lint checks for the entire repo.
  */
-function runRootTests() {
-  log('Running root-level tests...');
+function runLintChecks() {
+  log('Running lint checks for the repo...');
   timedExecOrDie(`npm run lint`);
-  log('Done running root-level tests\n\n');
+  logWithoutTimestamp('\n\n');
 }
 
 /**
@@ -50,11 +50,11 @@ function runRootTests() {
 function main() {
   if (isPushBuild()) {
     log('Running all tests because this is a push build...');
-    runRootTests();
+    runLintChecks();
     APPS_TO_TEST.forEach(runAppTests);
   } else {
     printChangeSummary();
-    runRootTests();
+    runLintChecks();
     determineBuildTargets().forEach(runAppTests);
   }
 }

--- a/build-system/pr-check.js
+++ b/build-system/pr-check.js
@@ -39,7 +39,7 @@ function runAppTests(appName) {
  */
 function runRootTests() {
   log('Running root-level tests...');
-  timedExecOrDie(`npm test -u`);
+  timedExecOrDie(`npm run lint`);
   log('Done running root-level tests\n\n');
 }
 

--- a/build-system/utils.js
+++ b/build-system/utils.js
@@ -35,7 +35,6 @@ const {log, logWithoutTimestamp} = require('./log');
  * @param {string} cmd command to execute.
  */
 function timedExecOrDie(cmd) {
-  log('Running', cyan(cmd) + '...');
   const startTime = Date.now();
   console.log(`::group::${cmd}`);
   execOrDie(cmd);

--- a/build-system/utils.js
+++ b/build-system/utils.js
@@ -36,9 +36,15 @@ const {log, logWithoutTimestamp} = require('./log');
  */
 function timedExecOrDie(cmd) {
   const startTime = Date.now();
-  console.log(`::group::${cmd}`);
+  if (isCiBuild()) {
+    logWithoutTimestamp(`::group::${cmd}`);
+  } else {
+    log('Running', cyan(cmd) + '...');
+  }
   execOrDie(cmd);
-  console.log('::endgroup::');
+  if (isCiBuild()) {
+    logWithoutTimestamp('::endgroup::');
+  }
   const endTime = Date.now();
   const executionTime = endTime - startTime;
   const mins = Math.floor(executionTime / 60000);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "fix": "npm run lint -- --fix",
-    "test": "npm run lint",
     "replace-secrets": "node bin/replace-secrets.js",
     "unredact-env": "read -p \"This will overwrite existing .env file. Press enter to continue.\n\" && node bin/unredact-env.js"
   },


### PR DESCRIPTION
**PR Highlights:**
- For repo-wide linting, directly call `npm run lint` for clarity
- De-dupe the various start / stop messages to make CI logs easier to read

**Screenshot:** ([link](https://github.com/ampproject/amp-github-apps/runs/2766824614?check_suite_focus=true#step:4:23))

![image](https://user-images.githubusercontent.com/26553114/121068775-add15400-c79a-11eb-839e-dd7d6ec5750c.png)


Addresses https://github.com/ampproject/amp-github-apps/pull/1369#discussion_r646749369