### PR TITLE
[release-calendar] Fix CORS issue preventing the client from communicating with the server

### DIFF
--- a/release-calendar/src/server/app.ts
+++ b/release-calendar/src/server/app.ts
@@ -43,10 +43,12 @@ async function main(): Promise<void> {
   const app = express();
   const port = process.env.PORT;
 
-  app.use(function (req, res, next) {
+  app.use(function (_req, res, next) {
     res.header(
       'Access-Control-Allow-Origin',
-      `${process.env.CLIENT_URL}:${process.env.CLIENT_PORT}`,
+      process.env.NODE_ENV === 'production'
+        ? `${process.env.CLIENT_URL}`
+        : `${process.env.CLIENT_URL}:${process.env.CLIENT_PORT}`,
     );
     res.header(
       'Access-Control-Allow-Headers',


### PR DESCRIPTION
The client cannot currently retrieve information from the backend due to an issue with the cors policy which assumes the client is running on `CLIENT_PORT`.

![image](https://user-images.githubusercontent.com/78179109/121422668-4f37e180-c924-11eb-9e4c-0f31741400a1.png)
