### PR TITLE
[release-calendar] fix issue in release calendar setup

### DIFF
--- a/release-calendar/test/setup.ts
+++ b/release-calendar/test/setup.ts
@@ -23,7 +23,7 @@ import addTestData from './test-data';
 async function main(): Promise<void> {
   const connection: Connection = await createConnection({
     type: 'mysql',
-    host: process.env.HOST,
+    host: process.env.DB_HOST,
     username: process.env.DB_USERNAME,
     password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME,


### PR DESCRIPTION
The release calendar setup script reads the wrong environment variable when setting up the database.