### PR TITLE
[release-calendar] Remove opt-in beta as a channel

### DIFF
--- a/release-calendar/src/client/components/ChannelTable.tsx
+++ b/release-calendar/src/client/components/ChannelTable.tsx
@@ -36,7 +36,7 @@ interface ChannelTableProps {
 
 export const channelTitles: Titles = {
   [Channel.STABLE]: {title: 'Stable'},
-  [Channel.BETA]: {title: 'Beta'},  
+  [Channel.BETA]: {title: 'Beta'},
   [Channel.NIGHTLY]: {title: 'Nightly'},
   [Channel.LTS]: {title: 'Long Term Stable'},
 };

--- a/release-calendar/src/client/components/ChannelTable.tsx
+++ b/release-calendar/src/client/components/ChannelTable.tsx
@@ -36,8 +36,7 @@ interface ChannelTableProps {
 
 export const channelTitles: Titles = {
   [Channel.STABLE]: {title: 'Stable'},
-  [Channel.PERCENT_BETA]: {title: '% Beta'},
-  [Channel.OPT_IN_BETA]: {title: 'Opt-in Beta'},
+  [Channel.BETA]: {title: 'Beta'},  
   [Channel.NIGHTLY]: {title: 'Nightly'},
   [Channel.LTS]: {title: 'Long Term Stable'},
 };

--- a/release-calendar/src/client/components/ReleaseCard.tsx
+++ b/release-calendar/src/client/components/ReleaseCard.tsx
@@ -59,13 +59,8 @@ export class ReleaseCard extends React.Component<
       emoji: '🌙',
       emojiName: 'moon',
     },
-    [Channel.OPT_IN_BETA]: {
-      title: channelTitles[Channel.OPT_IN_BETA].title,
-      emoji: '✋',
-      emojiName: 'hand',
-    },
-    [Channel.PERCENT_BETA]: {
-      title: channelTitles[Channel.PERCENT_BETA].title,
+    [Channel.BETA]: {
+      title: channelTitles[Channel.BETA].title,
       emoji: '🧪',
       emojiName: 'experiment',
     },

--- a/release-calendar/src/client/stylesheets/_base.scss
+++ b/release-calendar/src/client/stylesheets/_base.scss
@@ -1,8 +1,7 @@
 //Channel Colors
 $lts: rgb(61, 63, 206);
-$stable: rgb(216, 158, 83);
-$perc-beta: rgb(134, 62, 216);
-$opt-in-beta: rgb(200, 125, 207);
+$stable: rgb(134, 62, 216);
+$beta: rgb(200, 125, 207);
 $nightly: rgb(100, 204, 135);
 $amp-blue: rgb(33, 150, 243);
 $amp-off-blue: rgba(23, 93, 151, 0.596);

--- a/release-calendar/src/client/stylesheets/calendar.scss
+++ b/release-calendar/src/client/stylesheets/calendar.scss
@@ -75,13 +75,8 @@
   @include color(base.$stable);
 }
 
-.perc-beta {
-  @include color(base.$perc-beta)
-}
-
-
-.opt-in-beta {
-  @include color(base.$opt-in-beta);
+.beta {
+  @include color(base.$beta)
 }
 
 .nightly {

--- a/release-calendar/src/client/stylesheets/channelTable.scss
+++ b/release-calendar/src/client/stylesheets/channelTable.scss
@@ -61,12 +61,9 @@ $grey-border:rgb(216, 216, 216)
     .stable {
         @include square(base.$stable);
     }
-    .perc-beta{
-        @include square(base.$perc-beta);
-    }
-    .opt-in-beta {
-        @include square(base.$opt-in-beta);
-    }
+    .beta{
+        @include square(base.$beta);
+    }    
     .nightly {
         @include square(base.$nightly);
     }

--- a/release-calendar/src/server/app.ts
+++ b/release-calendar/src/server/app.ts
@@ -95,8 +95,8 @@ async function main(): Promise<void> {
         });
       }
 
-      if (promotion) {                
-        promotion.date = moment(promotion.time).toDate();       
+      if (promotion) {
+        promotion.date = moment(promotion.time).toDate();
         await repositoryService.createPromotion(promotion).catch((error) => {
           errors.push(error);
         });

--- a/release-calendar/src/server/app.ts
+++ b/release-calendar/src/server/app.ts
@@ -84,23 +84,20 @@ async function main(): Promise<void> {
       }
 
       // parse ctime string into date
-      const {release, promotions} = req.body;
+      const {release, promotion} = req.body;
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const errors: any[] = [];
 
       if (release) {
-        await repositoryService.createReleases(release).catch((error) => {
+        await repositoryService.createRelease(release).catch((error) => {
           errors.push(error);
         });
       }
 
-      if (promotions) {
-        promotions.forEach((p: {time: string; date: Date}) => {
-          p.date = moment(p.time).toDate();
-        });
-
-        await repositoryService.createPromotions(promotions).catch((error) => {
+      if (promotion) {                
+        promotion.date = moment(promotion.time).toDate();       
+        await repositoryService.createPromotion(promotion).catch((error) => {
           errors.push(error);
         });
       }

--- a/release-calendar/src/server/repository-service.ts
+++ b/release-calendar/src/server/repository-service.ts
@@ -56,8 +56,7 @@ export class RepositoryService {
       [
         Channel.LTS,
         Channel.NIGHTLY,
-        Channel.OPT_IN_BETA,
-        Channel.PERCENT_BETA,
+        Channel.BETA,        
         Channel.STABLE,
       ].map((channel) => {
         return this.promotionRepository
@@ -71,15 +70,15 @@ export class RepositoryService {
     );
   }
 
-  async createReleases(release: Release): Promise<void> {
+  async createRelease(release: Release): Promise<void> {
     await this.releaseRepository.save(release).catch((error) => {
       // a throw is required here due to bug typeorm/typeorm#5057
       throw error;
     });
   }
 
-  async createPromotions(promotions: Promotion[]): Promise<void> {
-    await this.promotionRepository.save(promotions).catch((error) => {
+  async createPromotion(promotion: Promotion): Promise<void> {
+    await this.promotionRepository.save(promotion).catch((error) => {
       // a throw is required here due to bug typeorm/typeorm#5057
       throw error;
     });

--- a/release-calendar/src/server/repository-service.ts
+++ b/release-calendar/src/server/repository-service.ts
@@ -53,20 +53,17 @@ export class RepositoryService {
 
   getCurrentPromotions(): Promise<Promotion[]> {
     return Promise.all(
-      [
-        Channel.LTS,
-        Channel.NIGHTLY,
-        Channel.BETA,        
-        Channel.STABLE,
-      ].map((channel) => {
-        return this.promotionRepository
-          .createQueryBuilder('promotion')
-          .select('promotion.releaseName')
-          .addSelect('promotion.channel')
-          .where('promotion.channel = :channel', {channel})
-          .orderBy('promotion.date', 'DESC')
-          .getOne();
-      }),
+      [Channel.LTS, Channel.NIGHTLY, Channel.BETA, Channel.STABLE].map(
+        (channel) => {
+          return this.promotionRepository
+            .createQueryBuilder('promotion')
+            .select('promotion.releaseName')
+            .addSelect('promotion.channel')
+            .where('promotion.channel = :channel', {channel})
+            .orderBy('promotion.date', 'DESC')
+            .getOne();
+        },
+      ),
     );
   }
 

--- a/release-calendar/src/types.ts
+++ b/release-calendar/src/types.ts
@@ -17,7 +17,7 @@
 export enum Channel {
   LTS = 'lts',
   STABLE = 'stable',
-  BETA = 'beta',  
+  BETA = 'beta',
   NIGHTLY = 'nightly',
 }
 

--- a/release-calendar/src/types.ts
+++ b/release-calendar/src/types.ts
@@ -17,8 +17,7 @@
 export enum Channel {
   LTS = 'lts',
   STABLE = 'stable',
-  PERCENT_BETA = 'perc-beta',
-  OPT_IN_BETA = 'opt-in-beta',
+  BETA = 'beta',  
   NIGHTLY = 'nightly',
 }
 

--- a/release-calendar/test/test-data.ts
+++ b/release-calendar/test/test-data.ts
@@ -32,8 +32,7 @@ export default async function addTestData(
   const releases = [
     new Release('2004252135000'), // lts
     new Release('2234567890123'), // stable
-    new Release('3234567890123'), // perc-beta
-    new Release('4234567890123'), // opt-in-beta
+    new Release('3234567890123'), // beta
     new Release('5234567890123'), // nightly
   ];
 
@@ -41,10 +40,9 @@ export default async function addTestData(
   const startDate = new Date(today.setDate(today.getDate() - 20));
   const promotePromises = [];
   const createPromises = [];
-  const channelsForBeta = [
+  const channels = [
     Channel.NIGHTLY,
-    Channel.OPT_IN_BETA,
-    Channel.PERCENT_BETA,
+    Channel.BETA,
     Channel.STABLE,
     Channel.LTS,
   ];
@@ -55,15 +53,15 @@ export default async function addTestData(
     createPromises.push(
       await repositoryService.createRelease(releases[i], newDate),
     );
-    for (let j = 0; j < channelsForBeta.length - 1 - i; j++) {
+    for (let j = 0; j < channels.length - 1 - i; j++) {
       const promoteDate = new Date(newDate);
       promoteDate.setDate(newDate.getDate() + j + 1);
-      const betaPromotions = promoteRelease(
+      const promotions = promoteRelease(
         releases[i],
-        channelsForBeta[j + 1],
+        channels[j + 1],
         promoteDate,
       );
-      promotePromises.push(repositoryService.savePromotions(betaPromotions));
+      promotePromises.push(repositoryService.savePromotions(promotions));
     }
   }
 

--- a/release-calendar/test/test-data.ts
+++ b/release-calendar/test/test-data.ts
@@ -40,12 +40,7 @@ export default async function addTestData(
   const startDate = new Date(today.setDate(today.getDate() - 20));
   const promotePromises = [];
   const createPromises = [];
-  const channels = [
-    Channel.NIGHTLY,
-    Channel.BETA,
-    Channel.STABLE,
-    Channel.LTS,
-  ];
+  const channels = [Channel.NIGHTLY, Channel.BETA, Channel.STABLE, Channel.LTS];
 
   for (let i = 0; i < releases.length; i++) {
     const newDate = new Date(startDate);


### PR DESCRIPTION
Simplifies release calendar to only track % beta as "beta".