### PR TITLE
Wrap filename in backticks to prevent accidental formatting

### DIFF
--- a/owners/src/ownership/owners_check.js
+++ b/owners/src/ownership/owners_check.js
@@ -33,6 +33,17 @@ const CheckRunState = {
 };
 
 /**
+ * Wraps filename in backticks to render as inline code.
+ * This prevents accidentally formatting a filename that may contain Markdown,
+ * like _accidental-italics_ or __accidental-bold__
+ * @param {string} filename
+ * @return {string}
+ */
+function getMarkdownPrintableFilename(filename) {
+  return `\`${filename}\``;
+}
+
+/**
  * A GitHub presubmit check-run.
  */
 class CheckRun {
@@ -301,12 +312,7 @@ class OwnersCheck {
    */
   buildCurrentCoverageText(fileTreeMap) {
     const allFilesText = Object.entries(fileTreeMap)
-      .map(([filenameRaw, subtree]) => {
-        // Wrap filename in backticks to render as inline code.
-        // This prevents accidentally formatting a filename that may contain
-        // Markdown, like _accidental-italics_ or __accidental_bold__
-        const filename = '`' + filenameRaw + '`';
-
+      .map(([filename, subtree]) => {
         const reviewers = Object.entries(this.reviewers).filter(([username]) =>
           this.tree.fileHasOwner(filename, username)
         );
@@ -321,24 +327,25 @@ class OwnersCheck {
           owner => owner.name
         );
 
+        const printableFilename = getMarkdownPrintableFilename(filename);
+
         if (approving.length && !missing.length) {
-          return `- ${filename} _(${approving.join(', ')})_`;
-        } else {
-          let line = `- **[NEEDS APPROVAL]** ${filename}`;
-
-          const names = [];
-          if (pending.length) {
-            names.push(`requested: ${pending.join(', ')}`);
-          }
-          if (missing.length) {
-            names.push(`required: ${missing.join(', ')}`);
-          }
-
-          if (names.length) {
-            line += ` _(${names.join('; ')})_`;
-          }
-          return line;
+          return `- ${printableFilename} _(${approving.join(', ')})_`;
         }
+        let line = `- **[NEEDS APPROVAL]** ${printableFilename}`;
+
+        const names = [];
+        if (pending.length) {
+          names.push(`requested: ${pending.join(', ')}`);
+        }
+        if (missing.length) {
+          names.push(`required: ${missing.join(', ')}`);
+        }
+
+        if (names.length) {
+          line += ` _(${names.join('; ')})_`;
+        }
+        return line;
       })
       .join('\n');
 
@@ -355,7 +362,9 @@ class OwnersCheck {
     const suggestionsText = reviewSuggestions.map(
       ([reviewer, coveredFiles]) => {
         const header = `Reviewer: _${reviewer}_`;
-        const files = coveredFiles.map(filename => `- ${filename}`);
+        const files = coveredFiles.map(filename =>
+          `- ${getMarkdownPrintableFilename(filename)}`
+        );
         return [header, ...files].join('\n');
       }
     );

--- a/owners/src/ownership/owners_check.js
+++ b/owners/src/ownership/owners_check.js
@@ -362,8 +362,8 @@ class OwnersCheck {
     const suggestionsText = reviewSuggestions.map(
       ([reviewer, coveredFiles]) => {
         const header = `Reviewer: _${reviewer}_`;
-        const files = coveredFiles.map(filename =>
-          `- ${getMarkdownPrintableFilename(filename)}`
+        const files = coveredFiles.map(
+          filename => `- ${getMarkdownPrintableFilename(filename)}`
         );
         return [header, ...files].join('\n');
       }

--- a/owners/src/ownership/owners_check.js
+++ b/owners/src/ownership/owners_check.js
@@ -301,7 +301,12 @@ class OwnersCheck {
    */
   buildCurrentCoverageText(fileTreeMap) {
     const allFilesText = Object.entries(fileTreeMap)
-      .map(([filename, subtree]) => {
+      .map(([filenameRaw, subtree]) => {
+        // Wrap filename in backticks to render as inline code.
+        // This prevents accidentally formatting a filename that may contain
+        // Markdown, like _accidental-italics_ or __accidental_bold__
+        const filename = '`' + filenameRaw + '`';
+
         const reviewers = Object.entries(this.reviewers).filter(([username]) =>
           this.tree.fileHasOwner(filename, username)
         );

--- a/owners/test/index.test.js
+++ b/owners/test/index.test.js
@@ -153,12 +153,12 @@ describe('GitHub app', () => {
             });
             expect(body.output.text).toContain(
               '### Current Coverage\n\n' +
-                '- **[NEEDS APPROVAL]** dir2/dir1/dir1/file.txt'
+                '- **[NEEDS APPROVAL]** `dir2/dir1/dir1/file.txt`'
             );
             expect(body.output.text).toContain(
               '### Suggested Reviewers\n\n' +
                 'Reviewer: _githubuser_\n' +
-                '- dir2/dir1/dir1/file.txt'
+                '- `dir2/dir1/dir1/file.txt`'
             );
             expect(body.output.text).toContain('HELP TEXT');
 
@@ -210,12 +210,12 @@ describe('GitHub app', () => {
             });
             expect(body.output.text).toContain(
               '### Current Coverage\n\n' +
-                '- **[NEEDS APPROVAL]** dir2/dir1/dir1/file.txt'
+                '- **[NEEDS APPROVAL]** `dir2/dir1/dir1/file.txt`'
             );
             expect(body.output.text).toContain(
               '### Suggested Reviewers\n\n' +
                 'Reviewer: _githubuser_\n' +
-                '- dir2/dir1/dir1/file.txt'
+                '- `dir2/dir1/dir1/file.txt`'
             );
             expect(body.output.text).toContain('HELP TEXT');
 
@@ -263,12 +263,12 @@ describe('GitHub app', () => {
             });
             expect(body.output.text).toContain(
               '### Current Coverage\n\n' +
-                '- **[NEEDS APPROVAL]** dir2/dir1/dir1/file.txt'
+                '- **[NEEDS APPROVAL]** `dir2/dir1/dir1/file.txt`'
             );
             expect(body.output.text).toContain(
               '### Suggested Reviewers\n\n' +
                 'Reviewer: _githubuser_\n' +
-                '- dir2/dir1/dir1/file.txt'
+                '- `dir2/dir1/dir1/file.txt`'
             );
             expect(body.output.text).toContain('HELP TEXT');
 
@@ -314,14 +314,14 @@ describe('GitHub app', () => {
             });
             expect(body.output.text).toContain(
               '### Current Coverage\n\n' +
-                '- **[NEEDS APPROVAL]** dir2/dir1/dir1/file.txt\n' +
-                '- **[NEEDS APPROVAL]** dir2/dir1/dir1/file-2.txt'
+                '- **[NEEDS APPROVAL]** `dir2/dir1/dir1/file.txt`\n' +
+                '- **[NEEDS APPROVAL]** `dir2/dir1/dir1/file-2.txt`'
             );
             expect(body.output.text).toContain(
               '### Suggested Reviewers\n\n' +
                 'Reviewer: _githubuser_\n' +
-                '- dir2/dir1/dir1/file.txt\n' +
-                '- dir2/dir1/dir1/file-2.txt'
+                '- `dir2/dir1/dir1/file.txt`\n' +
+                '- `dir2/dir1/dir1/file-2.txt`'
             );
             expect(body.output.text).toContain('HELP TEXT');
 
@@ -376,12 +376,12 @@ describe('GitHub app', () => {
             });
             expect(body.output.text).toContain(
               '### Current Coverage\n\n' +
-                '- **[NEEDS APPROVAL]** dir2/dir1/dir1/file.txt'
+                '- **[NEEDS APPROVAL]** `dir2/dir1/dir1/file.txt`'
             );
             expect(body.output.text).toContain(
               '### Suggested Reviewers\n\n' +
                 'Reviewer: _githubuser_\n' +
-                '- dir2/dir1/dir1/file.txt'
+                '- `dir2/dir1/dir1/file.txt`'
             );
             expect(body.output.text).toContain('HELP TEXT');
 
@@ -431,7 +431,7 @@ describe('GitHub app', () => {
             });
             expect(body.output.text).toContain(
               '### Current Coverage\n\n' +
-                '- dir2/dir1/dir1/file.txt _(githubuser)_'
+                '- `dir2/dir1/dir1/file.txt` _(githubuser)_'
             );
             expect(body.output.text).toContain('HELP TEXT');
 
@@ -478,7 +478,7 @@ describe('GitHub app', () => {
               },
             });
             expect(body.output.text).toContain(
-              '### Current Coverage\n\n- dir2/new-file.txt _(githubuser)_'
+              '### Current Coverage\n\n- `dir2/new-file.txt` _(githubuser)_'
             );
             expect(body.output.text).toContain('HELP TEXT');
 
@@ -530,7 +530,7 @@ describe('GitHub app', () => {
             });
             expect(body.output.text).toContain(
               '### Current Coverage\n\n' +
-                '- dir2/dir1/dir1/file.txt _(githubuser)_'
+                '- `dir2/dir1/dir1/file.txt` _(githubuser)_'
             );
             expect(body.output.text).toContain('HELP TEXT');
 

--- a/owners/test/ownership/owners_check.test.js
+++ b/owners/test/ownership/owners_check.test.js
@@ -620,27 +620,27 @@ describe('owners check', () => {
 
     it('lists files with their owners approvers', () => {
       expect(coverageText).toContain('### Current Coverage');
-      expect(coverageText).toContain('- foo/test.js _(approver)_');
-      expect(coverageText).toContain('- bar/baz/file.txt _(other_approver)_');
-      expect(coverageText).toContain('- buzz/README.md _(the_author)_');
+      expect(coverageText).toContain('- `foo/test.js` _(approver)_');
+      expect(coverageText).toContain('- `bar/baz/file.txt` _(other_approver)_');
+      expect(coverageText).toContain('- `buzz/README.md` _(the_author)_');
     });
 
     it('lists files needing approval', () => {
       expect(coverageText).toContain('### Current Coverage');
-      expect(coverageText).toContain('- **[NEEDS APPROVAL]** main.js');
+      expect(coverageText).toContain('- **[NEEDS APPROVAL]** `main.js`');
     });
 
     it('shows existing reviewers that could approve files', () => {
       expect(coverageText).toContain('### Current Coverage');
       expect(coverageText).toContain(
-        '- **[NEEDS APPROVAL]** extra/script.js _(requested: extra_reviewer)_'
+        '- **[NEEDS APPROVAL]** `extra/script.js` _(requested: extra_reviewer)_'
       );
     });
 
     it('shows missing required', () => {
       expect(coverageText).toContain('### Current Coverage');
       expect(coverageText).toContain(
-        '- **[NEEDS APPROVAL]** foo/required/info.html ' +
+        '- **[NEEDS APPROVAL]** `foo/required/info.html` ' +
           '_(required: required_reviewer)_'
       );
     });
@@ -656,11 +656,11 @@ describe('owners check', () => {
       expect(ownersCheck.buildReviewSuggestionsText(reviewSuggestions)).toEqual(
         '### Suggested Reviewers\n\n' +
           'Reviewer: _alice_\n' +
-          '- alice_file1.js\n' +
-          '- foo/alice_file2.js\n\n' +
+          '- `alice_file1.js`\n' +
+          '- `foo/alice_file2.js`\n\n' +
           'Reviewer: _bob_\n' +
-          '- bob_file1.js\n' +
-          '- bar/bob_file2.js'
+          '- `bob_file1.js`\n' +
+          '- `bar/bob_file2.js`'
       );
     });
   });


### PR DESCRIPTION
It's hard to notice in this screenshot, but the filename includes `__`, which makes a certain section render as bold.

The actual path is:
`.../extensions/__amp-component_name_hyphenated__/__component_version__/storybook/...`

but it looks like:
.../extensions/__amp-component_name_hyphenated__/__component_version__/storybook/...,

![image](https://user-images.githubusercontent.com/254946/131724154-65f8f243-53f5-4968-b859-8581c3436533.png)