### PR TITLE
[pr-deploy] Revert node-fetch from v3.0.0 to v2.6.2

### DIFF
--- a/pr-deploy/package-lock.json
+++ b/pr-deploy/package-lock.json
@@ -2292,12 +2292,13 @@
       "integrity": "sha512-8kQ3+wKGRNN0ghtEn7EGps/B8CzuBz1nXZEIGGLP2GnwbqYn4dbTs7k+VKLTq1HvZLRCIDtN3Snx1Ege8B7L5A=="
     },
     "@types/node-fetch": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.2.tgz",
-      "integrity": "sha512-3q5FyT6iuekUxXeL2qjcyIhtMJdfMF7RGhYXWKkYpdcW9k36A/+txXrjG0l+NMVkiC30jKNrcOqVlqBl7BcCHA==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
+      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
       "dev": true,
       "requires": {
-        "node-fetch": "*"
+        "@types/node": "*",
+        "form-data": "^3.0.0"
       }
     },
     "@types/pino": {
@@ -3290,11 +3291,6 @@
         }
       }
     },
-    "data-uri-to-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
-    },
     "data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -3816,14 +3812,6 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
-      }
-    },
-    "fetch-blob": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.2.tgz",
-      "integrity": "sha512-hunJbvy/6OLjCD0uuhLdp0mMPzP/yd2ssd1t2FCJsaA7wkWhpbp9xfuNVpv7Ll4jFhzp6T4LAupSiV9uOeg0VQ==",
-      "requires": {
-        "web-streams-polyfill": "^3.0.3"
       }
     },
     "fill-range": {
@@ -7595,13 +7583,9 @@
       }
     },
     "node-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
-      "integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
-      "requires": {
-        "data-uri-to-buffer": "^3.0.1",
-        "fetch-blob": "^3.1.2"
-      }
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA=="
     },
     "node-forge": {
       "version": "0.10.0",
@@ -7869,9 +7853,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -9437,9 +9421,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.0.tgz",
-      "integrity": "sha512-9iT6N4s93SMfzunOyDPe4vo4nLcSu1yq0IQK1gURmjm8tQNlM6loiuCRrKG1hHGXfB2EWd6H4cGi7tGdaygMFw==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -9532,11 +9516,6 @@
       "requires": {
         "makeerror": "1.0.x"
       }
-    },
-    "web-streams-polyfill": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.1.tgz",
-      "integrity": "sha512-Czi3fG883e96T4DLEPRvufrF2ydhOOW1+1a6c3gNjH2aIh50DNFBdfwh2AKoOf1rXvpvavAoA11Qdq9+BKjE0Q=="
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/pr-deploy/package.json
+++ b/pr-deploy/package.json
@@ -27,7 +27,7 @@
     "gunzip-maybe": "1.4.2",
     "mime-types": "2.1.31",
     "nock": "13.1.0",
-    "node-fetch": "3.0.0",
+    "node-fetch": "2.6.2",
     "probot": "12.1.1",
     "tar-stream": "2.2.0",
     "typescript": "4.3.4"
@@ -40,7 +40,7 @@
     "@types/jest": "27.0.1",
     "@types/mime-types": "2.1.0",
     "@types/node": "14.17.4",
-    "@types/node-fetch": "3.0.2",
+    "@types/node-fetch": "2.5.12",
     "@types/supertest": "2.0.11",
     "@types/tar-stream": "2.2.0",
     "jest": "27.0.5",

--- a/pr-deploy/package.json
+++ b/pr-deploy/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/ampproject/amp-github-apps.git"
   },
   "scripts": {
-    "build": "tsc -p . --esModuleInterop",
+    "build": "tsc",
     "dev": "nodemon",
     "gcp-build": "npm run build",
     "start": "probot run ./dist/src/app.js",


### PR DESCRIPTION
v3 now only supports being imported as an [ECMAScript module](https://www.npmjs.com/package/node-fetch#loading-and-configuring-the-module), and our TS config is set to output CommonJS code - this PR reverts that change until we decide to migrate to ESM output

Tag-along: remove flags from `tsc` call, they're already included in the tsconfig.json file