### PR TITLE
Add circleci api and metrics to project-metrics

### DIFF
--- a/project-metrics/metrics_service/apis/circleci.py
+++ b/project-metrics/metrics_service/apis/circleci.py
@@ -1,0 +1,49 @@
+"""Client for querying CircleCI API.
+
+For an overview of the API https://circleci.com/docs/api/v2/
+"""
+from typing import Dict
+from http import HTTPStatus
+import logging
+import requests
+from database import models
+
+import env
+
+CIRCLECI_API = 'https://circleci.com/api/v2'
+VCS_STAB = 'github'
+PROJECT = env.get('GITHUB_REPO')
+INSIGHTS_API = f'{CIRCLECI_API}/insights/{VCS_STAB}/{PROJECT}'
+
+def _dict_to_params(params: Dict):
+  param_string = '&'.join(f'{key}={value}' for (key, value) in params.items())
+  return param_string and '?' + param_string
+
+
+class CircleCiError(Exception):
+  def __init__(self, status_code: int, message: str):
+    msg = f'CircleCI API Error status {status_code}. Message: {message}'
+    super(CircleCiError, self).__init__(msg)
+
+
+class CircleCiAPI(object):
+  """Interface class for executing queries agains the CircleCI API."""
+  def __init__(self, token = None):
+    self._token = token or env.get('CIRCLECI_API_ACCESS_TOKEN')
+
+
+  def get_workflow_stats(self, reporting_window = models.CircleCiReportingWindow.LAST_90_DAYS) -> models.CircleCiWorkflowStats:
+    params = {
+      'reporting-window': reporting_window.value
+    }
+    endpoint = f'{INSIGHTS_API}/workflows{_dict_to_params(params)}'
+    logging.info('Called {endpoint}')
+    headers = { 'authorization': 'Basic %s' % env.get('CIRCLECI_API_ACCESS_TOKEN') }
+    response = requests.get(endpoint, headers=headers)
+    parsed = response.json()
+    if response.status_code != HTTPStatus.OK:
+      raise CircleCiError(response.status_code, parsed['message'])
+    stats = models.CircleCiWorkflowStats.from_json(parsed['items'][0])
+    
+    return stats
+

--- a/project-metrics/metrics_service/apis/circleci_test.py
+++ b/project-metrics/metrics_service/apis/circleci_test.py
@@ -1,0 +1,84 @@
+"""Tests for CircleCI API interface"""
+
+import unittest
+from unittest import mock
+import requests
+from database import models
+
+import env
+from apis.circleci import CircleCiAPI
+
+class FakeValidResponse():
+  status_code = 200
+  text = '''
+  {
+    "next_page_token" : null,
+    "items" : [ {
+      "name" : "CircleCI",
+      "metrics" : {
+        "total_runs" : 740,
+        "successful_runs" : 423,
+        "mttr" : 19686,
+        "total_credits_used" : 3245482,
+        "failed_runs" : 309,
+        "median_credits_used" : 0,
+        "success_rate" : 0.5716216216216217,
+        "duration_metrics" : {
+          "min" : 15,
+          "mean" : 1124,
+          "median" : 987,
+          "p95" : 1447,
+          "max" : 9031,
+          "standard_deviation" : 914.0,
+          "total_duration" : 0
+        },
+        "total_recoveries" : 0,
+        "throughput" : 8.314606741573034
+      },
+      "window_start" : "2021-06-03T00:05:18.812Z",
+      "window_end" : "2021-08-31T23:59:51.955Z",
+      "project_id" : "16f524bf-6612-4bba-8e0c-c9b6b00ceb61"
+    } ]
+  }
+  '''
+
+def stub_circleci_api():
+  mock.patch.object(
+        env, 'get', side_effect={
+            'GITHUB_REPO': '__repo__',
+        }.get).start()
+
+  mock.patch.object(
+      env, 'get', side_effect={
+          'CIRCLECI_API_ACCESS_TOKEN': 'FAKE_TOKEN',
+      }.get).start()
+  mock_request = mock.patch.object(requests, 'get', autospec=True).start()
+  mock_request.return_value = (FakeValidResponse())
+  return mock_request
+
+class TestCircleCiApi(unittest.TestCase):
+  def setUp(self) -> None:
+    super(TestCircleCiApi, self).setUp()
+    self.mock_request = stub_circleci_api()
+    self.addCleanup(mock.patch.stopall)
+
+  def testDictToParams(self):
+    self.assertEqual(CircleCiAPI._dict_to_params({}), '')
+
+    self.assertEqual(CircleCiAPI._dict_to_params({
+      'reporting-window': '',
+    }), '?reporting-window=')
+
+    self.assertEqual(CircleCiAPI._dict_to_params({
+      'reporting-window': models.CircleCiReportingWindow.LAST_90_DAYS.value
+    }), '?reporting-window=last-90-days')
+
+    self.assertEqual(CircleCiAPI._dict_to_params({'a': 1, 'b': 2}), '?a=1&b=2')
+
+  def testGetWorkflowStats(self):
+    CircleCiAPI().get_workflow_stats()
+
+    self.mock_request.assert_called_with(
+      'https://circleci.com/api/v2/insights/github/ampproject/amphtml/workflows?reporting-window=last-90-days',
+      headers = { 'authorization': "Basic FAKE_TOKEN" }
+    )

--- a/project-metrics/metrics_service/database/models.py
+++ b/project-metrics/metrics_service/database/models.py
@@ -30,6 +30,83 @@ def _is_last_n_days(
   return (timestamp_column >= n_days_ago) & (timestamp_column <= base_time)
 
 
+class CircleCiReportingWindow(enum.Enum):
+  """The reporting windows supported by the CircleCI insights api"""
+  LAST_24_HOURS = 'last-24-hours'
+  LAST_7_DAYS = 'last-7-days'
+  LAST_30_DAYS = 'last-30-days'
+  LAST_60_DAYS = 'last-60-days'
+  LAST_90_DAYS = 'last-90-days'
+
+
+class CircleCiWorkflowDurationMetrics():
+  min: int
+  mean: int
+  median: int
+  p95: int
+  max: int
+  standard_deviation: float
+  total_duration: int
+
+  @staticmethod
+  def from_json(dict):
+    metrics = CircleCiWorkflowDurationMetrics()
+    metrics.min = dict['min']
+    metrics.mean = dict['mean']
+    metrics.median = dict['median']
+    metrics.p95 = dict['p95']
+    metrics.max = dict['max']
+    metrics.standard_deviation = dict['standard_deviation']
+    metrics.total_duration = dict['total_duration']
+    return metrics
+
+
+class CircleCiWorkflowMetrics():
+  duration_metrics: CircleCiWorkflowDurationMetrics
+  total_runs: int
+  successful_runs: int
+  mttr: int
+  total_credits_used: int
+  failed_runs: int
+  median_credits_used: int
+  success_rate: float
+  total_recoveries: int
+  throughput: float
+
+  @staticmethod
+  def from_json(stats):
+    metrics = CircleCiWorkflowMetrics()
+    metrics.duration_metrics = CircleCiWorkflowDurationMetrics.from_json(stats['duration_metrics'])
+    metrics.total_runs = stats['total_runs']
+    metrics.successful_runs = stats['successful_runs']
+    metrics.mttr = stats['mttr']
+    metrics.total_credits_used = stats['total_credits_used']
+    metrics.failed_runs = stats['failed_runs']
+    metrics.median_credits_used = stats['median_credits_used']
+    metrics.success_rate = stats['success_rate']
+    metrics.total_recoveries = stats['total_recoveries']
+    metrics.throughput = stats['throughput']
+    return metrics
+
+
+class CircleCiWorkflowStats():
+  project_id: str
+  name: str
+  metrics: CircleCiWorkflowMetrics
+  window_start: datetime.datetime
+  window_end: datetime.datetime
+
+  @staticmethod
+  def from_json(raw_stats):
+    stats = CircleCiWorkflowStats
+    stats.project_id = raw_stats['project_id']
+    stats.name = raw_stats['name']
+    stats.metrics = CircleCiWorkflowMetrics.from_json(raw_stats['metrics'])
+    date_format = '%Y-%m-%dT%H:%M:%S.%fZ'
+    stats.window_start = datetime.datetime.strptime(raw_stats['window_start'], date_format)
+    stats.window_end = datetime.datetime.strptime(raw_stats['window_end'], date_format)
+    return stats
+
 class MetricScore(enum.Enum):
   """The computed score of a metric."""
   UNKNOWN = 0

--- a/project-metrics/metrics_service/metrics/base.py
+++ b/project-metrics/metrics_service/metrics/base.py
@@ -1,9 +1,9 @@
 """Base interface for metrics to implement.
 
 To create a new metric:
-1. Subclass `Metric` or `PercentMetric`
+1. Subclass `Metric` or `PercentageMetric`
 2. Implement `_score_value`, `_compute_value`, and (unless you're using
-   `PercentMetric`) `_format_value` and define the UNIT (for history plots)
+   `PercentageMetric`) `_format_value` and define the UNIT (for history plots)
 3. Call `metrics.base.Metric.register(YourNewMetric)`
 4. Import the metric in __init__.py so it can register itself
 5. Define the update frequency with a job in `cron.yaml`
@@ -17,7 +17,7 @@ import datetime
 import logging
 import sqlalchemy
 import stringcase
-from typing import Any, Dict, Iterable, Optional, Sequence, Text, Type, TypeVar
+from typing import Any, Dict, Optional, Sequence, Text, Type, TypeVar
 
 from database import db
 from database import models

--- a/project-metrics/metrics_service/metrics/cherrypick_issue_count_test.py
+++ b/project-metrics/metrics_service/metrics/cherrypick_issue_count_test.py
@@ -1,8 +1,6 @@
 """Tests for cherrypick-issue-count metric."""
 
 import datetime
-import random
-import uuid
 
 from database import models
 from metrics import cherrypick_issue_count
@@ -20,8 +18,6 @@ class TestCherrypickIssueCountMetric(metric_test_case.MetricTestCase):
         created_at=datetime.datetime.now() - datetime.timedelta(days=days))
 
   def testRecompute(self):
-    now = datetime.datetime.now()
-
     session = self.Session()
     session.add_all([
         self._cherrypick_issue_n_days_ago(12, 95),  # Older than 90 days.

--- a/project-metrics/metrics_service/metrics/circleci_flakiness.py
+++ b/project-metrics/metrics_service/metrics/circleci_flakiness.py
@@ -1,0 +1,23 @@
+"""CircleCI Flakiness metric."""
+
+from metrics.base import PercentageMetric
+from metrics import base
+from database import models
+from apis.circleci import CircleCiAPI
+
+class CircleCiFlakiness(PercentageMetric):
+  def _score_value(self, percentage: float) -> models.MetricScore:
+    if percentage < 0.6:
+      return models.MetricScore.POOR
+    elif percentage < 0.75:
+      return models.MetricScore.MODERATE
+    elif percentage < 0.9:
+      return models.MetricScore.GOOD
+    else:
+      return models.MetricScore.EXCELLENT
+
+  def _compute_value(self) -> models.MetricResult:
+    workflow_stats = CircleCiAPI().get_workflow_stats()
+    return workflow_stats.metrics.failed_runs / workflow_stats.metrics.total_runs
+  
+base.Metric.register(CircleCiFlakiness)

--- a/project-metrics/metrics_service/metrics/circleci_flakiness_test.py
+++ b/project-metrics/metrics_service/metrics/circleci_flakiness_test.py
@@ -1,0 +1,38 @@
+"""Tests for circleci flakiness metric."""
+
+from database import models
+from unittest import mock
+from metrics import circleci_flakiness
+from test import metric_test_case
+
+from apis.circleci_test import stub_circleci_api
+
+class CircleCiFlakiness(metric_test_case.MetricTestCase):
+  def setUp(self):
+    super(CircleCiFlakiness, self).setUp()
+    stub_circleci_api()
+    self.addCleanup(mock.patch.stopall)
+    
+
+  def new_metric_under_test(self):
+    return circleci_flakiness.CircleCiFlakiness()
+
+  def testRecompute(self):
+    self.metric.recompute()
+    self.assertLatestResultEquals(309/740)
+
+  def testName(self):
+    self.assertEqual(self.metric.name, 'CircleCiFlakiness')
+
+  def testLabel(self):
+    self.assertEqual(self.metric.label, 'Circle Ci Flakiness')
+
+  def testScore(self):
+    self.assertEqual(self.metric.score, models.MetricScore.UNKNOWN)
+    self.assertValueHasScore(0.5, models.MetricScore.POOR)
+    self.assertValueHasScore(0.6, models.MetricScore.MODERATE)
+    self.assertValueHasScore(0.7, models.MetricScore.MODERATE)
+    self.assertValueHasScore(0.75, models.MetricScore.GOOD)
+    self.assertValueHasScore(0.8, models.MetricScore.GOOD)
+    self.assertValueHasScore(0.9, models.MetricScore.EXCELLENT)
+    self.assertValueHasScore(0.95, models.MetricScore.EXCELLENT)

--- a/project-metrics/metrics_service/metrics/circleci_greenness.py
+++ b/project-metrics/metrics_service/metrics/circleci_greenness.py
@@ -1,0 +1,23 @@
+"""CircleCI Greenness metric."""
+
+from metrics.base import PercentageMetric
+from metrics import base
+from database import models
+from apis.circleci import CircleCiAPI
+
+class CircleCiGreenness(PercentageMetric):
+  def _score_value(self, percentage: float) -> models.MetricScore:
+    if percentage < 0.6:
+      return models.MetricScore.POOR
+    elif percentage < 0.75:
+      return models.MetricScore.MODERATE
+    elif percentage < 0.9:
+      return models.MetricScore.GOOD
+    else:
+      return models.MetricScore.EXCELLENT
+
+  def _compute_value(self) -> models.MetricResult:
+    workflow_stats = CircleCiAPI().get_workflow_stats()
+    return workflow_stats.metrics.success_rate
+  
+base.Metric.register(CircleCiGreenness)

--- a/project-metrics/metrics_service/metrics/circleci_greenness_test.py
+++ b/project-metrics/metrics_service/metrics/circleci_greenness_test.py
@@ -1,0 +1,38 @@
+"""Tests for circleci greenness metric."""
+
+from database import models
+from unittest import mock
+from metrics import circleci_greenness
+from test import metric_test_case
+
+from apis.circleci_test import stub_circleci_api
+
+class TestCircleCiGreenness(metric_test_case.MetricTestCase):
+  def setUp(self):
+    super(TestCircleCiGreenness, self).setUp()
+    stub_circleci_api()
+    self.addCleanup(mock.patch.stopall)
+    
+
+  def new_metric_under_test(self):
+    return circleci_greenness.CircleCiGreenness()
+
+  def testRecompute(self):
+    self.metric.recompute()
+    self.assertLatestResultEquals(0.5716216216216217)
+
+  def testName(self):
+    self.assertEqual(self.metric.name, 'CircleCiGreenness')
+
+  def testLabel(self):
+    self.assertEqual(self.metric.label, 'Circle Ci Greenness')
+
+  def testScore(self):
+    self.assertEqual(self.metric.score, models.MetricScore.UNKNOWN)
+    self.assertValueHasScore(0.5, models.MetricScore.POOR)
+    self.assertValueHasScore(0.6, models.MetricScore.MODERATE)
+    self.assertValueHasScore(0.7, models.MetricScore.MODERATE)
+    self.assertValueHasScore(0.75, models.MetricScore.GOOD)
+    self.assertValueHasScore(0.8, models.MetricScore.GOOD)
+    self.assertValueHasScore(0.9, models.MetricScore.EXCELLENT)
+    self.assertValueHasScore(0.95, models.MetricScore.EXCELLENT)

--- a/project-metrics/metrics_service/metrics/circleci_presubmit_latency.py
+++ b/project-metrics/metrics_service/metrics/circleci_presubmit_latency.py
@@ -1,0 +1,30 @@
+
+"""CircleCI Presubmit Latency."""
+
+from typing import Text
+from metrics.base import Metric
+from metrics import base
+from database import models
+from apis.circleci import CircleCiAPI
+
+class CircleCiPresubmitLatency(Metric):
+  def _score_value(self, presubmit_latency: float) -> models.MetricScore:
+    if presubmit_latency > 1800:
+      return models.MetricScore.CRITICAL
+    elif presubmit_latency > 1500:
+      return models.MetricScore.POOR
+    elif presubmit_latency > 1200:
+      return models.MetricScore.MODERATE
+    elif presubmit_latency > 900:
+      return models.MetricScore.GOOD
+    else:
+      return models.MetricScore.EXCELLENT
+
+  def _compute_value(self) -> models.MetricResult:
+    workflow_stats = CircleCiAPI().get_workflow_stats()
+    return workflow_stats.metrics.duration_metrics.mean
+
+  def _format_value(self, avg_seconds: float) -> Text:
+    return '%dm' % (avg_seconds // 60)
+  
+base.Metric.register(CircleCiPresubmitLatency)

--- a/project-metrics/metrics_service/metrics/circleci_presubmit_latency_test.py
+++ b/project-metrics/metrics_service/metrics/circleci_presubmit_latency_test.py
@@ -1,0 +1,44 @@
+"""Tests for circle ci presubmit latency metric."""
+
+from database import models
+from unittest import mock
+from metrics import circleci_presubmit_latency
+from test import metric_test_case
+
+from apis.circleci_test import stub_circleci_api
+
+class TestCircleCiPresubmitLatency(metric_test_case.MetricTestCase):
+  def setUp(self):
+    super(TestCircleCiPresubmitLatency, self).setUp()
+    stub_circleci_api()
+    self.addCleanup(mock.patch.stopall)
+    
+
+  def new_metric_under_test(self):
+    return circleci_presubmit_latency.CircleCiPresubmitLatency()
+
+  def testRecompute(self):
+    self.metric.recompute()
+    self.assertLatestResultEquals(1124)
+
+  def testName(self):
+    self.assertEqual(self.metric.name, 'CircleCiPresubmitLatency')
+
+  def testLabel(self):
+    self.assertEqual(self.metric.label, 'Circle Ci Presubmit Latency')
+
+  def testScore(self):
+    self.assertEqual(self.metric.score, models.MetricScore.UNKNOWN)
+    self.assertValueHasScore(1801, models.MetricScore.CRITICAL)
+    self.assertValueHasScore(1501, models.MetricScore.POOR)
+    self.assertValueHasScore(1201, models.MetricScore.MODERATE)
+    self.assertValueHasScore(901, models.MetricScore.GOOD)
+    self.assertValueHasScore(900, models.MetricScore.EXCELLENT)
+    self.assertValueHasScore(100, models.MetricScore.EXCELLENT)
+
+  def testFormattedResult(self):
+    self.assertEqual(self.metric.formatted_result, '?')
+
+    self.metric.result = models.MetricResult(
+        name='PresubmitLatency', value=15 * 60)
+    self.assertEqual(self.metric.formatted_result, '15m')

--- a/project-metrics/metrics_service/server.py
+++ b/project-metrics/metrics_service/server.py
@@ -130,7 +130,7 @@ def list_metrics():
 @app.route('/api/plot/<history_days>/<metric_cls_name>.png')
 def metric_history_plot(history_days: Text, metric_cls_name: Text):
   try:
-    metric_cls = base.Metric.get_metric(metric_cls_name)
+    base.Metric.get_metric(metric_cls_name)
   except KeyError:
     logging.error('No active metric found for %s.', metric_cls_name)
     return ('No active metric found for %s.' %


### PR DESCRIPTION
The first step to updating the project metrics dashboard to show data from CircleCI rather than Travis is to create the apis and metrics objects to obtain and display data from CircleCI