### PR TITLE
[meta] Lock `node-fetch` to SemVer 2.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -94,5 +94,8 @@
     "reviewers": ["danielrozenberg"],
     "rebaseWhen": "never",
     "automerge": true
+  }, {
+    "matchPackageNames": ["node-fetch", "@types/node-fetch"],
+    "allowedVersions": ["<3.0.0"]
   }]
 }


### PR DESCRIPTION
v3 now only supports being imported as an ECMAScript module, and our TS config is set to output CommonJS code - this PR reverts that change until we decide to migrate to ESM output