### PR TITLE
Improve usability of `bundle-size-chart`

### DIFF
--- a/bundle-size-chart/static/index.html
+++ b/bundle-size-chart/static/index.html
@@ -1,37 +1,227 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>AMPHTML bundle-size history</title>
-  <style>
-    .line {
-      fill: none;
-      stroke: lightsteelblue;
-      stroke-width: 1.5px;
-    }
-    .line.hover {
-      stroke: steelblue;
-      stroke-width: 3px;
-    }
-    .hover-line {
-      stroke: silver;
-      stroke-width: .5px;
-    }
-    .dot {
-      font-family: sans-serif;
-      text-anchor: middle;
-      text-decoration: underline;
-    }
-    .dot a:hover text {
-      fill: blue;
-    }
-  </style>
-</head>
-<body>
-  <h1><a href="https://github.com/ampproject/amphtml">AMPHTML</a> bundle-size history</h1>
-  <div id="chart"></div>
-  <label for="filter">Filter</label> <input type="text" id="filter" value="v0.js">
-  <script src="https://d3js.org/d3.v5.min.js" charset="utf-8"></script>
-  <script src="/index.js"></script>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
+    <title>AMPHTML bundle-size history</title>
+    <style>
+      html {
+        --bg: white;
+        --fg: #222;
+        --live: rgb(33, 82, 218);
+        --fg-faint: #888;
+        --overlay-shadow: rgba(40, 40, 60, 0.08);
+        --overlay-bg: rgba(255, 255, 255, 0.6);
+        --overlay-live: rgba(96, 122, 192, 0.1);
+        --line: rgb(176, 197, 255);
+        --line-active: rgb(21, 70, 207);
+        --border-passive: #aaa;
+      }
+      @media (prefers-color-scheme: dark) {
+        html {
+          --bg: #181818;
+          --fg: #ccc;
+          --live: rgb(83, 146, 228);
+          --fg-faint: #999;
+          --overlay-live: rgba(109, 158, 221, 0.1);
+          --overlay-bg: rgba(23, 23, 23, 0.6);
+          --line: rgb(40, 74, 117);
+          --line-active: rgb(89, 155, 240);
+          --border-passive: #555;
+        }
+      }
+      * {
+        box-sizing: border-box;
+      }
+      [hidden] {
+        display: none !important;
+      }
+      svg {
+        user-select: none;
+      }
+      a:link,
+      a:visited {
+        color: var(--live);
+        text-decoration: none;
+      }
+      html,
+      body {
+        height: 100%;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        margin: 0;
+        font-family: sans-serif;
+        font-size: 15px;
+      }
+      h1 {
+        margin: 0 auto 0 0;
+        font-size: inherit;
+      }
+      button {
+        cursor: pointer;
+      }
+      input[type="text"] {
+        background: var(--bg);
+        color: var(--fg);
+        font: inherit;
+        font-weight: normal;
+        padding: 8px 16px;
+        min-width: 220px;
+        border: 1px solid var(--border-passive);
+        border-radius: 18px;
+        font-weight: bold;
+        width: 100%;
+      }
+      input[type="text"]:focus {
+        border-color: var(--live);
+        outline: none;
+        box-shadow: 0 0 0 1px var(--live);
+      }
+      main {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        box-sizing: border-box;
+      }
+      header {
+        flex: 0;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        padding: 18px 24px 0;
+        gap: 12px;
+      }
+      .range-chip-container {
+        display: flex;
+        width: 220px;
+        justify-content: right;
+        margin-left: auto;
+      }
+      .range-chip {
+        display: block;
+        background: var(--live);
+        color: var(--bg);
+        border-radius: 20px;
+        padding: 2px 2px 2px 18px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .close {
+        background: transparent;
+        color: inherit;
+        border: none;
+        font-size: 20px;
+        line-height: 0.5;
+        width: 28px;
+        height: 28px;
+        text-align: center;
+        border-radius: 14px;
+      }
+      .range-chip .close:hover {
+        border: 2px solid var(--bg);
+      }
+      .range-chip .close:active {
+        background: var(--bg);
+        color: var(--live);
+      }
+      [for="query"] {
+        display: flex;
+        align-items: center;
+        min-width: 300px;
+        max-width: 520px;
+        gap: 8px;
+        flex: 1;
+      }
+      #chart {
+        flex: 1;
+        overflow: hidden;
+      }
+      .indicator {
+        fill: var(--border-passive);
+      }
+      .range {
+        fill: var(--overlay-live);
+      }
+      .line {
+        fill: none;
+        stroke: var(--line);
+        stroke-width: 2px;
+      }
+      .line.hover {
+        stroke: var(--line-active);
+        stroke-width: 3px;
+        z-index: 100000;
+      }
+      .hover-line {
+        stroke: var(--border-passive);
+        stroke-width: 0.5px;
+      }
+      .dot {
+        font-family: sans-serif;
+        text-decoration: none;
+        text-anchor: middle;
+      }
+      .dot circle {
+        fill: var(--bg);
+        stroke: var(--line-active);
+        stroke-width: 3px;
+      }
+      .dot a {
+        fill: var(--fg);
+        paint-order: stroke;
+        stroke: var(--overlay-bg);
+        stroke-width: 5px;
+        stroke-linecap: butt;
+        stroke-linejoin: miter;
+      }
+      .dot a:hover text {
+        fill: var(--live);
+      }
+      .tick text {
+        fill: var(--fg-faint);
+      }
+      .tick line {
+        stroke: #666;
+      }
+      .axis-x {
+        font-size: 0.8em;
+      }
+      .axis-y {
+        font-size: 0.9em;
+      }
+      .axis-y .tick:not(:first-of-type) line {
+        stroke: var(--border-passive);
+        stroke-dasharray: 2, 2;
+      }
+      .domain {
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <main hidden>
+      <header>
+        <h1>
+          <a href="https://github.com/ampproject/amphtml">AMPHTML</a>
+          bundle-size history
+        </h1>
+        <label for="query">
+          Filter
+          <input type="text" id="query" value="v0.js" />
+        </label>
+        <div class="range-chip-container">
+          <div class="range-chip" hidden>
+            <span></span>
+            <button class="close" id="clear-range">&times;</button>
+          </div>
+        </div>
+      </header>
+      <div id="chart"></div>
+    </main>
+    <script src="https://d3js.org/d3.v5.min.js" charset="utf-8"></script>
+    <script src="./index.js"></script>
+  </body>
 </html>

--- a/bundle-size-chart/static/index.html
+++ b/bundle-size-chart/static/index.html
@@ -33,8 +33,8 @@
       * {
         box-sizing: border-box;
       }
-      [hidden] {
-        display: none !important;
+      .hidden {
+        visibility: hidden;
       }
       svg {
         user-select: none;
@@ -202,7 +202,7 @@
     </style>
   </head>
   <body>
-    <main hidden>
+    <main class="hidden">
       <header>
         <h1>
           <a href="https://github.com/ampproject/amphtml">AMPHTML</a>
@@ -213,7 +213,7 @@
           <input type="text" id="query" value="v0.js" />
         </label>
         <div class="range-chip-container">
-          <div class="range-chip" hidden>
+          <div class="range-chip hidden">
             <span></span>
             <button class="close" id="clear-range">&times;</button>
           </div>

--- a/bundle-size-chart/static/index.html
+++ b/bundle-size-chart/static/index.html
@@ -149,6 +149,7 @@
         fill: none;
         stroke: var(--line);
         stroke-width: 2px;
+        stroke-linejoin: round;
       }
       .line.hover {
         stroke: var(--line-active);

--- a/bundle-size-chart/static/index.js
+++ b/bundle-size-chart/static/index.js
@@ -73,10 +73,10 @@ const dotAnchor = dot.append('a').attr('target', '_blank');
 dotAnchor
   .append('rect')
   .attr('width', 20)
-  .attr('height', 75)
+  .attr('height', 70)
   .attr('opacity', 0)
   .attr('y', -30)
-  .attr('x', -5);
+  .attr('x', -10);
 
 const dotSizeText = dotAnchor
   .append('text')

--- a/bundle-size-chart/static/index.js
+++ b/bundle-size-chart/static/index.js
@@ -2,65 +2,385 @@
 const MIN_DATE = new Date('2019-10-23T18:00:00Z');
 const CSV_FILE_NAME =
   'https://storage.googleapis.com/amp-bundle-size-chart/bundle-sizes.csv';
-const IGNORE_FILES = new Set(['dist/v0/amp-viz-vega-0.1.js']);
+const IGNORE_FILES = new Set([
+  // Deleted:
+  'dist/v0/amp-viz-vega-0.1.js',
+  'dist/v0/amp-viz-vega-0.1.mjs',
+]);
 
-const margin = {top: 30, right: 50, bottom: 30, left: 50};
-const width = 960 - margin.left - margin.right;
-const height = 500 - margin.top - margin.bottom;
+const margin = { left: 60, top: 36, right: 24, bottom: 48 };
 
-// Create basic chart placeholder and axes objects.
-const svg = d3
-  .select('#chart')
-  .append('svg')
-  .attr('width', width + margin.left + margin.right)
-  .attr('height', height + margin.top + margin.bottom)
-  .append('g')
-  .attr('transform', `translate(${margin.left},${margin.top})`);
-svg
+function debounce(fn, wait) {
+  let timeout = null;
+  return function () {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(() => {
+      timeout = null;
+      fn(...arguments);
+    }, wait);
+  };
+}
+
+function cancelNext(element, event) {
+  const capture = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    element.removeEventListener(event, capture, true);
+  };
+  element.addEventListener(event, capture, true);
+}
+
+const max = {};
+
+let rangeStart;
+let rangeEnd;
+let width;
+let height;
+let x;
+let y;
+
+const clearRangeButton = document.querySelector('#clear-range');
+const queryInput = document.querySelector('#query');
+const container = document.querySelector('#chart');
+
+const chart = d3.select(container);
+const svg = chart.append('svg').append('g');
+
+const axisX = svg.append('g').classed('axis axis-x', true);
+const axisY = svg.append('g').classed('axis axis-y', true);
+
+const indicator = svg
   .append('rect')
-  .attr('width', width)
-  .attr('height', height)
-  .attr('opacity', 0);
-
-const x = d3.scaleTime().range([0, width]);
-const y = d3.scaleLinear().range([height, 0]);
-
-// Create placeholders for the hover behavior.
-const hoverLine = svg
-  .append('path')
-  .classed('hover-line', true)
+  .classed('indicator', true)
+  .attr('y', margin.top)
   .attr('display', 'none');
+
 const dot = svg.append('g').attr('display', 'none').classed('dot', true);
-dot.append('circle').attr('r', 2.5);
-const dotAnchor = dot.append('a');
+dot.append('circle').attr('r', 4);
+
+const dotAnchor = dot.append('a').attr('target', '_blank');
+
+// Invisible vertical rect to force clickable area on dot.
+dotAnchor
+  .append('rect')
+  .attr('width', 20)
+  .attr('height', 75)
+  .attr('opacity', 0)
+  .attr('y', -30)
+  .attr('x', -5);
+
+const dotSizeText = dotAnchor
+  .append('text')
+  .style('font-size', '1em')
+  .style('font-weight', '700');
+const dotMessageText = dotAnchor.append('text').style('font-size', '1em');
 const dotFileNameText = dotAnchor
   .append('text')
-  .style('font-size', '.8em')
-  .attr('y', -20);
-const dotMessageText = dotAnchor
-  .append('text')
-  .style('font-size', '.6em')
-  .attr('y', -8);
+  .style('font-size', '1em')
+  .style('font-weight', '700');
 
 // Event listeners for the hover behavior.
-svg
-  .on('mousemove', moved)
-  .on('mouseenter', () => {
-    dot.attr('display', null);
-    hoverLine.attr('display', null);
-  })
+chart
+  .on('pointermove', moved)
+  .on('pointerdown', startSelection)
   .on('mouseleave', () => {
+    if (isSelecting) {
+      return;
+    }
     dot.attr('display', 'none');
-    hoverLine.attr('display', 'none');
+    indicator.attr('display', 'none');
     svg.selectAll('.line.hover').classed('hover', false);
   });
 
-// Initialize data from external CSV file.
+// Attach `pointerup` to window so that it's fired even if pointer is outside
+// viewport.
+d3.select(window).on('pointerup', applySelection);
+
+function redraw() {
+  const rect = container.getBoundingClientRect();
+
+  width = rect.width - margin.left - margin.right;
+  height = rect.height - margin.top - margin.bottom;
+
+  chart.select('svg').attr('width', rect.width).attr('height', rect.height);
+
+  svg.attr('transform', `translate(${margin.left},${margin.top})`);
+
+  updateAxes();
+
+  svg.selectAll('.line').remove();
+  for (const key of filteredData.columns) {
+    const valueline = d3
+      .line()
+      .x((d) => x(d.date))
+      .y((d) => y(d[key]))
+      .curve(d3.curveLinear);
+    svg
+      .insert('path', '.dot')
+      .data([filteredData])
+      .classed('line', true)
+      .attr('data-file', key)
+      .attr('d', valueline);
+  }
+}
+
+function updateAxes() {
+  if (!filteredData.length) {
+    svg.selectAll('.axis').attr('display', 'none');
+    return;
+  }
+  svg.selectAll('.axis').attr('display', null);
+
+  x = d3.scaleTime().range([0, width]);
+  y = d3.scaleLinear().range([height, 0]);
+
+  const xMin = filteredData[0].date;
+  const xMax = filteredData[filteredData.length - 1].date;
+  x.domain([xMin, xMax]);
+
+  let yMax = Math.max(0, ...filteredData.columns.map((k) => max[k]));
+  const yTickFactor = yMax <= 15 ? 1 : yMax <= 36 ? 2 : 5;
+  yMax = Math.ceil(yMax / yTickFactor) * yTickFactor;
+
+  y.domain([0, yMax]);
+
+  const deltaDays = Math.abs(xMin - xMax) / (1000 * 60 * 60 * 24);
+  const xTickUnit =
+    deltaDays >= 14
+      ? deltaDays >= 60
+        ? d3.timeMonth
+        : d3.timeWeek
+      : d3.timeDay;
+  const xTickFormat =
+    xTickUnit === d3.timeMonth ? d3.timeFormat('%B') : d3.timeFormat('%B %d');
+  axisX
+    .attr('transform', `translate(0,${height})`)
+    .call(d3.axisBottom(x).tickFormat(xTickFormat).ticks(xTickUnit));
+
+  function customYAxis(g) {
+    const ticks = Math.ceil(yMax / yTickFactor);
+    g.call(d3.axisRight(y).ticks(ticks).tickSize(width));
+    g.selectAll('.tick text').attr('x', -36).attr('dy', 2);
+  }
+
+  axisY.call(customYAxis);
+}
+
+function getClosestByPoint(offsetX, offsetY) {
+  const filter = queryInput.value;
+  if (!filteredData || !filteredData.length) {
+    return;
+  }
+
+  // Convert mouse event to x/y values in the data's value space.
+  const x0 = x.invert(Math.max(0, offsetX - margin.left));
+  const y0 = y.invert(offsetY - margin.top);
+
+  // Find the closest data row to the pointer.
+  const dataIndex = d3
+    .bisector((d) => d.date)
+    .left(filteredData, x0, 1, filteredData.length - 1);
+  const left = filteredData[dataIndex - 1];
+  const right = filteredData[dataIndex];
+  const row = x0 - left.date > right.date - x0 ? right : left;
+
+  // Find the closest data column (file name) to the pointer.
+  const column = filteredData.columns
+    .filter((key) => key.includes(filter))
+    .reduce((a, b) => (Math.abs(row[a] - y0) < Math.abs(row[b] - y0) ? a : b));
+
+  return { x: x(row.date), y: y(row[column]), row, column };
+}
+
+let isSelecting = false;
+let selectionStart;
+let selectionEnd;
+
+function startSelection() {
+  isSelecting = true;
+  selectionEnd = null;
+  selectionStart = getClosestByPoint(d3.event.offsetX, d3.event.offsetY);
+}
+
+function restartSelection() {
+  if (!selectionEnd) {
+    return;
+  }
+  setIndicator(selectionEnd.x, 1);
+  selectionStart = selectionEnd;
+  selectionEnd = null;
+}
+
+function applySelection() {
+  if (!isSelecting) {
+    return;
+  }
+  isSelecting = false;
+  if (selectionEnd && selectionStart) {
+    if (selectionStart.row.date > selectionEnd.row.date) {
+      const temp = selectionStart;
+      selectionStart = selectionEnd;
+      selectionEnd = temp;
+    }
+    if (selectionStart.x !== selectionEnd.x) {
+      // Cancel upcoming click to prevent link navigation.
+      cancelNext(container, 'click');
+      setRange(selectionStart.row.date, selectionEnd.row.date);
+    }
+  }
+  selectionEnd = null;
+  selectionStart = null;
+}
+
+function setRange(startDate, endDate) {
+  const daysAgoChecked = document.querySelector('[name=days-ago]:checked');
+  if (daysAgoChecked) {
+    daysAgoChecked.checked = false;
+  }
+  rangeStart = startDate;
+  rangeEnd = endDate;
+  updateOnChange();
+}
+
+function updateRangeChip() {
+  const chip = document.querySelector('.range-chip');
+  const label = document.querySelector('.range-chip > span');
+  if (!rangeStart || !rangeEnd) {
+    label.textContent = '';
+    chip.setAttribute('hidden', '');
+    return;
+  }
+  const left = shortDateLabel(rangeStart);
+  const right = shortDateLabel(rangeEnd);
+  label.textContent = left === right ? left : `${left}—${right}`;
+  chip.removeAttribute('hidden');
+}
+
+function shortDateLabel(date) {
+  return date.toLocaleDateString('en-us', { month: 'short', day: 'numeric' });
+}
+
+/**
+ * Event handler for when the mouse moves over the chart.
+ */
+function moved() {
+  if (!d3.event) {
+    return;
+  }
+
+  const closest = getClosestByPoint(d3.event.offsetX, d3.event.offsetY);
+  if (!closest) {
+    return;
+  }
+
+  const { row, column } = closest;
+
+  let dragDelta = 0;
+  if (isSelecting) {
+    selectionEnd = closest;
+    dragDelta = Math.abs(selectionEnd.x - selectionStart.x);
+  }
+
+  setIndicator(
+    isSelecting ? Math.min(selectionStart.x, selectionEnd.x) : closest.x,
+    dragDelta
+  );
+
+  svg.selectAll('.line.hover').classed('hover', false);
+  svg.selectAll(`.line[data-file='${column}']`).classed('hover', true);
+
+  const dotX = closest.x;
+  const dotY = closest.y;
+
+  dot.attr('display', null).attr('transform', `translate(${dotX},${dotY})`);
+
+  dotAnchor.attr(
+    'href',
+    `https://github.com/ampproject/amphtml/commit/${row.sha}`
+  );
+
+  const bundleSize = row[column];
+  dotSizeText.text(`${bundleSize.toFixed(2)} KB`).attr('y', -14);
+
+  const fileName = column.substring(5);
+  dotFileNameText.text(fileName).attr('y', 24);
+
+  dotMessageText.text(row.message).attr('y', 46);
+
+  nudgeFromCenter(dotX, dotSizeText);
+  nudgeFromCenter(dotX, dotFileNameText);
+  nudgeFromCenter(dotX, dotMessageText);
+}
+
+function nudgeFromCenter(center, text) {
+  const half = text.node().getComputedTextLength() / 2;
+  const padding = 12;
+  const offset =
+    center < half + padding
+      ? -center + half + padding
+      : width - center - padding < half
+      ? width - center - padding - half
+      : 0;
+  text.attr('x', offset);
+  return text;
+}
+
+function setIndicator(x, width) {
+  indicator
+    .classed('range', width > 1)
+    .attr('display', null)
+    .attr('x', x)
+    .attr('y', 0)
+    .attr('width', Math.max(1, width))
+    .attr('height', height);
+}
+
+function setStateFromHash() {
+  const parts = window.location.hash
+    .substr(1)
+    .split('&')
+    .map(decodeURIComponent);
+  const q = parts[0];
+  const s = parts[1];
+  const e = parts[2];
+  if (q) {
+    queryInput.value = q;
+  }
+  if (s) {
+    rangeStart = deserializeDatetime(s);
+  }
+  if (e) {
+    rangeEnd = deserializeDatetime(e);
+  }
+}
+
+function serializeHashState(filter) {
+  return (
+    `#${encodeURIComponent(filter)}` +
+    (rangeStart ? `&${serializeDatetime(rangeStart)}` : '') +
+    (rangeEnd ? `&${serializeDatetime(rangeEnd, true)}` : '')
+  );
+}
+
+function serializeDatetime(date) {
+  const isoString = date.toISOString();
+  return isoString.substr(0, isoString.length - ':00.000Z'.length);
+}
+
+function deserializeDatetime(string, ceil) {
+  return new Date(`${string}:${ceil ? '59' : '00'}.000Z`);
+}
+
+setStateFromHash();
+document.querySelector('main').removeAttribute('hidden');
+
 let data;
-const filesMax = {};
-d3.csv(CSV_FILE_NAME).then(data_ => {
-  data = data_;
-  data.forEach(d => {
+let filteredData;
+
+function initializeData(data) {
+  data.forEach((d) => {
     d.date = d3.isoParse(d.date);
     for (const key of Object.keys(d)) {
       if (key.startsWith('dist/')) {
@@ -71,126 +391,69 @@ d3.csv(CSV_FILE_NAME).then(data_ => {
         // Convert string value to number for files and collect the maximum
         // bundle-size of each file.
         d[key] = Number(d[key]);
-        filesMax[key] = Math.max(filesMax[key] || 0, d[key]);
+        max[key] = Math.max(max[key] || 0, d[key]);
       }
     }
   });
-  data = data.filter(d => d.date > MIN_DATE);
   data.sort((a, b) => a.date - b.date);
-  data.columns = data_.columns.filter(key => !IGNORE_FILES.has(key));
+  data.columns = data.columns.filter((key) => !IGNORE_FILES.has(key));
+  return data;
+}
 
-  // The x axis is the time and it does not change with filtering.
-  x.domain(d3.extent(data, d => d.date));
+function updateFilteredData() {
+  const query = queryInput.value.trim();
+  filteredData =
+    rangeStart && rangeEnd
+      ? data.filter((d) => d.date >= rangeStart && d.date <= rangeEnd)
+      : [...data];
+  filteredData.columns = data.columns.filter(
+    (key) => key.startsWith('dist/') && key.includes(query)
+  );
+  setHashState(query);
+}
 
-  // Create the axis graphics. Set the x axis, but only prepare the y axis
-  // since it changes with the filter.
-  svg
-    .append('g')
-    .classed('axis axis-x', true)
-    .attr('transform', `translate(0,${height})`)
-    .call(d3.axisBottom(x));
-  svg.append('g').classed('axis axis-y', true);
+function clearRange() {
+  rangeStart = null;
+  rangeEnd = null;
+  updateOnChange();
+}
 
-  updateFilter();
+function updateOnChange() {
+  updateRangeChip();
+  updateFilteredData();
+  redraw();
+  moved();
+}
+
+let prevHash = window.location.hash;
+function setHashState(query) {
+  const hash = serializeHashState(query);
+  if (prevHash !== hash) {
+    window.location.href = hash;
+    prevHash = hash;
+  }
+}
+function onHashChange() {
+  if (prevHash !== window.location.hash) {
+    prevHash = window.location.hash;
+    updateOnChange();
+  }
+}
+
+window.addEventListener('hashchange', onHashChange, false);
+window.addEventListener('resize', redraw);
+window.addEventListener('keyup', (e) => {
+  if (e.key === 'Escape') {
+    restartSelection();
+  }
 });
 
-/**
- * Updates the y axis based on the filter.
- *
- * @param {!RegExp} filter text that should be in the file name
- */
-function updateYAxis(filter) {
-  let yMax = 0;
-  for (const key of data.columns) {
-    if (key.startsWith('dist/') && filter.test(key)) {
-      yMax = Math.max(yMax, filesMax[key]);
-    }
-  }
-  y.domain([0, yMax]);
-  svg.select('.axis-y').call(d3.axisLeft(y));
-}
+clearRangeButton.addEventListener('click', clearRange);
 
-/**
- * Draws all bundle-size lines based on the filter.
- */
-function updateFilter() {
-  const filter = new RegExp(document.querySelector('#filter').value);
-  svg.selectAll('.line').remove(); // Remove any previously added lines.
-  updateYAxis(filter);
+const updateOnQueryInput = debounce(updateOnChange);
+queryInput.addEventListener('input', updateOnQueryInput);
 
-  for (const key of data.columns) {
-    if (key.startsWith('dist/') && filter.test(key)) {
-      const valueline = d3
-        .line()
-        .x(d => x(d.date))
-        .y(d => y(d[key]))
-        .curve(d3.curveBasis);
-      svg
-        .append('path')
-        .data([data])
-        .classed('line', true)
-        .attr('data-file', key)
-        .attr('d', valueline);
-    }
-  }
-}
-
-/**
- * Event handler for when the mouse moves over the chart.
- */
-function moved() {
-  const filter = new RegExp(document.querySelector('#filter').value);
-  if (!data || !data.columns.some(key => filter.test(key))) {
-    // Ignore while still loading the data or if the filter results in an empty
-    // set.
-    return;
-  }
-
-  d3.event.preventDefault();
-  // Convert mouse event to x/y values in the data's value space.
-  const x0 = x.invert(d3.event.offsetX - margin.left);
-  const y0 = y.invert(d3.event.offsetY - margin.top);
-
-  // Find the closest data row to the pointer.
-  const dataIndex = d3.bisector(d => d.date).left(data, x0, 1, data.length - 1);
-  const leftDataRow = data[dataIndex - 1];
-  const rightDataRow = data[dataIndex];
-  const closestDataRow =
-    x0 - leftDataRow.date > rightDataRow.date - x0 ? rightDataRow : leftDataRow;
-
-  // Find the closest data column (file name) to the pointer.
-  const closestDataFile = data.columns
-    .filter(key => filter.test(key))
-    .reduce((a, b) =>
-      Math.abs(closestDataRow[a] - y0) < Math.abs(closestDataRow[b] - y0)
-        ? a
-        : b
-    );
-
-  // Set the selected line to have the .hover class for effect.
-  svg.selectAll('.line.hover').classed('hover', false);
-  svg.select(`.line[data-file="${closestDataFile}"]`).classed('hover', true);
-
-  // Move the hover line and set the text for the link.
-  const fileName = closestDataFile.substring(5);
-  const bundleSize = closestDataRow[closestDataFile];
-
-  hoverLine.attr('d', function () {
-    let d = 'M' + x(closestDataRow.date) + ',' + height;
-    d += ' ' + x(closestDataRow.date) + ',' + 0;
-    return d;
-  });
-  dot.attr(
-    'transform',
-    `translate(${x(closestDataRow.date)},${y(bundleSize)})`
-  );
-  dotAnchor.attr(
-    'href',
-    `https://github.com/ampproject/amphtml/commit/${closestDataRow.sha}`
-  );
-  dotFileNameText.text(`${fileName}: ${bundleSize} KB`);
-  dotMessageText.text(closestDataRow.message);
-}
-
-// Event listener for changing the filter text.
-document.querySelector('#filter').addEventListener('input', updateFilter);
+d3.csv(CSV_FILE_NAME).then((data_) => {
+  data = initializeData(data_);
+  updateOnChange();
+});

--- a/bundle-size-chart/static/index.js
+++ b/bundle-size-chart/static/index.js
@@ -413,7 +413,7 @@ function serializeHashState(query) {
  */
 function serializeDatetime(date) {
   const isoString = date.toISOString();
-  return isoString.substr(0, isoString.length - ':00.000Z'.length);
+  return isoString.substring(0, isoString.length - ':00.000Z'.length);
 }
 
 /**

--- a/bundle-size-chart/static/index.js
+++ b/bundle-size-chart/static/index.js
@@ -275,13 +275,13 @@ function updateRangeChip() {
   const label = document.querySelector('.range-chip > span');
   if (!rangeStart || !rangeEnd) {
     label.textContent = '';
-    chip.setAttribute('hidden', '');
+    chip.classList.add('hidden');
     return;
   }
   const left = shortDateLabel(rangeStart);
   const right = shortDateLabel(rangeEnd);
   label.textContent = left === right ? left : `${left}—${right}`;
-  chip.removeAttribute('hidden');
+  chip.classList.remove('hidden');
 }
 
 /**
@@ -426,7 +426,7 @@ function deserializeDatetime(string, ceil) {
 }
 
 setStateFromHash();
-document.querySelector('main').removeAttribute('hidden');
+document.querySelector('main').classList.remove('hidden');
 
 let data;
 let filteredData;

--- a/bundle-size-chart/static/index.js
+++ b/bundle-size-chart/static/index.js
@@ -1,5 +1,3 @@
-// Before this date only dist/v0.js was collected.
-const MIN_DATE = new Date('2019-10-23T18:00:00Z');
 const CSV_FILE_NAME =
   'https://storage.googleapis.com/amp-bundle-size-chart/bundle-sizes.csv';
 const IGNORE_FILES = new Set([

--- a/bundle-size-chart/static/index.js
+++ b/bundle-size-chart/static/index.js
@@ -352,7 +352,7 @@ function setStateFromHash() {
     rangeStart = deserializeDatetime(s);
   }
   if (e) {
-    rangeEnd = deserializeDatetime(e);
+    rangeEnd = deserializeDatetime(e, /* ceil */ true);
   }
 }
 
@@ -360,7 +360,7 @@ function serializeHashState(filter) {
   return (
     `#${encodeURIComponent(filter)}` +
     (rangeStart ? `&${serializeDatetime(rangeStart)}` : '') +
-    (rangeEnd ? `&${serializeDatetime(rangeEnd, true)}` : '')
+    (rangeEnd ? `&${serializeDatetime(rangeEnd)}` : '')
   );
 }
 


### PR DESCRIPTION
- Dark mode.

- Expands chart to fill viewport. 

- Allows zooming in on a time range by clicking and dragging (!)

- Hover indicator dots are clickable. Labels are now nudged when reaching the edge, so they never truncate.

- Sets a hash so that query and time range filters are shareable by URL.

Demo on [canyon-subsequent-sea.glitch.me](https://canyon-subsequent-sea.glitch.me) (data may be stale).
