### PR TITLE
[Percy Mirror Verifier] Use the fingerprint field when comparing snapshots

### DIFF
--- a/percy-mirror-verifier/src/percy.ts
+++ b/percy-mirror-verifier/src/percy.ts
@@ -21,16 +21,12 @@ export type PercySnapshot = {
   id: string;
   attributes: {
     name: string;
+    fingerprint: string | null;
     'review-state':
       | 'approved'
       | 'unreviewed'
       | 'changes_requested'
       | 'failed'
-      | null;
-    'review-state-reason':
-      | 'no_diffs'
-      | 'auto_approved_branch'
-      | 'user_approved'
       | null;
   };
 };

--- a/percy-mirror-verifier/src/server.ts
+++ b/percy-mirror-verifier/src/server.ts
@@ -106,19 +106,12 @@ export async function handleBuildFinished(
     for (const [name, prSnapshot] of prSnapshots) {
       const mainSnapshot = mainSnapshots.get(name);
 
-      const prApprovalReason = prSnapshot.attributes['review-state-reason'];
-      const mainApprovalReason = mainSnapshot.attributes['review-state-reason'];
-
       if (
-        !(
-          (prApprovalReason === 'no_diffs' &&
-            mainApprovalReason === 'no_diffs') ||
-          (prApprovalReason === 'user_approved' &&
-            mainApprovalReason === 'auto_approved_branch')
-        )
+        prSnapshot.attributes.fingerprint !==
+        mainSnapshot.attributes.fingerprint
       ) {
         console.error(
-          'PR/main disparity: not all snapshots have the same approval reason'
+          'PR/main disparity: not all snapshots have the same fingerprint'
         );
         return await github.postErrorComment(githubPullNumber);
       }

--- a/percy-mirror-verifier/test/server.test.ts
+++ b/percy-mirror-verifier/test/server.test.ts
@@ -82,8 +82,8 @@ describe('server', () => {
       id: '832098704',
       attributes: {
         name: 'Blank page',
+        fingerprint: null,
         'review-state': 'approved',
-        'review-state-reason': 'no_diffs',
       },
     };
     const snapshotA: PercySnapshot = {
@@ -91,8 +91,8 @@ describe('server', () => {
       id: '832098742',
       attributes: {
         name: 'Snapshot A',
+        fingerprint: null,
         'review-state': 'approved',
-        'review-state-reason': 'no_diffs',
       },
     };
     const snapshotB: PercySnapshot = {
@@ -100,25 +100,26 @@ describe('server', () => {
       id: '832098753',
       attributes: {
         name: 'Snapshot B',
+        fingerprint: null,
         'review-state': 'approved',
-        'review-state-reason': 'no_diffs',
       },
     };
 
     const notApproved: DeepPartial<PercySnapshot> = {
       attributes: {
         'review-state': 'unreviewed',
-        'review-state-reason': null,
       },
     };
-    const userApproved: DeepPartial<PercySnapshot> = {
+    const approvedFingerprint1: DeepPartial<PercySnapshot> = {
       attributes: {
-        'review-state-reason': 'user_approved',
+        fingerprint: 'af2da54e2a5cc0e4afe8a9eefdbf862249e654d2',
+        'review-state': 'approved',
       },
     };
-    const autoApproved: DeepPartial<PercySnapshot> = {
+    const approvedFingerprint2: DeepPartial<PercySnapshot> = {
       attributes: {
-        'review-state-reason': 'auto_approved_branch',
+        fingerprint: '68e037a2fb2be29de4ef6feba095f31d110e1d2b',
+        'review-state': 'approved',
       },
     };
 
@@ -169,21 +170,38 @@ describe('server', () => {
       expect(mockPostErrorComment).not.toHaveBeenCalled();
     });
 
-    it('verifies mirrored PR/main builds with approved diffs', async () => {
+    it('verifies mirrored PR/main builds with approved diffs with the same fingerprint', async () => {
       mockGetPercyBuildId.mockResolvedValue(1234566);
       mockGetSnapshots.mockResolvedValueOnce(
-        new Map([['Snapshot A', deepmerge(snapshotA, userApproved)]])
+        new Map([['Snapshot A', deepmerge(snapshotA, approvedFingerprint1)]])
       );
       mockGetSnapshots.mockResolvedValueOnce(
         new Map([
           ['Blank page', snapshotBlankPage],
-          ['Snapshot A', deepmerge(snapshotA, autoApproved)],
+          ['Snapshot A', deepmerge(snapshotA, approvedFingerprint1)],
         ])
       );
 
       await handleBuildFinished(included);
 
       expect(mockPostErrorComment).not.toHaveBeenCalled();
+    });
+
+    it('rejects a build when a snapshot has different fingerprints in PR/main', async () => {
+      mockGetPercyBuildId.mockResolvedValue(1234566);
+      mockGetSnapshots.mockResolvedValueOnce(
+        new Map([['Snapshot A', deepmerge(snapshotA, approvedFingerprint1)]])
+      );
+      mockGetSnapshots.mockResolvedValueOnce(
+        new Map([
+          ['Blank page', snapshotBlankPage],
+          ['Snapshot A', deepmerge(snapshotA, approvedFingerprint2)],
+        ])
+      );
+
+      await handleBuildFinished(included);
+
+      expect(mockPostErrorComment).toHaveBeenCalledWith(5678, 1234567, 1234566);
     });
 
     it('rejects a build when snapshot in main has a diff, but not in PR', async () => {
@@ -194,7 +212,7 @@ describe('server', () => {
       mockGetSnapshots.mockResolvedValueOnce(
         new Map([
           ['Blank page', snapshotBlankPage],
-          ['Snapshot A', deepmerge(snapshotA, autoApproved)],
+          ['Snapshot A', deepmerge(snapshotA, approvedFingerprint1)],
         ])
       );
 
@@ -206,7 +224,7 @@ describe('server', () => {
     it('rejects a build when snapshot in PR has a diff, but not in main', async () => {
       mockGetPercyBuildId.mockResolvedValue(1234566);
       mockGetSnapshots.mockResolvedValueOnce(
-        new Map([['Snapshot A', deepmerge(snapshotA, userApproved)]])
+        new Map([['Snapshot A', deepmerge(snapshotA, approvedFingerprint1)]])
       );
       mockGetSnapshots.mockResolvedValueOnce(
         new Map([


### PR DESCRIPTION
From observing the logs, it looks like a snapshot that produces no diffs results in `fingerprint: null`, whereas a snapshot that produces a diff results in `fingerprint: <some-sha1-string>` that is unique to that snapshot:
* If a snapshot results in the exact same pixels it will have the same fingerprint value, which means the PR and the main builds are mirrored
* If one comes with a null fingerprint and the other not-null, then there is a diff
* If they both have a non-null fingerprint but the sha1 values are different, it means the pixels are different - this is a case that wasn't caught using the previous logic - this PR deals with this and makes the code simpler! Woot woot 🥳