### PR TITLE
Fix `percy-mirror-verifier` test

### DIFF
--- a/percy-mirror-verifier/test/server.test.ts
+++ b/percy-mirror-verifier/test/server.test.ts
@@ -201,7 +201,7 @@ describe('server', () => {
 
       await handleBuildFinished(included);
 
-      expect(mockPostErrorComment).toHaveBeenCalledWith(5678);
+      expect(mockPostErrorComment).toHaveBeenCalledWith(5678, 1234567, 1234566);
     });
 
     it('rejects a build when snapshot in main has a diff, but not in PR', async () => {


### PR DESCRIPTION
One test currently fails for a super weird reason: the merge commit https://github.com/ampproject/amp-github-apps/commit/9bb19928290191c09246a5f7c4f6f77ac6ed9390 does not match the single commit https://github.com/ampproject/amp-github-apps/pull/1566/commits/93a16816dc8c307babde226d3e131e07b42d697b of this PR https://github.com/ampproject/amp-github-apps/pull/1566

This line is missing from the merge commit, which then breaks main:
https://github.com/danielrozenberg/amp-github-apps/blob/93a16816dc8c307babde226d3e131e07b42d697b/percy-mirror-verifier/test/server.test.ts#L203