### PR TITLE
Pin Node to v18 for Cloud Functions

### DIFF
--- a/invite/cloud_build.yaml
+++ b/invite/cloud_build.yaml
@@ -59,6 +59,8 @@ steps:
       - invite-bot
       - --entry-point
       - probot
+      - --runtime
+      - nodejs18
 
 # Overall cloud build timeout
 timeout: 1800s

--- a/onduty/cloud_build.yaml
+++ b/onduty/cloud_build.yaml
@@ -54,6 +54,8 @@ steps:
       - dist/
       - --entry-point
       - refreshRotation
+      - --runtime
+      - nodejs18
 
 # Overall cloud build timeout
 timeout: 1800s


### PR DESCRIPTION
https://cloud.google.com/functions/docs/migrating/nodejs-runtimes