### PR TITLE
Skip GCP build step for Cloud Functions

### DIFF
--- a/invite/package.json
+++ b/invite/package.json
@@ -12,7 +12,8 @@
     "dev": "nodemon",
     "deploy-tag": "git tag 'deploy-invite-'`date -u '+%Y%m%d%H%M%S'`",
     "test": "jest --reporters=jest-silent-reporter",
-    "test:watch": "jest --watch --notify --notifyMode=change"
+    "test:watch": "jest --watch --notify --notifyMode=change",
+    "gcp-build": "echo \"Skipping build step on GCP (See https://cloud.google.com/functions/docs/release-notes#April_11_2023)\""
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/onduty/package.json
+++ b/onduty/package.json
@@ -12,7 +12,8 @@
     "dev": "nodemon",
     "deploy-tag": "git tag 'deploy-onduty-'`date -u '+%Y%m%d%H%M%S'`",
     "test": "jest --reporters=jest-silent-reporter",
-    "test:watch": "jest --watch --notify --notifyMode=change"
+    "test:watch": "jest --watch --notify --notifyMode=change",
+    "gcp-build": "echo \"Skipping build step on GCP (See https://cloud.google.com/functions/docs/release-notes#April_11_2023)\""
   },
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
Since April this year, Cloud Functions attempt to run the build step for the deployed code - we already pre-compile the deployed code during the Cloud Build step, and we don't upload the TS sources, so deployments fail unless we skip the build as recommended [here](https://cloud.google.com/functions/docs/release-notes#April_11_2023)