### PR TITLE
Switch `bundle-size-chart` to GAE standard environment

### DIFF
--- a/bundle-size-chart/.gcloudignore
+++ b/bundle-size-chart/.gcloudignore
@@ -1,0 +1,17 @@
+# This file specifies files that are *not* uploaded to Google Cloud
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Node.js dependencies:
+node_modules/

--- a/bundle-size-chart/app.yaml
+++ b/bundle-size-chart/app.yaml
@@ -11,15 +11,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: nodejs
-env: flex
-
-runtime_config:
-  operating_system: "ubuntu22"
-  runtime_version: 18
-
-handlers:
-  - url: /.*
-    secure: always
-    redirect_http_response_code: 301
-    script: auto
+runtime: nodejs20


### PR DESCRIPTION
I'm not sure why, but the flexible environment is failing to deploy. I tested the standard environment and it seems to work well, and it sort of [makes sense for this low-traffic project](https://cloud.google.com/appengine/docs/the-appengine-environments) anyways - so let's just switch it and not thing about it anymore :)